### PR TITLE
[DOC] Fix arg parser

### DIFF
--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -29,63 +29,63 @@ def _get_parser():
     optional = parser._action_groups.pop()
     required = parser.add_argument_group('required arguments')
     required.add_argument('-d',
-                        dest='data',
-                        nargs='+',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('Multi-echo dataset for analysis. May be a '
-                              'single file with spatially concatenated data '
-                              'or a set of echo-specific files, in the same '
-                              'order as the TEs are listed in the -e '
-                              'argument.'),
-                        required=True)
+                          dest='data',
+                          nargs='+',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('Multi-echo dataset for analysis. May be a '
+                                'single file with spatially concatenated data '
+                                'or a set of echo-specific files, in the same '
+                                'order as the TEs are listed in the -e '
+                                'argument.'),
+                          required=True)
     required.add_argument('-e',
-                        dest='tes',
-                        nargs='+',
-                        metavar='TE',
-                        type=float,
-                        help='Echo times (in ms). E.g., 15.0 39.0 63.0',
-                        required=True)
+                          dest='tes',
+                          nargs='+',
+                          metavar='TE',
+                          type=float,
+                          help='Echo times (in ms). E.g., 15.0 39.0 63.0',
+                          required=True)
     optional.add_argument('--mask',
-                        dest='mask',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('Binary mask of voxels to include in TE '
-                              'Dependent ANAlysis. Must be in the same '
-                              'space as `data`.'),
-                        default=None)
+                          dest='mask',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('Binary mask of voxels to include in TE '
+                                'Dependent ANAlysis. Must be in the same '
+                                'space as `data`.'),
+                          default=None)
     optional.add_argument('--fitmode',
-                        dest='fitmode',
-                        action='store',
-                        choices=['all', 'ts'],
-                        help=('Monoexponential model fitting scheme. '
-                              '"all" means that the model is fit, per voxel, '
-                              'across all timepoints. '
-                              '"ts" means that the model is fit, per voxel '
-                              'and per timepoint.'),
-                        default='all')
+                          dest='fitmode',
+                          action='store',
+                          choices=['all', 'ts'],
+                          help=('Monoexponential model fitting scheme. '
+                                '"all" means that the model is fit, per voxel, '
+                                'across all timepoints. '
+                                '"ts" means that the model is fit, per voxel '
+                                'and per timepoint.'),
+                          default='all')
     optional.add_argument('--combmode',
-                        dest='combmode',
-                        action='store',
-                        choices=['t2s', 'ste'],
-                        help=('Combination scheme for TEs: '
-                              't2s (Posse 1999, default), ste (Poser)'),
-                        default='t2s')
+                          dest='combmode',
+                          action='store',
+                          choices=['t2s', 'ste'],
+                          help=('Combination scheme for TEs: '
+                                't2s (Posse 1999, default), ste (Poser)'),
+                          default='t2s')
     optional.add_argument('--label',
-                        dest='label',
-                        type=str,
-                        help='Label for output directory.',
-                        default=None)
+                          dest='label',
+                          type=str,
+                          help='Label for output directory.',
+                          default=None)
     optional.add_argument('--debug',
-                        dest='debug',
-                        help=argparse.SUPPRESS,
-                        action='store_true',
-                        default=False)
+                          dest='debug',
+                          help=argparse.SUPPRESS,
+                          action='store_true',
+                          default=False)
     optional.add_argument('--quiet',
-                        dest='quiet',
-                        help=argparse.SUPPRESS,
-                        action='store_true',
-                        default=False)
+                          dest='quiet',
+                          help=argparse.SUPPRESS,
+                          action='store_true',
+                          default=False)
     parser._action_groups.append(optional)
     return parser
 

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -86,6 +86,7 @@ def _get_parser():
                         help=argparse.SUPPRESS,
                         action='store_true',
                         default=False)
+    parser._action_groups.append(optional)
     return parser
 
 

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -24,7 +24,11 @@ def _get_parser():
     parser.parse_args() : argparse dict
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d',
+    # Argument parser follow templtate provided by RalphyZ
+    # https://stackoverflow.com/a/43456577
+    optional = parser._action_groups.pop()
+    required = parser.add_argument_group('required arguments')
+    required.add_argument('-d',
                         dest='data',
                         nargs='+',
                         metavar='FILE',
@@ -35,14 +39,14 @@ def _get_parser():
                               'order as the TEs are listed in the -e '
                               'argument.'),
                         required=True)
-    parser.add_argument('-e',
+    required.add_argument('-e',
                         dest='tes',
                         nargs='+',
                         metavar='TE',
                         type=float,
                         help='Echo times (in ms). E.g., 15.0 39.0 63.0',
                         required=True)
-    parser.add_argument('--mask',
+    optional.add_argument('--mask',
                         dest='mask',
                         metavar='FILE',
                         type=lambda x: is_valid_file(parser, x),
@@ -50,7 +54,7 @@ def _get_parser():
                               'Dependent ANAlysis. Must be in the same '
                               'space as `data`.'),
                         default=None)
-    parser.add_argument('--fitmode',
+    optional.add_argument('--fitmode',
                         dest='fitmode',
                         action='store',
                         choices=['all', 'ts'],
@@ -60,24 +64,24 @@ def _get_parser():
                               '"ts" means that the model is fit, per voxel '
                               'and per timepoint.'),
                         default='all')
-    parser.add_argument('--combmode',
+    optional.add_argument('--combmode',
                         dest='combmode',
                         action='store',
                         choices=['t2s', 'ste'],
                         help=('Combination scheme for TEs: '
                               't2s (Posse 1999, default), ste (Poser)'),
                         default='t2s')
-    parser.add_argument('--label',
+    optional.add_argument('--label',
                         dest='label',
                         type=str,
                         help='Label for output directory.',
                         default=None)
-    parser.add_argument('--debug',
+    optional.add_argument('--debug',
                         dest='debug',
                         help=argparse.SUPPRESS,
                         action='store_true',
                         default=False)
-    parser.add_argument('--quiet',
+    optional.add_argument('--quiet',
                         dest='quiet',
                         help=argparse.SUPPRESS,
                         action='store_true',

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -27,6 +27,8 @@ def _get_parser():
     parser.parse_args() : argparse dict
     """
     parser = argparse.ArgumentParser()
+    # Argument parser follow templtate provided by RalphyZ
+    # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()
     required = parser.add_argument_group('required arguments')
     required.add_argument('-d',

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -27,7 +27,9 @@ def _get_parser():
     parser.parse_args() : argparse dict
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d',
+    optional = parser._action_groups.pop()
+    required = parser.add_argument_group('required arguments')
+    required.add_argument('-d',
                         dest='data',
                         nargs='+',
                         metavar='FILE',
@@ -38,14 +40,14 @@ def _get_parser():
                               'order as the TEs are listed in the -e '
                               'argument.'),
                         required=True)
-    parser.add_argument('-e',
+    required.add_argument('-e',
                         dest='tes',
                         nargs='+',
                         metavar='TE',
                         type=float,
                         help='Echo times (in ms). E.g., 15.0 39.0 63.0',
                         required=True)
-    parser.add_argument('--mask',
+    optional.add_argument('--mask',
                         dest='mask',
                         metavar='FILE',
                         type=lambda x: is_valid_file(parser, x),
@@ -53,51 +55,51 @@ def _get_parser():
                               'Dependent ANAlysis. Must be in the same '
                               'space as `data`.'),
                         default=None)
-    parser.add_argument('--mix',
+    optional.add_argument('--mix',
                         dest='mixm',
                         metavar='FILE',
                         type=lambda x: is_valid_file(parser, x),
                         help=('File containing mixing matrix. If not '
                               'provided, ME-PCA & ME-ICA is done.'),
                         default=None)
-    parser.add_argument('--ctab',
+    optional.add_argument('--ctab',
                         dest='ctab',
                         metavar='FILE',
                         type=lambda x: is_valid_file(parser, x),
                         help=('File containing a component table from which '
                               'to extract pre-computed classifications.'),
                         default=None)
-    parser.add_argument('--manacc',
+    optional.add_argument('--manacc',
                         dest='manacc',
                         help=('Comma separated list of manually '
                               'accepted components'),
                         default=None)
-    parser.add_argument('--sourceTEs',
+    optional.add_argument('--sourceTEs',
                         dest='ste',
                         type=str,
                         help=('Source TEs for models. E.g., 0 for all, '
                               '-1 for opt. com., and 1,2 for just TEs 1 and '
                               '2. Default=-1.'),
                         default=-1)
-    parser.add_argument('--combmode',
+    optional.add_argument('--combmode',
                         dest='combmode',
                         action='store',
                         choices=['t2s', 'ste'],
                         help=('Combination scheme for TEs: '
                               't2s (Posse 1999, default), ste (Poser)'),
                         default='t2s')
-    parser.add_argument('--verbose',
+    optional.add_argument('--verbose',
                         dest='verbose',
                         action='store_true',
                         help='Generate intermediate and additional files.',
                         default=False)
-    parser.add_argument('--tedort',
+    optional.add_argument('--tedort',
                         dest='tedort',
                         action='store_true',
                         help=('Orthogonalize rejected components w.r.t. '
                               'accepted components prior to denoising.'),
                         default=False)
-    parser.add_argument('--gscontrol',
+    optional.add_argument('--gscontrol',
                         dest='gscontrol',
                         required=False,
                         action='store',
@@ -108,39 +110,40 @@ def _get_parser():
                               'delimited list'),
                         choices=['t1c', 'gsr'],
                         default=None)
-    parser.add_argument('--wvpca',
+    optional.add_argument('--wvpca',
                         dest='wvpca',
                         help='Perform PCA on wavelet-transformed data',
                         action='store_true',
                         default=False)
-    parser.add_argument('--tedpca',
+    optional.add_argument('--tedpca',
                         dest='tedpca',
                         help='Method with which to select components in TEDPCA',
                         choices=['mle', 'kundu', 'kundu-stabilize'],
                         default='mle')
-    parser.add_argument('--out-dir',
+    optional.add_argument('--out-dir',
                         dest='out_dir',
                         type=str,
                         help='Output directory.',
                         default='.')
-    parser.add_argument('--seed',
+    optional.add_argument('--seed',
                         dest='fixed_seed',
                         type=int,
                         help=('Value passed to repr(mdp.numx_rand.seed()) '
                               'Set to an integer value for reproducible ICA results; '
                               'otherwise, set to -1 for varying results across calls.'),
                         default=42)
-    parser.add_argument('--debug',
+    optional.add_argument('--debug',
                         dest='debug',
                         help=argparse.SUPPRESS,
                         action='store_true',
                         default=False)
-    parser.add_argument('--quiet',
+    optional.add_argument('--quiet',
                         dest='quiet',
                         help=argparse.SUPPRESS,
                         action='store_true',
                         default=False)
-    return parser
+    parser._action_groups.append(optional)
+    return parser.parse_args()
 
 
 def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -32,118 +32,118 @@ def _get_parser():
     optional = parser._action_groups.pop()
     required = parser.add_argument_group('required arguments')
     required.add_argument('-d',
-                        dest='data',
-                        nargs='+',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('Multi-echo dataset for analysis. May be a '
-                              'single file with spatially concatenated data '
-                              'or a set of echo-specific files, in the same '
-                              'order as the TEs are listed in the -e '
-                              'argument.'),
-                        required=True)
+                          dest='data',
+                          nargs='+',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('Multi-echo dataset for analysis. May be a '
+                                'single file with spatially concatenated data '
+                                'or a set of echo-specific files, in the same '
+                                'order as the TEs are listed in the -e '
+                                'argument.'),
+                          required=True)
     required.add_argument('-e',
-                        dest='tes',
-                        nargs='+',
-                        metavar='TE',
-                        type=float,
-                        help='Echo times (in ms). E.g., 15.0 39.0 63.0',
-                        required=True)
+                          dest='tes',
+                          nargs='+',
+                          metavar='TE',
+                          type=float,
+                          help='Echo times (in ms). E.g., 15.0 39.0 63.0',
+                          required=True)
     optional.add_argument('--mask',
-                        dest='mask',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('Binary mask of voxels to include in TE '
-                              'Dependent ANAlysis. Must be in the same '
-                              'space as `data`.'),
-                        default=None)
+                          dest='mask',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('Binary mask of voxels to include in TE '
+                                'Dependent ANAlysis. Must be in the same '
+                                'space as `data`.'),
+                          default=None)
     optional.add_argument('--mix',
-                        dest='mixm',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('File containing mixing matrix. If not '
-                              'provided, ME-PCA & ME-ICA is done.'),
-                        default=None)
+                          dest='mixm',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('File containing mixing matrix. If not '
+                                'provided, ME-PCA & ME-ICA is done.'),
+                          default=None)
     optional.add_argument('--ctab',
-                        dest='ctab',
-                        metavar='FILE',
-                        type=lambda x: is_valid_file(parser, x),
-                        help=('File containing a component table from which '
-                              'to extract pre-computed classifications.'),
-                        default=None)
+                          dest='ctab',
+                          metavar='FILE',
+                          type=lambda x: is_valid_file(parser, x),
+                          help=('File containing a component table from which '
+                                'to extract pre-computed classifications.'),
+                          default=None)
     optional.add_argument('--manacc',
-                        dest='manacc',
-                        help=('Comma separated list of manually '
-                              'accepted components'),
-                        default=None)
+                          dest='manacc',
+                          help=('Comma separated list of manually '
+                                'accepted components'),
+                          default=None)
     optional.add_argument('--sourceTEs',
-                        dest='ste',
-                        type=str,
-                        help=('Source TEs for models. E.g., 0 for all, '
-                              '-1 for opt. com., and 1,2 for just TEs 1 and '
-                              '2. Default=-1.'),
-                        default=-1)
+                          dest='ste',
+                          type=str,
+                          help=('Source TEs for models. E.g., 0 for all, '
+                                '-1 for opt. com., and 1,2 for just TEs 1 and '
+                                '2. Default=-1.'),
+                          default=-1)
     optional.add_argument('--combmode',
-                        dest='combmode',
-                        action='store',
-                        choices=['t2s', 'ste'],
-                        help=('Combination scheme for TEs: '
-                              't2s (Posse 1999, default), ste (Poser)'),
-                        default='t2s')
+                          dest='combmode',
+                          action='store',
+                          choices=['t2s', 'ste'],
+                          help=('Combination scheme for TEs: '
+                                't2s (Posse 1999, default), ste (Poser)'),
+                          default='t2s')
     optional.add_argument('--verbose',
-                        dest='verbose',
-                        action='store_true',
-                        help='Generate intermediate and additional files.',
-                        default=False)
+                          dest='verbose',
+                          action='store_true',
+                          help='Generate intermediate and additional files.',
+                          default=False)
     optional.add_argument('--tedort',
-                        dest='tedort',
-                        action='store_true',
-                        help=('Orthogonalize rejected components w.r.t. '
-                              'accepted components prior to denoising.'),
-                        default=False)
+                          dest='tedort',
+                          action='store_true',
+                          help=('Orthogonalize rejected components w.r.t. '
+                                'accepted components prior to denoising.'),
+                          default=False)
     optional.add_argument('--gscontrol',
-                        dest='gscontrol',
-                        required=False,
-                        action='store',
-                        nargs='+',
-                        help=('Perform additional denoising to remove '
-                              'spatially diffuse noise. Default is None. '
-                              'This argument can be single value or a space '
-                              'delimited list'),
-                        choices=['t1c', 'gsr'],
-                        default=None)
+                          dest='gscontrol',
+                          required=False,
+                          action='store',
+                          nargs='+',
+                          help=('Perform additional denoising to remove '
+                                'spatially diffuse noise. Default is None. '
+                                'This argument can be single value or a space '
+                                'delimited list'),
+                          choices=['t1c', 'gsr'],
+                          default=None)
     optional.add_argument('--wvpca',
-                        dest='wvpca',
-                        help='Perform PCA on wavelet-transformed data',
-                        action='store_true',
-                        default=False)
+                          dest='wvpca',
+                          help='Perform PCA on wavelet-transformed data',
+                          action='store_true',
+                          default=False)
     optional.add_argument('--tedpca',
-                        dest='tedpca',
-                        help='Method with which to select components in TEDPCA',
-                        choices=['mle', 'kundu', 'kundu-stabilize'],
-                        default='mle')
+                          dest='tedpca',
+                          help='Method with which to select components in TEDPCA',
+                          choices=['mle', 'kundu', 'kundu-stabilize'],
+                          default='mle')
     optional.add_argument('--out-dir',
-                        dest='out_dir',
-                        type=str,
-                        help='Output directory.',
-                        default='.')
+                          dest='out_dir',
+                          type=str,
+                          help='Output directory.',
+                          default='.')
     optional.add_argument('--seed',
-                        dest='fixed_seed',
-                        type=int,
-                        help=('Value passed to repr(mdp.numx_rand.seed()) '
-                              'Set to an integer value for reproducible ICA results; '
-                              'otherwise, set to -1 for varying results across calls.'),
-                        default=42)
+                          dest='fixed_seed',
+                          type=int,
+                          help=('Value passed to repr(mdp.numx_rand.seed()) '
+                                'Set to an integer value for reproducible ICA results; '
+                                'otherwise, set to -1 for varying results across calls.'),
+                          default=42)
     optional.add_argument('--debug',
-                        dest='debug',
-                        help=argparse.SUPPRESS,
-                        action='store_true',
-                        default=False)
+                          dest='debug',
+                          help=argparse.SUPPRESS,
+                          action='store_true',
+                          default=False)
     optional.add_argument('--quiet',
-                        dest='quiet',
-                        help=argparse.SUPPRESS,
-                        action='store_true',
-                        default=False)
+                          dest='quiet',
+                          help=argparse.SUPPRESS,
+                          action='store_true',
+                          default=False)
     parser._action_groups.append(optional)
     return parser
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -143,7 +143,7 @@ def _get_parser():
                         action='store_true',
                         default=False)
     parser._action_groups.append(optional)
-    return parser.parse_args()
+    return parser
 
 
 def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,


### PR DESCRIPTION
Now required argument show up when tedana or t2smap help is called, via tedana -h/ t2smap -h

<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #194 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-required arguments show up first, in required group, when viewing tedana help
-Same solution used for t2smap
-took directly from the ~~StackExchange~~ stackoverflow - https://stackoverflow.com/a/43456577
