### PR TITLE
Fix broken link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ You're awesome. :wave::smiley:
 [link_milestones]: https://github.com/ME-ICA/tedana/milestones/
 [link_project_boards]: https://github.com/ME-ICA/tedana/projects
 [link_gitter]: https://gitter.im/me-ica/tedana
-[link_coc]: https://github.com/ME-ICA/tedana/blob/master/Code_of_Conduct.md
+[link_coc]: https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md
 
 [link_labels]: https://github.com/ME-ICA/tedana/labels
 [link_bugs]: https://github.com/ME-ICA/tedana/labels/bug

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -44,7 +44,7 @@ in-person workshops or development sprints, and when giving talks about the soft
 As stated in the code, severe or repeated violations by community members may result in exclusion
 from collective decision-making and rejection of future contributions to the ``tedana`` project.
 
-.. _code of conduct: https://github.com/ME-ICA/tedana/blob/master/Code_of_Conduct.md
+.. _code of conduct: https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md
 
 tedana's development philosophy
 --------------------------------------


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Doesn't close an open issue.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Fixed broken links to code of conduct.
  - This would have been a great "good first issue" but given that they're links to the code of conduct from the contributing guide in the docs and in the repo I think it's important to fix quickly! I hope that's ok 👾 