### PR TITLE
[FIX] Include ignored components in ME-DN T1c time series

### DIFF
--- a/tedana/utils/io.py
+++ b/tedana/utils/io.py
@@ -40,11 +40,11 @@ def gscontrol_mmix(optcom_ts, mmix, mask, acc, ign, ref_img):
     ======================    =================================================
     Filename                  Content
     ======================    =================================================
-    sphis_hik.nii             T1-like effect.
-    hik_ts_OC_T1c.nii         T1 corrected time series.
-    dn_ts_OC_T1c.nii          Denoised version of T1 corrected time series
-    betas_hik_OC_T1c.nii      T1-GS corrected components
-    meica_mix_T1c.1D          T1-GS corrected mixing matrix
+    sphis_hik.nii             T1-like effect
+    hik_ts_OC_T1c.nii         T1-corrected BOLD (high-Kappa) time series
+    dn_ts_OC_T1c.nii          Denoised version of T1-corrected time series
+    betas_hik_OC_T1c.nii      T1 global signal-corrected components
+    meica_mix_T1c.1D          T1 global signal-corrected mixing matrix
     ======================    =================================================
     """
     optcom_masked = optcom_ts[mask, :]
@@ -79,14 +79,14 @@ def gscontrol_mmix(optcom_ts, mmix, mask, acc, ign, ref_img):
     """
     bold_noT1gs = bold_ts - np.dot(lstsq(glob_sig.T, bold_ts.T,
                                          rcond=None)[0].T, glob_sig)
-    utils.filewrite(utils.unmask(bold_noT1gs * optcom_std, mask),
-                    'hik_ts_OC_T1c.nii', ref_img)
+    hik_ts = bold_noT1gs * optcom_std
+    utils.filewrite(utils.unmask(hik_ts, mask), 'hik_ts_OC_T1c.nii', ref_img)
 
     """
     Make denoised version of T1-corrected time series
     """
     medn_ts = optcom_mu + ((bold_noT1gs + resid) * optcom_std)
-    utils.filewrite(utils.unmask(medn_ts, mask), 'dn_ts_OC_T1c', ref_img)
+    utils.filewrite(utils.unmask(medn_ts, mask), 'dn_ts_OC_T1c.nii', ref_img)
 
     """
     Orthogonalize mixing matrix w.r.t. T1-GS
@@ -103,8 +103,8 @@ def gscontrol_mmix(optcom_ts, mmix, mask, acc, ign, ref_img):
     Write T1-GS corrected components and mixing matrix
     """
     cbetas_norm = lstsq(mmixnogs_norm.T, data_norm.T, rcond=None)[0].T
-    utils.filewrite(utils.unmask(cbetas_norm[:, 2:], mask), 'betas_hik_OC_T1c',
-                    ref_img)
+    utils.filewrite(utils.unmask(cbetas_norm[:, 2:], mask),
+                    'betas_hik_OC_T1c.nii', ref_img)
     np.savetxt('meica_mix_T1c.1D', mmixnogs)
 
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -432,7 +432,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
 
     utils.writeresults(OCcatd, mask, comptable, mmix, fixed_seed, n_vols,
                        acc, rej, midk, empty, ref_img)
-    utils.gscontrol_mmix(OCcatd, mmix, mask, acc, ref_img)
+    utils.gscontrol_mmix(OCcatd, mmix, mask, acc, empty, ref_img)
     if dne:
         utils.writeresults_echoes(catd, mmix, mask, acc, rej, midk, ref_img)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://tedana.readthedocs.io/en/latest/contributing.html#pull-requests
-->
The ME-DN time series should include the ignored ICA components, but does not. The current approach is to regress out all ICA components from the data to get `resid`, and then to combine that with the BOLD-T1c (GS-controlled accepted components) time series as the ME-DN T1c time series. With this PR, the residuals time series will not have the ignored components regressed out, and thus the ME-DN time series will include those components.

Changes proposed in this pull request:

- Add `rej` (index of rejected components) argument to `gscontrol_mmix`.
- Compose ICA residuals time series  (`resid`) of the data minus all of the ICA components _except_ the ignored components.
- There are some minor improvements to documentation as well.
