### PR TITLE
[FIX] Add early escape from TEDICA decision tree

### DIFF
--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -165,6 +165,18 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     rej = np.union1d(temp_rej2, rej)
     unclf = np.setdiff1d(unclf, rej)
 
+    # Quit early if no potentially accepted components remain
+    if len(unclf) == 0:
+        LGR.warning('No BOLD-like components detected. Ignoring all remaining '
+                    'components.')
+        ign = sorted(np.setdiff1d(all_comps, rej))
+        comptable.loc[ign, 'classification'] = 'ignored'
+        comptable.loc[ign, 'rationale'] += 'I006;'
+
+        # Move decision columns to end
+        comptable = clean_dataframe(comptable)
+        return comptable
+
     """
     Step 2: Make a guess for what the good components are, in order to
     estimate good component properties
@@ -211,6 +223,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     acc_prov = ncls[(comptable.loc[ncls, 'kappa'] >= kappa_elbow) &
                     (comptable.loc[ncls, 'rho'] < rho_elbow)]
 
+    # Quit early if no potentially accepted components remain
     if len(acc_prov) == 0:
         LGR.warning('No BOLD-like components detected. Ignoring all remaining '
                     'components.')


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #297.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Add early stopping procedure to TEDICA decision for when no potential BOLD components are identified in Step 1.
