### PR TITLE
[FIX] Explicitly strip extensions

### DIFF
--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -123,8 +123,8 @@ def test_load_data():
     # list of filepath to images
     d, ref = utils.load_data(fnames, n_echos=len(tes))
     assert d.shape == exp_shape
-    assert isinstance(ref, str)
-    assert ref == fnames[0]
+    assert isinstance(ref, nib.Nifti1Image)
+    assert np.allclose(ref.get_data(), nib.load(fnames[0]).get_data())
 
     # list of img_like
     d, ref = utils.load_data(fimg, n_echos=len(tes))

--- a/tedana/utils/utils.py
+++ b/tedana/utils/utils.py
@@ -133,7 +133,9 @@ def load_data(data, n_echos=None):
                              '{}'.format(data))
         else:  # individual echo files were provided (surface or volumetric)
             fdata = np.stack([load_image(f) for f in data], axis=1)
-            return np.atleast_3d(fdata), data[0]
+            ref_img = check_niimg(data[0])
+            ref_img.header.extensions = []
+            return np.atleast_3d(fdata), ref_img
 
     img = check_niimg(data)
     (nx, ny), nz = img.shape[:2], img.shape[2] // n_echos


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://tedana.readthedocs.io/en/latest/contributing.html#pull-requests
-->

Closes #82.

Changes proposed in this pull request:

- Reformats `load_data` to explicitly strip extensions for both zcat images and listed echo files
