### PR TITLE
[FIX] Prevents shell expansion in API

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -81,8 +81,11 @@ def test_integration_five_echo(skip_integration):
     # download data and run the test
     download_test_data('https://osf.io/9c42e/download',
                        os.path.dirname(out_dir))
+    prepend = '/tmp/data/five-echo/p06.SBJ01_S09_Task11_e'
+    suffix = '.sm.nii.gz'
+    datalist = [prepend + str(i+1) + suffix for i in range(5)]
     tedana_workflow(
-        data='/tmp/data/five-echo/p06.SBJ01_S09_Task11_e[1,2,3,4,5].sm.nii.gz',
+        data=datalist,
         tes=[15.4, 29.7, 44.0, 58.3, 72.6],
         out_dir=out_dir,
         debug=True, verbose=True)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -366,6 +366,8 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
 
     # coerce data to samples x echos x time array
     if isinstance(data, str):
+        if not op.exists(data):
+            raise ValueError('Zcat file {} does not exist'.format(data))
         data = [data]
 
     LGR.info('Loading input data: {}'.format([f for f in data]))


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Prevents shell-expansion in Python, which is allowed bi `nilearn` but concatenates the data in time, which is incorrect. 
-
