### PR TITLE
[DOC] Remove fMRIPrep recommendation from usage page

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,7 +56,8 @@ Constructing ME-EPI pipelines
 -----------------------------
 
 ``tedana`` must be called in the context of a larger ME-EPI preprocessing pipeline.
-Two common pipelines which support ME-EPI processing include `fMRIPrep`_ and `afni_proc.py`_.
+One common pipeline which supports ME-EPI processing is `afni_proc.py`_.
+Additionally, there are plans currently underway to integrate ``tedana`` into `fMRIPrep`_.
 
 .. _fMRIPrep: https://fmriprep.readthedocs.io
 .. _afni_proc.py: https://afni.nimh.nih.gov/pub/dist/doc/program_help/afni_proc.py.html


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Given a [recent NeuroStars question](https://neurostars.org/t/using-fmriprep-with-tedana-for-echo-combination/2883) which referenced our documentation, I thought it might be good to clarify the usage documentation regarding fMRIPrep (i.e., that it does not currently support `tedana`, but that there **are** future plans).
