### PR TITLE
add option for external regressors

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -271,8 +271,8 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         Enables low-memory processing, including the use of IncrementalPCA.
         May increase workflow duration. Default is False.
     ext_reg : :obj:`bool`, optional
-        Setting to true writes out the rejected components to a text file for
-        usage as exteranl regressors. Default is False.
+        Writes out a text file of rejected components. These can be used as
+        as nuisance regressors in other software. Default is False.
     debug : :obj:`bool`, optional
         Whether to run in debugging mode or not. Default is False.
     quiet : :obj:`bool`, optional


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # None!.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

This creates an option to write out a text file that just contains only the timecourses of the rejected components (in addition to the other files).

Intended use is for ease of using the rejected components as additional nuisance components in a GLM - and making it a text file makes it the most flexible - it could be plopped into AFNI/SPM/FSL etc without any trouble. 

- Add an option to write out the rejected components as text file `--extreg`
