### PR TITLE
[FIX] Fix use of d_table_score

### DIFF
--- a/tedana/selection/select_comps.py
+++ b/tedana/selection/select_comps.py
@@ -351,7 +351,7 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
             comptable.loc[acc[:num_acc_guess], 'variance explained'],
             LOW_PERC)
         candart = comptable.loc[acc].loc[
-            comptable.loc[acc, 'd_table_score'] >
+            comptable.loc[acc, 'd_table_score_scrub'] >
             num_acc_guess * n_decision_metrics].index.values
         ign_add0 = np.intersect1d(
             candart[comptable.loc[candart, 'variance explained'] > new_varex_lower],


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. This was originally part of #247, but has been split off because it is self-contained and should be merged separately.

At one point, the d_table_score metric is used when d_table_score_scrub should have been used. This is a minor bug.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace `d_table_score` with `d_table_score_scrub` in one instance.