### PR TITLE
[ENH, REF] Reduce memory requirements for metric calculation and PCA

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -77,9 +77,9 @@ def low_mem_pca(data):
     from sklearn.decomposition import IncrementalPCA
     ppca = IncrementalPCA(n_components=(data.shape[-1] - 1))
     ppca.fit(data)
-    v = ppca.components_
+    v = ppca.components_.T
     s = ppca.explained_variance_
-    u = np.dot(np.dot(data, v.T), np.diag(1. / s))
+    u = np.dot(np.dot(data, v), np.diag(1. / s))
     return u, s, v
 
 

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -48,7 +48,7 @@ def run_mlepca(data):
         Component timeseries.
     """
     # do PC dimension selection and get eigenvalue cutoff
-    ppca = PCA(n_components='mle', svd_solver='full')
+    ppca = PCA(n_components='mle', svd_solver='full', copy=False)
     ppca.fit(data)
     v = ppca.components_.T
     s = ppca.explained_variance_
@@ -218,7 +218,7 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
     elif low_mem:
         voxel_comp_weights, varex, comp_ts = low_mem_pca(data_z)
     else:
-        ppca = PCA()
+        ppca = PCA(copy=False)
         ppca.fit(data_z)
         comp_ts = ppca.components_.T
         varex = ppca.explained_variance_

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -56,9 +56,36 @@ def run_mlepca(data):
     return u, s, v
 
 
+def low_mem_pca(data):
+    """
+    Run Singular Value Decomposition (SVD) on input data.
+
+    Parameters
+    ----------
+    data : (S [*E] x T) array_like
+        Optimally combined (S x T) or full multi-echo (S*E x T) data.
+
+    Returns
+    -------
+    u : (S [*E] x C) array_like
+        Component weight map for each component.
+    s : (C,) array_like
+        Variance explained for each component.
+    v : (C x T) array_like
+        Component timeseries.
+    """
+    from sklearn.decomposition import IncrementalPCA
+    ppca = IncrementalPCA(n_components=(data.shape[-1] - 1))
+    ppca.fit(data)
+    v = ppca.components_
+    s = ppca.explained_variance_
+    u = np.dot(np.dot(data, v.T), np.diag(1. / s))
+    return u, s, v
+
+
 def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
            ref_img, tes, algorithm='mle', source_tes=-1, kdaw=10., rdaw=1.,
-           out_dir='.', verbose=False):
+           out_dir='.', verbose=False, low_mem=False):
     """
     Use principal components analysis (PCA) to identify and remove thermal
     noise from multi-echo data.
@@ -101,6 +128,9 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
         Output directory.
     verbose : :obj:`bool`, optional
         Whether to output files from fitmodels_direct or not. Default: False
+    low_mem : :obj:`bool`, optional
+        Whether to use incremental PCA (for low-memory systems) or not.
+        Default: False
 
     Returns
     -------
@@ -158,6 +188,11 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
     mepca_mix.1D              PCA mixing matrix.
     ======================    =================================================
     """
+    if low_mem and algorithm == 'mle':
+        LGR.warning('Low memory option is not compatible with MLE '
+                    'dimensionality estimation. Switching to Kundu decision '
+                    'tree.')
+        algorithm = 'kundu'
 
     n_samp, n_echos, n_vols = data_cat.shape
     source_tes = np.array([int(ee) for ee in str(source_tes).split(',')])
@@ -180,6 +215,8 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
 
     if algorithm == 'mle':
         voxel_comp_weights, varex, comp_ts = run_mlepca(data_z)
+    elif low_mem:
+        voxel_comp_weights, varex, comp_ts = low_mem_pca(data_z)
     else:
         ppca = PCA()
         ppca.fit(data_z)

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -217,7 +217,7 @@ def writeresults(ts, mask, comptable, mmix, n_vols, ref_img):
     acc = comptable[comptable.classification == 'accepted'].index.values
 
     fout = filewrite(ts, 'ts_OC', ref_img)
-    LGR.info('Writing optimally-combined time series: {}'.format(op.abspath(fout)))
+    LGR.info('Writing optimally combined time series: {}'.format(op.abspath(fout)))
 
     write_split_ts(ts, mmix, mask, comptable, ref_img, suffix='OC')
 

--- a/tedana/metrics/kundu_fit.py
+++ b/tedana/metrics/kundu_fit.py
@@ -209,8 +209,10 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
 
     if verbose:
         # Echo-specific weight maps for each of the ICA components.
-        io.filewrite(betas, op.join(out_dir, '{0}betas_catd.nii'.format(label)),
+        io.filewrite(utils.unmask(betas, mask),
+                     op.join(out_dir, '{0}betas_catd.nii'.format(label)),
                      ref_img)
+
         # Echo-specific maps of predicted values for R2 and S0 models for each
         # component.
         io.filewrite(utils.unmask(pred_R2_maps, mask),

--- a/tedana/metrics/kundu_fit.py
+++ b/tedana/metrics/kundu_fit.py
@@ -249,7 +249,7 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
                 np.squeeze(utils.unmask(F_R2_maps[:, i_comp], mask)))
             F_R2_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=fmin, mask=mask,
-                binarize=True).astype(bool)
+                binarize=True)
             countsigFR2 = F_R2_clmaps[:, i_comp].sum()
 
             ccimg = io.new_nii_like(
@@ -257,7 +257,7 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
                 np.squeeze(utils.unmask(F_S0_maps[:, i_comp], mask)))
             F_S0_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=fmin, mask=mask,
-                binarize=True).astype(bool)
+                binarize=True)
             countsigFS0 = F_S0_clmaps[:, i_comp].sum()
 
             # Cluster-extent threshold and binarize Z-maps with CDT of p < 0.05
@@ -266,7 +266,7 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
                 np.squeeze(utils.unmask(Z_maps[:, i_comp], mask)))
             Z_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=1.95, mask=mask,
-                binarize=True).astype(bool)
+                binarize=True)
 
             # Cluster-extent threshold and binarize ranked signal-change map
             ccimg = io.new_nii_like(
@@ -275,11 +275,11 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
             Br_R2_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize,
                 threshold=(max(tsoc_Babs.shape) - countsigFR2), mask=mask,
-                binarize=True).astype(bool)
+                binarize=True)
             Br_S0_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize,
                 threshold=(max(tsoc_Babs.shape) - countsigFS0), mask=mask,
-                binarize=True).astype(bool)
+                binarize=True)
         del ccimg, tsoc_Babs
 
         if algorithm == 'kundu_v2':

--- a/tedana/metrics/kundu_fit.py
+++ b/tedana/metrics/kundu_fit.py
@@ -87,17 +87,22 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
                              '({0}) does not match number of volumes in '
                              't2s ({1})'.format(catd.shape[2], t2s.shape[1]))
 
-    # demean optimal combination
+    # mask everything we can
     tsoc = tsoc[mask, :]
+    catd = catd[mask, ...]
+    t2s = t2s[mask]
+
+    # demean optimal combination
     tsoc_dm = tsoc - tsoc.mean(axis=-1, keepdims=True)
 
     # compute un-normalized weight dataset (features)
     if mmixN is None:
         mmixN = mmix
-    WTS = computefeats2(utils.unmask(tsoc, mask), mmixN, mask, normalize=False)
+    WTS = computefeats2(tsoc, mmixN, mask=None, normalize=False)
 
     # compute PSC dataset - shouldn't have to refit data
     tsoc_B = get_coeffs(tsoc_dm, mmix, mask=None)
+    del tsoc_dm
     tsoc_Babs = np.abs(tsoc_B)
     PSC = tsoc_B / tsoc.mean(axis=-1, keepdims=True) * 100
 
@@ -113,23 +118,18 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
     totvar_norm = (WTS**2).sum()
 
     # compute Betas and means over TEs for TE-dependence analysis
-    betas = get_coeffs(catd, mmix, np.repeat(mask[:, np.newaxis], len(tes),
-                                             axis=1))
-    n_samp, n_echos, n_components = betas.shape
-    n_voxels = mask.sum()
-    n_data_voxels = (t2s != 0).sum()
+    betas = get_coeffs(utils.unmask(catd, mask),
+                       mmix,
+                       np.repeat(mask[:, np.newaxis], len(tes), axis=1))
+    betas = betas[mask, ...]
+    n_voxels, n_echos, n_components = betas.shape
     mu = catd.mean(axis=-1, dtype=float)
     tes = np.reshape(tes, (n_echos, 1))
     fmin, _, _ = getfbounds(n_echos)
 
-    # mask arrays
-    mumask = mu[t2s != 0]
-    t2smask = t2s[t2s != 0]
-    betamask = betas[t2s != 0]
-
     # set up Xmats
-    X1 = mumask.T  # Model 1
-    X2 = np.tile(tes, (1, n_data_voxels)) * mumask.T / t2smask.T  # Model 2
+    X1 = mu.T  # Model 1
+    X2 = np.tile(tes, (1, n_voxels)) * mu.T / t2s.T  # Model 2
 
     # tables for component selection
     kappas = np.zeros([n_components])
@@ -137,35 +137,34 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
     varex = np.zeros([n_components])
     varex_norm = np.zeros([n_components])
     Z_maps = np.zeros([n_voxels, n_components])
-    F_R2_maps = np.zeros([n_data_voxels, n_components])
-    F_S0_maps = np.zeros([n_data_voxels, n_components])
-    pred_R2_maps = np.zeros([n_data_voxels, n_echos, n_components])
-    pred_S0_maps = np.zeros([n_data_voxels, n_echos, n_components])
+    F_R2_maps = np.zeros([n_voxels, n_components])
+    F_S0_maps = np.zeros([n_voxels, n_components])
+    pred_R2_maps = np.zeros([n_voxels, n_echos, n_components])
+    pred_S0_maps = np.zeros([n_voxels, n_echos, n_components])
 
     LGR.info('Fitting TE- and S0-dependent models to components')
     for i_comp in range(n_components):
-        # size of B is (n_echoes, n_samples)
-        B = np.atleast_3d(betamask)[:, :, i_comp].T
-        alpha = (np.abs(B)**2).sum(axis=0)
+        # size of comp_betas is (n_echoes, n_samples)
+        comp_betas = np.atleast_3d(betas)[:, :, i_comp].T
+        alpha = (np.abs(comp_betas)**2).sum(axis=0)
         varex[i_comp] = (tsoc_B[:, i_comp]**2).sum() / totvar * 100.
-        varex_norm[i_comp] = (utils.unmask(WTS, mask)[t2s != 0][:, i_comp]**2).sum() /\
-            totvar_norm * 100.
+        varex_norm[i_comp] = (WTS[:, i_comp]**2).sum() / totvar_norm * 100.
 
         # S0 Model
         # (S,) model coefficient map
-        coeffs_S0 = (B * X1).sum(axis=0) / (X1**2).sum(axis=0)
+        coeffs_S0 = (comp_betas * X1).sum(axis=0) / (X1**2).sum(axis=0)
         pred_S0 = X1 * np.tile(coeffs_S0, (n_echos, 1))
         pred_S0_maps[:, :, i_comp] = pred_S0.T
-        SSE_S0 = (B - pred_S0)**2
+        SSE_S0 = (comp_betas - pred_S0)**2
         SSE_S0 = SSE_S0.sum(axis=0)  # (S,) prediction error map
         F_S0 = (alpha - SSE_S0) * (n_echos - 1) / (SSE_S0)
         F_S0_maps[:, i_comp] = F_S0
 
         # R2 Model
-        coeffs_R2 = (B * X2).sum(axis=0) / (X2**2).sum(axis=0)
+        coeffs_R2 = (comp_betas * X2).sum(axis=0) / (X2**2).sum(axis=0)
         pred_R2 = X2 * np.tile(coeffs_R2, (n_echos, 1))
         pred_R2_maps[:, :, i_comp] = pred_R2.T
-        SSE_R2 = (B - pred_R2)**2
+        SSE_R2 = (comp_betas - pred_R2)**2
         SSE_R2 = SSE_R2.sum(axis=0)
         F_R2 = (alpha - SSE_R2) * (n_echos - 1) / (SSE_R2)
         F_R2_maps[:, i_comp] = F_R2
@@ -179,10 +178,12 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
         # compute Kappa and Rho
         F_S0[F_S0 > F_MAX] = F_MAX
         F_R2[F_R2 > F_MAX] = F_MAX
-        norm_weights = np.abs(np.squeeze(
-            utils.unmask(wtsZ, mask)[t2s != 0]**2.))
+        norm_weights = np.abs(wtsZ ** 2.)
         kappas[i_comp] = np.average(F_R2, weights=norm_weights)
         rhos[i_comp] = np.average(F_S0, weights=norm_weights)
+    del SSE_S0, SSE_R2, wtsZ, F_S0, F_R2, norm_weights, comp_betas
+    if algorithm != 'kundu_v3':
+        del WTS, PSC, tsoc_B
 
     # tabulate component values
     comptable = np.vstack([kappas, rhos, varex, varex_norm]).T
@@ -194,15 +195,17 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
         betas = betas[..., sort_idx]
         pred_R2_maps = pred_R2_maps[:, :, sort_idx]
         pred_S0_maps = pred_S0_maps[:, :, sort_idx]
-        F_S0_maps = F_S0_maps[:, sort_idx]
         F_R2_maps = F_R2_maps[:, sort_idx]
+        F_S0_maps = F_S0_maps[:, sort_idx]
         Z_maps = Z_maps[:, sort_idx]
-        WTS = WTS[:, sort_idx]
-        PSC = PSC[:, sort_idx]
-        tsoc_B = tsoc_B[:, sort_idx]
         tsoc_Babs = tsoc_Babs[:, sort_idx]
+        if algorithm == 'kundu_v3':
+            WTS = WTS[:, sort_idx]
+            PSC = PSC[:, sort_idx]
+            tsoc_B = tsoc_B[:, sort_idx]
     else:
         mmix_new = mmix
+    del mmix
 
     if verbose:
         # Echo-specific weight maps for each of the ICA components.
@@ -218,6 +221,7 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
         io.filewrite(utils.unmask(Z_maps ** 2., mask),
                      op.join(out_dir, '{0}metric_weights.nii'.format(label)),
                      ref_img)
+    del pred_R2_maps, pred_S0_maps
 
     comptable = pd.DataFrame(comptable,
                              columns=['kappa', 'rho',
@@ -227,11 +231,11 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
 
     # Generate clustering criteria for component selection
     if algorithm in ['kundu_v2', 'kundu_v3']:
-        Z_clmaps = np.zeros([n_voxels, n_components])
-        F_R2_clmaps = np.zeros([n_data_voxels, n_components])
-        F_S0_clmaps = np.zeros([n_data_voxels, n_components])
-        Br_R2_clmaps = np.zeros([n_voxels, n_components])
-        Br_S0_clmaps = np.zeros([n_voxels, n_components])
+        Z_clmaps = np.zeros([n_voxels, n_components], bool)
+        F_R2_clmaps = np.zeros([n_voxels, n_components], bool)
+        F_S0_clmaps = np.zeros([n_voxels, n_components], bool)
+        Br_R2_clmaps = np.zeros([n_voxels, n_components], bool)
+        Br_S0_clmaps = np.zeros([n_voxels, n_components], bool)
 
         LGR.info('Performing spatial clustering of components')
         csize = np.max([int(n_voxels * 0.0005) + 5, 20])
@@ -240,40 +244,41 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
             # Cluster-extent threshold and binarize F-maps
             ccimg = io.new_nii_like(
                 ref_img,
-                np.squeeze(utils.unmask(F_R2_maps[:, i_comp], t2s != 0)))
+                np.squeeze(utils.unmask(F_R2_maps[:, i_comp], mask)))
             F_R2_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=fmin, mask=mask,
-                binarize=True)
+                binarize=True).astype(bool)
             countsigFR2 = F_R2_clmaps[:, i_comp].sum()
 
             ccimg = io.new_nii_like(
                 ref_img,
-                np.squeeze(utils.unmask(F_S0_maps[:, i_comp], t2s != 0)))
+                np.squeeze(utils.unmask(F_S0_maps[:, i_comp], mask)))
             F_S0_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=fmin, mask=mask,
-                binarize=True)
+                binarize=True).astype(bool)
             countsigFS0 = F_S0_clmaps[:, i_comp].sum()
 
             # Cluster-extent threshold and binarize Z-maps with CDT of p < 0.05
             ccimg = io.new_nii_like(
                 ref_img,
-                np.squeeze(utils.unmask(Z_maps[:, i_comp], t2s != 0)))
+                np.squeeze(utils.unmask(Z_maps[:, i_comp], mask)))
             Z_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize, threshold=1.95, mask=mask,
-                binarize=True)
+                binarize=True).astype(bool)
 
             # Cluster-extent threshold and binarize ranked signal-change map
             ccimg = io.new_nii_like(
                 ref_img,
-                utils.unmask(stats.rankdata(tsoc_Babs[:, i_comp]), t2s != 0))
+                utils.unmask(stats.rankdata(tsoc_Babs[:, i_comp]), mask))
             Br_R2_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize,
                 threshold=(max(tsoc_Babs.shape) - countsigFR2), mask=mask,
-                binarize=True)
+                binarize=True).astype(bool)
             Br_S0_clmaps[:, i_comp] = utils.threshold_map(
                 ccimg, min_cluster_size=csize,
                 threshold=(max(tsoc_Babs.shape) - countsigFS0), mask=mask,
-                binarize=True)
+                binarize=True).astype(bool)
+        del ccimg, tsoc_Babs
 
         if algorithm == 'kundu_v2':
             # WTS, tsoc_B, PSC, and F_S0_maps are not used by Kundu v2.5

--- a/tedana/stats.py
+++ b/tedana/stats.py
@@ -32,7 +32,7 @@ def getfbounds(n_echos):
     return f05, f025, f01
 
 
-def computefeats2(data, mmix, mask, normalize=True):
+def computefeats2(data, mmix, mask=None, normalize=True):
     """
     Converts `data` to component space using `mmix`
 
@@ -43,8 +43,8 @@ def computefeats2(data, mmix, mask, normalize=True):
     mmix : (T [x C]) array_like
         Mixing matrix for converting input data to component space, where `C`
         is components and `T` is the same as in `data`
-    mask : (S,) array_like
-        Boolean mask array
+    mask : (S,) array_like or None, optional
+        Boolean mask array. Default: None
     normalize : bool, optional
         Whether to z-score output. Default: True
 
@@ -58,9 +58,9 @@ def computefeats2(data, mmix, mask, normalize=True):
     elif mmix.ndim not in [2]:
         raise ValueError('Parameter mmix should be 2d, not '
                          '{0}d'.format(mmix.ndim))
-    elif mask.ndim != 1:
+    elif (mask is not None) and (mask.ndim != 1):
         raise ValueError('Parameter mask should be 1d, not {0}d'.format(mask.ndim))
-    elif data.shape[0] != mask.shape[0]:
+    elif (mask is not None) and (data.shape[0] != mask.shape[0]):
         raise ValueError('First dimensions (number of samples) of data ({0}) '
                          'and mask ({1}) do not match.'.format(data.shape[0],
                                                                mask.shape[0]))
@@ -70,7 +70,9 @@ def computefeats2(data, mmix, mask, normalize=True):
                                                                mmix.shape[0]))
 
     # demean masked data
-    data_vn = stats.zscore(data[mask], axis=-1)
+    if mask is not None:
+        data = data[mask, ...]
+    data_vn = stats.zscore(data, axis=-1)
 
     # get betas of `data`~`mmix` and limit to range [-0.999, 0.999]
     data_R = get_coeffs(data_vn, mmix, mask=None)
@@ -87,6 +89,7 @@ def computefeats2(data, mmix, mask, normalize=True):
         data_Zm = stats.zscore(data_Z, axis=0)
         data_Z = data_Zm + (data_Z.mean(axis=0, keepdims=True) /
                             data_Z.std(axis=0, keepdims=True))
+
     return data_Z
 
 

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -264,7 +264,10 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
         mask = mask.astype(bool)
         arr *= mask.reshape(arr.shape)
 
-    clust_thresholded = np.zeros(arr.shape, int)
+    if binarize:
+        clust_thresholded = np.zeros(arr.shape, bool)
+    else:
+        clust_thresholded = np.zeros(arr.shape, int)
 
     if sided == 'two':
         test_arr = np.abs(arr)
@@ -286,7 +289,7 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
     for i_clust in clust_sizes.keys():
         if np.all(thresh_arr[labeled == i_clust] == 1):
             if binarize:
-                clust_thresholded[labeled == i_clust] = 1
+                clust_thresholded[labeled == i_clust] = True
             else:
                 clust_thresholded[labeled == i_clust] = arr[labeled == i_clust]
 
@@ -304,7 +307,7 @@ def threshold_map(img, min_cluster_size, threshold=None, mask=None,
         for i_clust in clust_sizes.keys():
             if np.all(thresh_arr[labeled == i_clust] == 1):
                 if binarize:
-                    clust_thresholded[labeled == i_clust] = 1
+                    clust_thresholded[labeled == i_clust] = True
                 else:
                     clust_thresholded[labeled == i_clust] = arr[labeled == i_clust]
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -169,6 +169,13 @@ def _get_parser():
                                 'convergence is achieved before maxrestart '
                                 'attempts, ICA will finish early.'),
                           default=10)
+    optional.add_argument('--lowmem',
+                          dest='low_mem',
+                          action='store_true',
+                          help=('Enables low-memory processing, including the '
+                                'use of IncrementalPCA. May increase workflow '
+                                'duration.'),
+                          default=False)
     optional.add_argument('--debug',
                           dest='debug',
                           help=argparse.SUPPRESS,
@@ -187,7 +194,8 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
                     tedort=False, gscontrol=None, tedpca='mle',
                     source_tes=-1, combmode='t2s', verbose=False, stabilize=False,
                     out_dir='.', fixed_seed=42, maxit=500, maxrestart=10,
-                    debug=False, quiet=False, png=False, png_cmap='coolwarm'):
+                    debug=False, quiet=False, png=False, png_cmap='coolwarm',
+                    low_mem=False):
     """
     Run the "canonical" TE-Dependent ANAlysis workflow.
 
@@ -249,6 +257,9 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         fixed seed will be updated and ICA will be run again. If convergence
         is achieved before maxrestart attempts, ICA will finish early.
         Default is 10.
+    low_mem : :obj:`bool`, optional
+        Enables low-memory processing, including the use of IncrementalPCA.
+        May increase workflow duration. Default is False.
     debug : :obj:`bool`, optional
         Whether to run in debugging mode or not. Default is False.
     quiet : :obj:`bool`, optional
@@ -389,7 +400,9 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
                                                 tes=tes, algorithm=tedpca,
                                                 source_tes=source_tes,
                                                 kdaw=10., rdaw=1.,
-                                                out_dir=out_dir, verbose=verbose)
+                                                out_dir=out_dir,
+                                                verbose=verbose,
+                                                low_mem=low_mem)
         mmix_orig = decomposition.tedica(dd, n_components, fixed_seed,
                                          maxit, maxrestart)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
References #269. I very much doubt that these changes will solve the problem on their own, and I'm not even sure if they'll help much.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add `--lowmem` argument to trigger use of IncrementalPCA. Should also trigger other low-memory steps we might implement in the future.
- Clean up arrays in `dependence_metrics` when they're no longer used.
- Operate on masks arrays as much as possible within `dependence_metrics`.
- Make `mask` argument for `computefeats2` optional.
