### PR TITLE
[FIX] Propagate TR to ref_image header

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -544,7 +544,7 @@ def load_data(data, n_echos=None):
     fdata = utils.load_image(img.get_data().reshape(nx, ny, nz, n_echos, -1, order='F'))
 
     # create reference image
-    ref_img = img.__class__(np.zeros((nx, ny, nz)), affine=img.affine,
+    ref_img = img.__class__(np.zeros((nx, ny, nz, 1)), affine=img.affine,
                             header=img.header, extra=img.extra)
     ref_img.header.extensions = []
     ref_img.header.set_sform(ref_img.header.get_sform(), code=1)

--- a/tedana/tests/test_io.py
+++ b/tedana/tests/test_io.py
@@ -42,7 +42,7 @@ def test_load_data():
     d, ref = me.load_data(fnames[0], n_echos=3)
     assert d.shape == (21450, 3, 5)
     assert isinstance(ref, nib.Nifti1Image)
-    assert ref.shape == (39, 50, 11)
+    assert ref.shape == (39, 50, 11, 1)
 
     with pytest.raises(ValueError):
         me.load_data(fnames[0])


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #206  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- in load_data, the ref image now has a 4th dimension, TR in output is now correct
-
