### PR TITLE
[FIX] Sort comptable by varex before identifying outlier components

### DIFF
--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -182,6 +182,8 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
         comptable.loc[comptable['kappa'] > getelbow(comptable['kappa'], return_val=True),
                       'variance explained'])
 
+    # Sort component table by variance explained and find outlier components by
+    # change in variance explained from one component to the next.
     # Remove variance-explained outliers from list of components to consider
     # for acceptance. These components will have another chance to be accepted
     # later on.
@@ -189,7 +191,8 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     # done three times.
     ncls = unclf.copy()
     for i_loop in range(3):
-        temp_comptable = comptable.loc[ncls]
+        temp_comptable = comptable.loc[ncls].sort_values(by=['variance explained'],
+                                                         ascending=False)
         ncls = temp_comptable.loc[
             temp_comptable['variance explained'].diff() < varex_upper_p].index.values
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #176. While this does not clarify everything about this step (e.g., why it is run three times specifically, or why the outlier components are excluded when computing elbows but not when selecting components later), it does resolve the most pressing issue of explaining why the step exists.

This was originally part of #247, but has been split off because it is self-contained and should be merged separately.

Changes proposed in this pull request:
- Sort component table when identifying ncls (components presumably without outlier variance explained) by descending variance explained. Before, the component table was sorted by descending Kappa values when identifying outliers. Per discussions with @handwerkerd, this was identified as a bug.