### PR TITLE
[REF] Clean up outdated/unused functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -145,14 +145,11 @@ API
    :template: function.rst
 
    tedana.io.split_ts
-
-   tedana.io.ctabsel
    tedana.io.filewrite
    tedana.io.gscontrol_mmix
    tedana.io.load_data
    tedana.io.new_nii_like
    tedana.io.write_split_ts
-   tedana.io.writect
    tedana.io.writefeats
    tedana.io.writeresults
    tedana.io.writeresults_echoes
@@ -180,14 +177,9 @@ API
 
    tedana.utils.andb
    tedana.utils.dice
-   tedana.utils.fitgaussian
-   tedana.utils.gaussian
-   tedana.utils.get_dtype
    tedana.utils.getfbounds
    tedana.utils.load_image
    tedana.utils.make_adaptive_mask
-   tedana.utils.make_min_mask
-   tedana.utils.moments
    tedana.utils.unmask
 
    :template: module.rst

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -395,33 +395,6 @@ def writeresults_echoes(catd, mmix, mask, acc, rej, midk, ref_img):
                        suffix='e%i' % (i_echo + 1))
 
 
-def ctabsel(ctabfile):
-    """
-    Loads a pre-existing component table file
-
-    Parameters
-    ----------
-    ctabfile : :obj:`str`
-        Filepath to existing component table
-
-    Returns
-    -------
-    ctab : (4,) :obj:`tuple` of :obj:`numpy.ndarray`
-        Tuple containing arrays of (1) accepted, (2) rejected, (3) mid, and (4)
-        ignored components
-    """
-
-    with open(ctabfile, 'r') as src:
-        ctlines = src.readlines()
-    class_tags = ['#ACC', '#REJ', '#MID', '#IGN']
-    class_dict = {}
-    for ii, ll in enumerate(ctlines):
-        for kk in class_tags:
-            if ll[:4] is kk and ll[4:].strip() is not '':
-                class_dict[kk] = ll[4:].split('#')[0].split(',')
-    return tuple([np.array(class_dict[kk], dtype=int) for kk in class_tags])
-
-
 def new_nii_like(ref_img, data, affine=None, copy_header=True):
     """
     Coerces `data` into NiftiImage format like `ref_img`

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -4,50 +4,8 @@ Utility functions for tedana.selection
 import logging
 
 import numpy as np
-from sklearn import svm
 
 LGR = logging.getLogger(__name__)
-
-
-def do_svm(X_train, y_train, X_test, svmtype=0):
-    """
-    Implements Support Vector Classification on provided data
-
-    Parameters
-    ----------
-    X_train : (N1 x F) array_like
-        Training vectors, where n_samples is the number of samples in the
-        training dataset and n_features is the number of features.
-    y_train : (N1,) array_like
-        Target values (class labels in classification, real numbers in
-        regression)
-    X_test : (N2 x F) array_like
-        Test vectors, where n_samples is the number of samples in the test
-        dataset and n_features is the number of features.
-    svmtype : :obj:`int`, optional
-        Desired support vector machine type. Must be in [0, 1, 2]. Default: 0
-
-    Returns
-    -------
-    y_pred : (N2,) :obj:`numpy.ndarray`
-        Predicted class labels for samples in `X_test`
-    clf : {:obj:`sklearn.svm.SVC`, :obj:`sklearn.svm.LinearSVC`}
-        Trained sklearn model instance
-    """
-
-    if svmtype == 0:
-        clf = svm.SVC(kernel='linear')
-    elif svmtype == 1:
-        clf = svm.LinearSVC(loss='squared_hinge', penalty='l1', dual=False)
-    elif svmtype == 2:
-        clf = svm.SVC(kernel='linear', probability=True)
-    else:
-        raise ValueError('Input svmtype not in [0, 1, 2]: {}'.format(svmtype))
-
-    clf.fit(X_train, y_train)
-    y_pred = clf.predict(X_test)
-
-    return y_pred, clf
 
 
 def getelbow_cons(arr, return_val=False):

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -17,7 +17,7 @@ def testdata1():
     in_files = [op.join(get_test_data_path(), 'echo{0}.nii.gz'.format(i+1))
                 for i in range(3)]
     data, _ = io.load_data(in_files, n_echos=len(tes))
-    mask, mask_sum = utils.make_adaptive_mask(data, minimum=False, getsum=True)
+    mask, mask_sum = utils.make_adaptive_mask(data, getsum=True)
     data_dict = {'data': data,
                  'tes': tes,
                  'mask': mask,

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -105,12 +105,3 @@ def test_make_adaptive_mask():
                                                               'mask.nii.gz'),
                                              getsum=True)
     assert np.allclose(mask, masksum.astype(bool))
-
-
-def test_make_min_mask():
-    # load data make mask
-    data = io.load_data(fnames, n_echos=len(tes))[0]
-    minmask = utils.make_min_mask(data)
-
-    assert minmask.shape == (64350,)
-    assert minmask.sum() == 58378

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -85,13 +85,10 @@ def test_load_image():
 def test_make_adaptive_mask():
     # load data make masks
     data = io.load_data(fnames, n_echos=len(tes))[0]
-    minmask = utils.make_adaptive_mask(data)
-    mask, masksum = utils.make_adaptive_mask(data, minimum=False, getsum=True)
+    mask, masksum = utils.make_adaptive_mask(data, getsum=True)
 
-    # minimum mask different than adaptive mask
-    assert not np.allclose(minmask, mask)
     # getsum doesn't change mask values
-    assert np.allclose(mask, utils.make_adaptive_mask(data, minimum=False))
+    assert np.allclose(mask, utils.make_adaptive_mask(data))
     # shapes are all the same
     assert mask.shape == masksum.shape == (64350,)
     assert np.allclose(mask, masksum.astype(bool))
@@ -106,7 +103,7 @@ def test_make_adaptive_mask():
     # TODO: Add mask file with no bad voxels to test against
     mask, masksum = utils.make_adaptive_mask(data, mask=pjoin(datadir,
                                                               'mask.nii.gz'),
-                                             minimum=False, getsum=True)
+                                             getsum=True)
     assert np.allclose(mask, masksum.astype(bool))
 
 

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -16,27 +16,6 @@ fnames = [pjoin(datadir, 'echo{}.nii.gz'.format(n)) for n in range(1, 4)]
 tes = ['14.5', '38.5', '62.5']
 
 
-def test_get_dtype():
-    # various combinations of input types
-    good_inputs = [
-        (['echo1.nii.gz', 'echo2.nii.gz', 'echo3.nii.gz'], 'NIFTI'),
-        ('echo1.nii.gz', 'NIFTI'),
-        (['echo1.unknown', 'echo2.unknown', 'echo3.unknown'], 'OTHER'),
-        ('echo1.unknown', 'OTHER'),
-        (nib.Nifti1Image(np.zeros((10,)*3),
-                         affine=np.diag(np.ones(4))), 'NIFTI')
-    ]
-
-    for (input, expected) in good_inputs:
-        assert utils.get_dtype(input) == expected
-
-    with pytest.raises(ValueError):  # mixed arrays don't work
-        utils.get_dtype(['echo1.unknown', 'echo1.nii.gz'])
-
-    with pytest.raises(TypeError):  # non-img_like inputs don't work
-        utils.get_dtype(rs.rand(100, 100))
-
-
 def test_getfbounds():
     good_inputs = range(1, 12)
 
@@ -60,12 +39,6 @@ def test_unmask():
         out = utils.unmask(input, mask)
         assert out.shape == (100,) + input.shape[1:]
         assert out.dtype == dtype
-
-
-def test_fitgaussian():
-    # not sure a good way to test this
-    # it's straight out of the scipy cookbook, so hopefully its robust?
-    assert utils.fitgaussian(rs.rand(100, 100)).size == 5
 
 
 def test_dice():

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -60,7 +60,7 @@ def load_image(data):
     return fdata
 
 
-def make_adaptive_mask(data, mask=None, minimum=True, getsum=False):
+def make_adaptive_mask(data, mask=None, getsum=False):
     """
     Makes map of `data` specifying longest echo a voxel can be sampled with
 
@@ -72,9 +72,6 @@ def make_adaptive_mask(data, mask=None, minimum=True, getsum=False):
     mask : :obj:`str` or img_like, optional
         Binary mask for voxels to consider in TE Dependent ANAlysis. Default is
         to generate mask from data with good signal across echoes
-    minimum : :obj:`bool`, optional
-        Use `make_min_mask()` instead of generating a map with echo-specific
-        times. Default: True
     getsum : :obj:`bool`, optional
         Return `masksum` in addition to `mask`. Default: False
 
@@ -87,10 +84,6 @@ def make_adaptive_mask(data, mask=None, minimum=True, getsum=False):
         Valued array indicating the number of echos with sufficient signal in a
         given voxel. Only returned if `getsum = True`
     """
-
-    if minimum:
-        return make_min_mask(data, roi=mask)
-
     # take temporal mean of echos and extract non-zero values in first echo
     echo_means = data.mean(axis=-1)  # temporal mean of echos
     first_echo = echo_means[echo_means[:, 0] != 0, 0]
@@ -131,37 +124,6 @@ def make_adaptive_mask(data, mask=None, minimum=True, getsum=False):
         return mask, masksum
 
     return mask
-
-
-def make_min_mask(data, roi=None):
-    """
-    Generates a 3D mask of `data`
-
-    Only samples that are consistently (i.e., across time AND echoes) non-zero
-    in `data` are True in output
-
-    Parameters
-    ----------
-    data : (S x E x T) array_like
-        Multi-echo data array, where `S` is samples, `E` is echos, and `T` is
-        time
-    roi : :obj:`str`, optional
-        Binary mask for region-of-interest to consider in TE Dependent ANAlysis
-
-    Returns
-    -------
-    mask : (S,) :obj:`numpy.ndarray`
-        Boolean array
-    """
-
-    data = np.asarray(data).astype(bool)
-    mask = data.prod(axis=-1).prod(axis=-1).astype(bool)
-
-    if roi is None:
-        return mask
-    else:
-        roi = load_image(roi).astype(bool)
-        return np.logical_and(mask, roi)
 
 
 def unmask(data, mask):

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -181,7 +181,7 @@ def t2smap_workflow(data, tes, mask=None, fitmode='all', combmode='t2s',
         LGR.info('Computing adaptive mask')
     else:
         LGR.info('Using user-defined mask')
-    mask, masksum = utils.make_adaptive_mask(catd, minimum=False, getsum=True)
+    mask, masksum = utils.make_adaptive_mask(catd, getsum=True)
 
     LGR.info('Computing adaptive T2* map')
     if fitmode == 'all':

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -298,8 +298,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         # TODO: add affine check
         LGR.info('Using user-defined mask')
 
-    mask, masksum = utils.make_adaptive_mask(catd, mask=mask,
-                                             minimum=False, getsum=True)
+    mask, masksum = utils.make_adaptive_mask(catd, mask=mask, getsum=True)
     LGR.debug('Retaining {}/{} samples'.format(mask.sum(), n_samp))
     if verbose:
         io.filewrite(masksum, op.join(out_dir, 'adaptive_mask.nii'), ref_img)


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. This PR will clean up the package a little bit. If we ever plan to re-integrate v3.2 into `tedana`, we can pull the removed functions from old releases. 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove the following functions tied to v3.2 of the selection criteria, which we no longer support:
    - `selection._utils.do_svm`
    - `utils.moments`
    - `utils.gaussian`
    - `utils.fitgaussian`
- Remove the following functions which are outdated due to package-wide changes:
    - `utils.get_dtype`: We dropped support for surfaces, so I think this is no longer necessary. It's not used anywhere in the package.
    - `io.ctabsel`: We use csv/tsv files, and will use jsons, for the component tables. The old text files are no longer used.
- Remove the `minimum` argument for `utils.make_adaptive_mask`. This argument set to `True` by default, but is actually never used.
- Remove `utils.make_min_mask`. This goes with removing the `minimum` argument for `utils.make_adaptive_mask`.
