### PR TITLE
[ENH] --debug flag appear now in the help & documentation

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -178,9 +178,11 @@ def _get_parser():
                           default=False)
     optional.add_argument('--debug',
                           dest='debug',
-                          help=argparse.SUPPRESS,
                           action='store_true',
-                          default=False)
+                          help=('Logs in the terminal will have increased '
+                                'verbosity, and also will also be written  '
+                                'into a .txt file in the output directory.'),
+                          default=True)
     optional.add_argument('--quiet',
                           dest='quiet',
                           help=argparse.SUPPRESS,
@@ -194,7 +196,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
                     tedort=False, gscontrol=None, tedpca='mle',
                     source_tes=-1, combmode='t2s', verbose=False, stabilize=False,
                     out_dir='.', fixed_seed=42, maxit=500, maxrestart=10,
-                    debug=False, quiet=False, png=False, png_cmap='coolwarm',
+                    debug=True, quiet=False, png=False, png_cmap='coolwarm',
                     low_mem=False):
     """
     Run the "canonical" TE-Dependent ANAlysis workflow.

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -180,9 +180,9 @@ def _get_parser():
                           dest='debug',
                           action='store_true',
                           help=('Logs in the terminal will have increased '
-                                'verbosity, and also will also be written  '
-                                'into a .txt file in the output directory.'),
-                          default=True)
+                                'verbosity, and will also be written into '
+                                'a .txt file in the output directory.'),
+                          default=False)
     optional.add_argument('--quiet',
                           dest='quiet',
                           help=argparse.SUPPRESS,
@@ -196,7 +196,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
                     tedort=False, gscontrol=None, tedpca='mle',
                     source_tes=-1, combmode='t2s', verbose=False, stabilize=False,
                     out_dir='.', fixed_seed=42, maxit=500, maxrestart=10,
-                    debug=True, quiet=False, png=False, png_cmap='coolwarm',
+                    debug=False, quiet=False, png=False, png_cmap='coolwarm',
                     low_mem=False):
     """
     Run the "canonical" TE-Dependent ANAlysis workflow.


### PR DESCRIPTION
Hello,

This PR is a solution for #361, as discussed with @tsalo.
The changes are :
- make `--debug` visible in the help
- added some *help* documentation about this `--debug` option
- this `--debug` option is is now the default behavior

For now, I see 2 drawbacks that can easily be fixed :
1) changing the behavior so the option can be controlled : `--debug yes/no`
**and / or**
2) create a new option separate such as `--report` or `--log` and separate if from the `--debug` option

What do you think ?

Best,
Benoît