### PR TITLE
[ENH] Improve manual component selection

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -129,24 +129,24 @@ P007   rejected         Rho below fmin (only in stabilized PCA decision tree)
 
 TEDICA codes
 ````````````
-=====  ===============  ========================================================
-Code   Classification   Description
-=====  ===============  ========================================================
-I001   rejected         Manual exclusion
-I002   rejected         Rho greater than Kappa
-I003   rejected         More significant voxels in S0 model than R2 model
-I004   rejected         S0 Dice is higher than R2 Dice and high variance
-                        explained
-I005   rejected         Noise F-value is higher than signal F-value and high
-                        variance explained
-I006   ignored          No good components found
-I007   rejected         Mid-Kappa component
-I008   ignored          Low variance explained
-I009   rejected         Mid-Kappa artifact type A
-I010   rejected         Mid-Kappa artifact type B
-I011   ignored          ign_add0
-I012   ignored          ign_add1
-=====  ===============  ========================================================
+=====  =================  ========================================================
+Code   Classification     Description
+=====  =================  ========================================================
+I001   rejected|accepted  Manual classification
+I002   rejected           Rho greater than Kappa
+I003   rejected           More significant voxels in S0 model than R2 model
+I004   rejected           S0 Dice is higher than R2 Dice and high variance
+                          explained
+I005   rejected           Noise F-value is higher than signal F-value and high
+                          variance explained
+I006   ignored            No good components found
+I007   rejected           Mid-Kappa component
+I008   ignored            Low variance explained
+I009   rejected           Mid-Kappa artifact type A
+I010   rejected           Mid-Kappa artifact type B
+I011   ignored            ign_add0
+I012   ignored            ign_add1
+=====  =================    ========================================================
 
 Visual reports
 --------------

--- a/tedana/selection/select_comps.py
+++ b/tedana/selection/select_comps.py
@@ -89,7 +89,12 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
 
     # If user has specified
     if manacc:
-        acc = sorted([int(vv) for vv in manacc.split(',')])
+        LGR.info('Performing manual ICA component selection')
+        if ('classification' in comptable.columns and
+                'original_classification' not in comptable.columns):
+            comptable['original_classification'] = comptable['classification']
+            comptable['original_rationale'] = comptable['rationale']
+        acc = [int(comp) for comp in manacc]
         rej = sorted(np.setdiff1d(all_comps, acc))
         comptable.loc[acc, 'classification'] = 'accepted'
         comptable.loc[rej, 'classification'] = 'rejected'

--- a/tedana/selection/select_comps.py
+++ b/tedana/selection/select_comps.py
@@ -56,31 +56,10 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
     distinguish components, a hypercommented version of this attempt is available at:
     https://gist.github.com/emdupre/ca92d52d345d08ee85e104093b81482e
     """
-
     cols_at_end = ['classification', 'rationale']
-    comptable['classification'] = 'accepted'
-    comptable['rationale'] = ''
-
-    Z_maps = seldict['Z_maps']
-    Z_clmaps = seldict['Z_clmaps']
-    F_R2_maps = seldict['F_R2_maps']
-    F_S0_clmaps = seldict['F_S0_clmaps']
-    F_R2_clmaps = seldict['F_R2_clmaps']
-    Br_S0_clmaps = seldict['Br_S0_clmaps']
-    Br_R2_clmaps = seldict['Br_R2_clmaps']
-
-    n_vols, n_comps = mmix.shape
-
-    # Set knobs
-    LOW_PERC = 25
-    HIGH_PERC = 90
-    if n_vols < 100:
-        EXTEND_FACTOR = 3
-    else:
-        EXTEND_FACTOR = 2
-    RESTRICT_FACTOR = 2
 
     # List of components
+    n_vols, n_comps = mmix.shape
     midk = []
     ign = []
     all_comps = np.arange(comptable.shape[0])
@@ -94,6 +73,8 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
                 'original_classification' not in comptable.columns):
             comptable['original_classification'] = comptable['classification']
             comptable['original_rationale'] = comptable['rationale']
+        comptable['classification'] = 'accepted'
+        comptable['rationale'] = ''
         acc = [int(comp) for comp in manacc]
         rej = sorted(np.setdiff1d(all_comps, acc))
         comptable.loc[acc, 'classification'] = 'accepted'
@@ -104,6 +85,26 @@ def selcomps(seldict, comptable, mmix, manacc, n_echos):
                               [c for c in cols_at_end if c in comptable]]
         comptable['rationale'] = comptable['rationale'].str.rstrip(';')
         return comptable
+
+    comptable['classification'] = 'accepted'
+    comptable['rationale'] = ''
+
+    Z_maps = seldict['Z_maps']
+    Z_clmaps = seldict['Z_clmaps']
+    F_R2_maps = seldict['F_R2_maps']
+    F_S0_clmaps = seldict['F_S0_clmaps']
+    F_R2_clmaps = seldict['F_R2_clmaps']
+    Br_S0_clmaps = seldict['Br_S0_clmaps']
+    Br_R2_clmaps = seldict['Br_R2_clmaps']
+
+    # Set knobs
+    LOW_PERC = 25
+    HIGH_PERC = 90
+    if n_vols < 100:
+        EXTEND_FACTOR = 3
+    else:
+        EXTEND_FACTOR = 2
+    RESTRICT_FACTOR = 2
 
     """
     Tally number of significant voxels for cluster-extent thresholded R2 and S0


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. This was originally part of #247, but has been split off because it is self-contained and should be merged separately.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Allow users to re-run tedana on the same directory without raising copyfile errors.
- Retain original classification and rationale when manually overriding classification.
- Allow `manacc` to be a list to make it easier to run within Python.
- Clean up logic around checking mixm, ctab, and manacc arguments.