### PR TITLE
[FIX] Use PCA-based variance explained in PCA decision tree

### DIFF
--- a/.circleci/tedana_outputs.txt
+++ b/.circleci/tedana_outputs.txt
@@ -125,14 +125,6 @@ comp_119.png
 comp_120.png
 comp_121.png
 comp_122.png
-comp_123.png
-comp_124.png
-comp_125.png
-comp_126.png
-comp_127.png
-comp_128.png
-comp_129.png
-comp_130.png
 comp_table_ica.txt
 comp_table_pca.txt
 dn_ts_OC.nii

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -245,7 +245,8 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
 
     # varex_norm from PCA overrides varex_norm from dependence_metrics,
     # but we retain the original
-    comptable['estimated normalized variance explained'] = comptable['normalized variance explained']
+    comptable['estimated normalized variance explained'] = \
+        comptable['normalized variance explained']
     comptable['normalized variance explained'] = varex_norm
 
     np.savetxt('mepca_mix.1D', comp_ts)

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -220,7 +220,7 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
         voxel_comp_weights, varex, comp_ts = low_mem_pca(data_z)
         varex_norm = varex / varex.sum()
     else:
-        ppca = PCA(copy=False)
+        ppca = PCA(copy=False, n_components=(n_vols - 1))
         ppca.fit(data_z)
         comp_ts = ppca.components_.T
         varex = ppca.explained_variance_

--- a/tedana/metrics/kundu_fit.py
+++ b/tedana/metrics/kundu_fit.py
@@ -148,7 +148,7 @@ def dependence_metrics(catd, tsoc, mmix, t2s, tes, ref_img,
         comp_betas = np.atleast_3d(betas)[:, :, i_comp].T
         alpha = (np.abs(comp_betas)**2).sum(axis=0)
         varex[i_comp] = (tsoc_B[:, i_comp]**2).sum() / totvar * 100.
-        varex_norm[i_comp] = (WTS[:, i_comp]**2).sum() / totvar_norm * 100.
+        varex_norm[i_comp] = (WTS[:, i_comp]**2).sum() / totvar_norm
 
         # S0 Model
         # (S,) model coefficient map


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #363.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Switch from using `dependence_metrics`-based variance explained estimates (which sum to 100 and thus break the `kundu-stabilize` decision tree) to using the PCA-based ones.
- Retain `dependence_metrics`-based variance explained estimates as "estimated normalized variance explained" in component table. This also removed "original normalized variance explained", which was the PCA-based values (now just "normalized variance explained").
- Make `dependence_metrics`-based variance explained estimates sum to 1 instead of 100, just so that "normalized variance explained" remains a relatively consistent measure across implementations.
- Use `ppca.explained_variance_ratio_` instead of `ppca.explained_variance_` to calculate normalized variance explained for the MLE dimensionality estimation method, because variance explained shouldn't sum to 1 with automatic dimensionality estimation methods. We can still use `ppca.explained_variance_` (i.e., divide values by the sum across components) for the other PCA methods, since their variance explained should always sum to 1.
- Fit standard PCA using "number of volumes - 1" for number of components instead of just "number of volumes". This will eliminate a divide-by-zero warning when computing dependence metrics.