### PR TITLE
[REF] Clean up comptable handling in tedana.io

### DIFF
--- a/tedana/gscontrol.py
+++ b/tedana/gscontrol.py
@@ -114,9 +114,9 @@ def gscontrol_mmix(optcom_ts, mmix, mask, comptable, ref_img):
         is components and `T` is the same as in `optcom_ts`
     mask : (S,) array_like
         Boolean mask array
-    comptable : :obj:`pandas.DataFrame`
-        Component table with metrics and with classification (accepted,
-        rejected, midk, or ignored)
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. The index should be the component number.
     ref_img : :obj:`str` or img_like
         Reference image to dictate how outputs are saved to disk
 
@@ -134,9 +134,9 @@ def gscontrol_mmix(optcom_ts, mmix, mask, comptable, ref_img):
     meica_mix_T1c.1D          T1 global signal-corrected mixing matrix
     ======================    =================================================
     """
-    all_comps = comptable['component'].values
-    acc = comptable.loc[comptable['classification'] == 'accepted', 'component']
-    ign = comptable.loc[comptable['classification'] == 'ignored', 'component']
+    all_comps = comptable.index.values
+    acc = comptable[comptable.classification == 'accepted'].index.values
+    ign = comptable[comptable.classification == 'ignored'].index.values
     not_ign = sorted(np.setdiff1d(all_comps, ign))
 
     optcom_masked = optcom_ts[mask, :]

--- a/tedana/model/fit.py
+++ b/tedana/model/fit.py
@@ -59,10 +59,9 @@ def fitmodels_direct(catd, mmix, mask, t2s, t2s_full, tes, combmode, ref_img,
     Returns
     -------
     seldict : dict
-    comptab : (N x 5) :obj:`pandas.DataFrame`
-        Array with columns denoting (1) index of component, (2) Kappa score of
-        component, (3) Rho score of component, (4) variance explained by
-        component, and (5) normalized variance explained by component
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. The index is the component number.
     betas : :obj:`numpy.ndarray`
     mmix_new : :obj:`numpy.ndarray`
     """
@@ -197,11 +196,11 @@ def fitmodels_direct(catd, mmix, mask, t2s, t2s_full, tes, combmode, ref_img,
         rhos[i_comp] = np.average(F_S0, weights=norm_weights)
 
     # tabulate component values
-    comptab = np.vstack([kappas, rhos, varex, varex_norm]).T
+    comptable = np.vstack([kappas, rhos, varex, varex_norm]).T
     if reindex:
         # re-index all components in Kappa order
-        sort_idx = comptab[:, 0].argsort()[::-1]
-        comptab = comptab[sort_idx, :]
+        sort_idx = comptable[:, 0].argsort()[::-1]
+        comptable = comptable[sort_idx, :]
         mmix_new = mmix[:, sort_idx]
         betas = betas[..., sort_idx]
         pred_R2_maps = pred_R2_maps[:, :, sort_idx]
@@ -231,11 +230,11 @@ def fitmodels_direct(catd, mmix, mask, t2s, t2s_full, tes, combmode, ref_img,
                      op.join(out_dir, '{0}metric_weights.nii'.format(label)),
                      ref_img)
 
-    comptab = pd.DataFrame(comptab,
-                           columns=['kappa', 'rho',
-                                    'variance explained',
-                                    'normalized variance explained'])
-    comptab.index.name = 'component'
+    comptable = pd.DataFrame(comptable,
+                             columns=['kappa', 'rho',
+                                      'variance explained',
+                                      'normalized variance explained'])
+    comptable.index.name = 'component'
 
     # full selection including clustering criteria
     seldict = None
@@ -287,7 +286,7 @@ def fitmodels_direct(catd, mmix, mask, t2s, t2s_full, tes, combmode, ref_img,
         for vv in selvars:
             seldict[vv] = eval(vv)
 
-    return seldict, comptab, betas, mmix_new
+    return seldict, comptable, betas, mmix_new
 
 
 def computefeats2(data, mmix, mask, normalize=True):

--- a/tedana/selection/select_comps.py
+++ b/tedana/selection/select_comps.py
@@ -25,8 +25,9 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
     seldict : :obj:`dict`
         A dictionary with component-specific features used for classification.
         As output from `fitmodels_direct`
-    comptable : (C x 5) :obj:`pandas.DataFrame`
-        Component metric table
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. The index should be the component number.
     mmix : (T x C) array_like
         Mixing matrix for converting input data to component space, where `C`
         is components and `T` is the number of volumes in the original data
@@ -39,7 +40,7 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
     -------
     comptable : :obj:`pandas.DataFrame`
         Updated component table with additional metrics and with
-        classification (accepted, rejected, midk, or ignored)
+        classification (accepted, rejected, or ignored)
 
     Notes
     -----

--- a/tedana/viz.py
+++ b/tedana/viz.py
@@ -54,10 +54,9 @@ def write_comp_figs(ts, mask, comptable, mmix, ref_img, out_dir,
         Time series from which to derive ICA betas
     mask : (S,) array_like
         Boolean mask array
-    comptable : (N x 5) array_like
-        Array with columns denoting (1) index of component, (2) Kappa score of
-        component, (3) Rho score of component, (4) variance explained by
-        component, and (5) normalized variance explained by component
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. The index should be the component number.
     mmix : (C x T) array_like
         Mixing matrix for converting input data to component space, where `C`
         is components and `T` is the same as in `data`
@@ -95,17 +94,16 @@ def write_comp_figs(ts, mask, comptable, mmix, ref_img, out_dir,
 
     # Remove trailing ';' from rationale column
     comptable['rationale'] = comptable['rationale'].str.rstrip(';')
-    for compnum in range(0, mmix.shape[1], 1):
-
-        if comptable.iloc[compnum]["classification"] == 'accepted':
+    for compnum in comptable.index.values:
+        if comptable.loc[compnum, "classification"] == 'accepted':
             line_color = 'g'
             expl_text = 'accepted'
-        elif comptable.iloc[compnum]["classification"] == 'rejected':
+        elif comptable.loc[compnum, "classification"] == 'rejected':
             line_color = 'r'
-            expl_text = 'rejection reason(s): ' + comptable.iloc[compnum]["rationale"]
-        elif comptable.iloc[compnum]["classification"] == 'ignored':
+            expl_text = 'rejection reason(s): ' + comptable.loc[compnum, "rationale"]
+        elif comptable.loc[compnum, "classification"] == 'ignored':
             line_color = 'k'
-            expl_text = 'ignored reason(s): ' + comptable.iloc[compnum]["rationale"]
+            expl_text = 'ignored reason(s): ' + comptable.loc[compnum, "rationale"]
         else:
             # Classification not added
             # If new, this will keep code running
@@ -141,12 +139,12 @@ def write_comp_figs(ts, mask, comptable, mmix, ref_img, out_dir,
         ax_ts.plot(mmix[:, compnum], color=line_color)
 
         # Title will include variance from comptable
-        comp_var = "{0:.2f}".format(comptable.iloc[compnum]["variance explained"])
-        comp_kappa = "{0:.2f}".format(comptable.iloc[compnum]["kappa"])
-        comp_rho = "{0:.2f}".format(comptable.iloc[compnum]["rho"])
-        plt_title = 'Comp. {}: variance: {}%, kappa: {}, rho: {}, {}'.format(compnum, comp_var,
-                                                                             comp_kappa, comp_rho,
-                                                                             expl_text)
+        comp_var = "{0:.2f}".format(comptable.loc[compnum, "variance explained"])
+        comp_kappa = "{0:.2f}".format(comptable.loc[compnum, "kappa"])
+        comp_rho = "{0:.2f}".format(comptable.loc[compnum, "rho"])
+        plt_title = ('Comp. {}: variance: {}%, kappa: {}, rho: {}, '
+                     '{}'.format(compnum, comp_var, comp_kappa, comp_rho,
+                                 expl_text))
         title = ax_ts.set_title(plt_title)
         title.set_y(1.5)
 
@@ -202,10 +200,10 @@ def write_kappa_scatter(comptable, out_dir):
 
     Parameters
     ----------
-    comptable : (N x 5) array_like
-        Array with columns denoting (1) index of component, (2) Kappa score of
-        component, (3) Rho score of component, (4) variance explained by
-        component, and (5) normalized variance explained by component
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. Requires at least four columns: "classification",
+        "kappa", "rho", and "variance explained".
     out_dir : :obj:`str`
         Figures folder within output directory
 
@@ -254,10 +252,10 @@ def write_summary_fig(comptable, out_dir):
 
     Parameters
     ----------
-    comptable : (N x 5) array_like
-        Array with columns denoting (1) index of component, (2) Kappa score of
-        component, (3) Rho score of component, (4) variance explained by
-        component, and (5) normalized variance explained by component
+    comptable : (C x X) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. Requires at least two columns: "variance explained" and
+        "classification".
     out_dir : :obj:`str`
         Figures folder within output directory
     """

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -391,23 +391,16 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
 
     comptable.to_csv(op.join(out_dir, 'comp_table_ica.txt'), sep='\t',
                      index=True, index_label='component', float_format='%.6f')
-    if 'component' not in comptable.columns:
-        comptable['component'] = comptable.index
-    acc = comptable.loc[comptable['classification'] == 'accepted', 'component']
-    rej = comptable.loc[comptable['classification'] == 'rejected', 'component']
-    midk = comptable.loc[comptable['classification'] == 'midk', 'component']
-    ign = comptable.loc[comptable['classification'] == 'ignored', 'component']
-    if len(acc) == 0:
+
+    if comptable[comptable.classification == 'accepted'].shape[0] == 0:
         LGR.warning('No BOLD components detected! Please check data and '
                     'results!')
 
     if tedort:
         acc_idx = comptable.loc[
-            ~comptable['classification'].str.contains('rejected'),
-            'component']
+            ~comptable.classification.str.contains('rejected')].index.values
         rej_idx = comptable.loc[
-            comptable['classification'].str.contains('rejected'),
-            'component']
+            comptable.classification.str.contains('rejected')].index.values
         acc_ts = mmix[:, acc_idx]
         rej_ts = mmix[:, rej_idx]
         betas = np.linalg.lstsq(acc_ts, rej_ts, rcond=None)[0]
@@ -417,9 +410,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         np.savetxt(op.join(out_dir, 'meica_mix_orth.1D'), mmix)
 
     io.writeresults(data_oc, mask=mask, comptable=comptable, mmix=mmix,
-                    n_vols=n_vols,
-                    acc=acc, rej=rej, midk=midk, empty=ign,
-                    ref_img=ref_img)
+                    n_vols=n_vols, ref_img=ref_img)
 
     if 't1c' in gscontrol:
         LGR.info('Performing T1c global signal regression to remove spatially '
@@ -427,7 +418,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         gsc.gscontrol_mmix(data_oc, mmix, mask, comptable, ref_img)
 
     if verbose:
-        io.writeresults_echoes(catd, mmix, mask, acc, rej, midk, ref_img)
+        io.writeresults_echoes(catd, mmix, mask, comptable, ref_img)
 
     if png:
         LGR.info('Making figures folder with static component maps and '


### PR DESCRIPTION
Also fix up docstrings and eliminate step where component number is set
as a column. Always keep it as the index of the DataFrame.

<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use comptable DataFrame instead of lists of components in tedana.io
- Clean up docstring documentation of comptable throughout tedana
- Eliminate step where component number is set as a column. Always keep it as the index of the DataFrame.
- Use more concise methods for indexing DataFrames (e.g., `comptable[comptable.classification == 'acc'].index.values` instead of `comptable.loc[comptable['classification'] == 'acc'].index.values`).