### PR TITLE
[FIX] Make figures using un-orthogonalized mixing matrix

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -401,6 +401,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         LGR.warning('No BOLD components detected! Please check data and '
                     'results!')
 
+    mmix_orig = mmix.copy()
     if tedort:
         acc_idx = comptable.loc[
             ~comptable['classification'].str.contains('rejected'),
@@ -436,8 +437,8 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         if not op.isdir(op.join(out_dir, 'figures')):
             os.mkdir(op.join(out_dir, 'figures'))
 
-        viz.write_comp_figs(data_oc, mask=mask, comptable=comptable, mmix=mmix,
-                            ref_img=ref_img,
+        viz.write_comp_figs(data_oc, mask=mask, comptable=comptable,
+                            mmix=mmix_orig, ref_img=ref_img,
                             out_dir=op.join(out_dir, 'figures'),
                             png_cmap=png_cmap)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #243.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Make a copy of the mixing matrix before orthogonalizing if `tedort` and use that one for figure-making.
