### PR TITLE
[ENH] Speed up cluster-extent thresholding function

### DIFF
--- a/tedana/model/__init__.py
+++ b/tedana/model/__init__.py
@@ -2,9 +2,8 @@
 # ex: set sts=4 ts=4 sw=4 et:
 
 from .fit import (
-    fitmodels_direct, spatclust, gscontrol_raw, get_coeffs, computefeats2
+    fitmodels_direct, gscontrol_raw, get_coeffs, computefeats2
 )
 
 __all__ = [
-    'fitmodels_direct', 'spatclust', 'gscontrol_raw', 'get_coeffs',
-    'computefeats2']
+    'fitmodels_direct', 'gscontrol_raw', 'get_coeffs', 'computefeats2']

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 import nibabel as nib
 from scipy import stats
-from scipy.ndimage import label
+from scipy import ndimage
 from nilearn._utils import check_niimg
 from sklearn.utils import check_array
 
@@ -301,7 +301,7 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
 
     # 6 connectivity
     struc = ndimage.generate_binary_structure(3, 1)
-    labeled, _ = label(thresh_arr, struc)
+    labeled, _ = ndimage.label(thresh_arr, struc)
     unique, counts = np.unique(labeled, return_counts=True)
     clust_sizes = dict(zip(unique, counts))
     clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}
@@ -319,7 +319,7 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
         else:
             thresh_arr = test_arr < 0
 
-        labeled, _ = label(thresh_arr, struc)
+        labeled, _ = ndimage.label(thresh_arr, struc)
         unique, counts = np.unique(labeled, return_counts=True)
         clust_sizes = dict(zip(unique, counts))
         clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -4,8 +4,9 @@ Utilities for tedana package
 import logging
 
 import numpy as np
-from scipy import stats
 import nibabel as nib
+from scipy import stats
+from scipy.ndimage import label
 from nilearn._utils import check_niimg
 from sklearn.utils import check_array
 
@@ -251,3 +252,93 @@ def get_spectrum(data: np.array, tr: float = 1.0):
     freqs = np.fft.rfftfreq(power_spectrum.size * 2 - 1, tr)
     idx = np.argsort(freqs)
     return power_spectrum[idx], freqs[idx]
+
+
+def threshold_map(img, min_cluster_size, threshold=None, mask=None,
+                  binarize=True, sided='two'):
+    """
+    Cluster-extent threshold and binarize image.
+
+    Parameters
+    ----------
+    img : img_like or array_like
+        Image object or 3D array to be clustered
+    min_cluster_size : int
+        Minimum cluster size (in voxels)
+    threshold : float or None, optional
+        Cluster-defining threshold for img. If None (default), assume img is
+        already thresholded.
+    mask : (S,) array_like or None, optional
+        Boolean array for masking resultant data array. Default is None.
+    binarize : bool, optional
+        Default is True.
+    sided : {'two', 'one', 'bi'}, optional
+        How to apply thresholding. One-sided thresholds on the positive side.
+        Two-sided thresholds positive and negative values together. Bi-sided
+        thresholds positive and negative values separately. Default is 'two'.
+    """
+    if not isinstance(img, np.ndarray):
+        arr = img.get_data()
+    else:
+        arr = img.copy()
+
+    if mask is not None:
+        mask = mask.astype(bool)
+        arr *= mask.reshape(arr.shape)
+
+    # 6 connectivity
+    conn_mat = np.zeros((3, 3, 3), int)
+    conn_mat[1, 1, :] = 1
+    conn_mat[1, :, 1] = 1
+    conn_mat[:, 1, 1] = 1
+
+    clust_thresholded = np.zeros(arr.shape, int)
+
+    if sided == 'two':
+        test_arr = np.abs(arr)
+    else:
+        test_arr = arr.copy()
+
+    # Positive values (or absolute values) first
+    if threshold is not None:
+        thresh_arr = test_arr >= threshold
+    else:
+        thresh_arr = test_arr > 0
+
+    labeled, _ = label(thresh_arr, conn_mat)
+    unique, counts = np.unique(labeled, return_counts=True)
+    clust_sizes = dict(zip(unique, counts))
+    clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}
+    for i_clust in clust_sizes.keys():
+        if np.all(thresh_arr[labeled == i_clust] == 1):
+            if binarize:
+                clust_thresholded[labeled == i_clust] = 1
+            else:
+                clust_thresholded[labeled == i_clust] = arr[labeled == i_clust]
+
+    # Now negative values *if bi-sided*
+    if sided == 'bi':
+        if threshold is not None:
+            thresh_arr = test_arr <= (-1 * threshold)
+        else:
+            thresh_arr = test_arr < 0
+
+        labeled, _ = label(thresh_arr, conn_mat)
+        unique, counts = np.unique(labeled, return_counts=True)
+        clust_sizes = dict(zip(unique, counts))
+        clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}
+        for i_clust in clust_sizes.keys():
+            if np.all(thresh_arr[labeled == i_clust] == 1):
+                if binarize:
+                    clust_thresholded[labeled == i_clust] = 1
+                else:
+                    clust_thresholded[labeled == i_clust] = arr[labeled == i_clust]
+
+    # reshape to (S,)
+    clust_thresholded = clust_thresholded.ravel()
+
+    # if mask provided, mask output
+    if mask is not None:
+        clust_thresholded = clust_thresholded[mask]
+
+    return clust_thresholded

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -286,12 +286,6 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
         mask = mask.astype(bool)
         arr *= mask.reshape(arr.shape)
 
-    # 6 connectivity
-    conn_mat = np.zeros((3, 3, 3), int)
-    conn_mat[1, 1, :] = 1
-    conn_mat[1, :, 1] = 1
-    conn_mat[:, 1, 1] = 1
-
     clust_thresholded = np.zeros(arr.shape, int)
 
     if sided == 'two':
@@ -305,7 +299,9 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
     else:
         thresh_arr = test_arr > 0
 
-    labeled, _ = label(thresh_arr, conn_mat)
+    # 6 connectivity
+    struc = ndimage.generate_binary_structure(3, 1)
+    labeled, _ = label(thresh_arr, struc)
     unique, counts = np.unique(labeled, return_counts=True)
     clust_sizes = dict(zip(unique, counts))
     clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}
@@ -323,7 +319,7 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
         else:
             thresh_arr = test_arr < 0
 
-        labeled, _ = label(thresh_arr, conn_mat)
+        labeled, _ = label(thresh_arr, struc)
         unique, counts = np.unique(labeled, return_counts=True)
         clust_sizes = dict(zip(unique, counts))
         clust_sizes = {k: v for k, v in clust_sizes.items() if v >= min_cluster_size}


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use `numpy.unique` to cluster-extent threshold and binarize maps with `spatclust`.
- Cluster positive and negative values separately.
- Rename `spatclust` to `threshold_map` and move from `model.fit` to `utils`.
- Add arguments for binarization (default is yes) and sided-ness of the thresholding (default is to treat positive and negative values the same).