### PR TITLE
fix: use first echo data in t2s optcomb for zero voxels

### DIFF
--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -181,7 +181,7 @@ def t2smap_workflow(data, tes, mask=None, fitmode='all', combmode='t2s',
         LGR.info('Computing adaptive mask')
     else:
         LGR.info('Using user-defined mask')
-    mask, masksum = utils.make_adaptive_mask(catd, getsum=True)
+    mask, masksum = utils.make_adaptive_mask(catd, mask=mask, getsum=True)
 
     LGR.info('Computing adaptive T2* map')
     if fitmode == 'all':


### PR DESCRIPTION
Closes None. 

In response to a bug report from @shotgunosine on NeuroStars, fMRIPrep expects that optimally combined data has no masking applied. Since voxels with no T2* value create a divide by zero error, these were traditionally excluded from the calculation. This fix uses the first echo's T2* value instead of zero as the filler value.