### PR TITLE
[REF] Reorganize fit_decay

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -70,10 +70,6 @@ If ``verbose`` is set to True:
 ======================    =====================================================
 Filename                  Content
 ======================    =====================================================
-t2ss.nii.gz               Voxel-wise T2* estimates using ascending numbers
-                          of echoes, starting with 2.
-s0vs.nii.gz               Voxel-wise S0 estimates using ascending numbers
-                          of echoes, starting with 2.
 t2svG.nii.gz              Full T2* map/time series. The difference between
                           the limited and full maps is that, for voxels
                           affected by dropout where only one echo contains

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -27,6 +27,9 @@ midk_ts_OC.nii.gz         Combined time series from "mid-k" rejected components.
 hik_ts_OC.nii.gz          High-kappa time series. This dataset does not
                           include thermal noise or low variance components.
                           Not the recommended dataset for analysis.
+adaptive_mask.nii.gz      Integer-valued mask used in the workflow, where
+                          each voxel's value corresponds to the number of good
+                          echoes to be used for T2*/S0 estimation.
 pca_decomposition.json    TEDPCA component table. A BIDS Derivatives-compatible
                           json file with summary metrics and inclusion/exclusion
                           information for each component from the PCA

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -229,7 +229,8 @@ def fit_decay(data, tes, mask, adaptive_mask, fittype):
         raise ValueError('Unknown fittype option: {}'.format(fittype))
 
     t2s_limited[np.isinf(t2s_limited)] = 500.  # why 500?
-    t2s_limited[t2s_limited <= 0] = 1.  # let's get rid of negative values!
+    # let's get rid of negative values, but keep zeros where limited != full
+    t2s_limited[(adaptive_mask_masked > 1) & (t2s_limited <= 0)] = 1.
     s0_limited[np.isnan(s0_limited)] = 0.  # why 0?
     t2s_full[np.isinf(t2s_full)] = 500.  # why 500?
     t2s_full[t2s_full <= 0] = 1.  # let's get rid of negative values!

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -44,9 +44,11 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
     """
     RepLGR.info("A monoexponential model was fit to the data at each voxel "
                 "using nonlinear model fitting in order to estimate T2* and S0 "
-                "maps. For each voxel, the value from the adaptive mask was "
-                "used to determine which echoes would be used to estimate T2* "
-                "and S0.")
+                "maps, using T2*/S0 estimates from a log-linear fit as "
+                "initial values. For each voxel, the value from the adaptive "
+                "mask was used to determine which echoes would be used to "
+                "estimate T2* and S0. In cases of model fit failure, T2*/S0 "
+                "estimates from the log-linear fit were retained instead.")
     n_samp, n_echos, n_vols = data_cat.shape
     t2s_asc_maps = np.zeros([n_samp, n_echos - 1])
     s0_asc_maps = np.zeros([n_samp, n_echos - 1])
@@ -56,7 +58,7 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
     # fit_sigma = np.std(data_cat, axis=2)
 
     t2s_limited, s0_limited, t2s_full, s0_full = fit_loglinear(
-        data_cat, echo_times, adaptive_mask)
+        data_cat, echo_times, adaptive_mask, report=False)
 
     echos_to_run = np.unique(adaptive_mask)
     if 1 in echos_to_run:
@@ -116,14 +118,15 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
     return t2s_limited, s0_limited, t2s_full, s0_full
 
 
-def fit_loglinear(data_cat, echo_times, adaptive_mask):
+def fit_loglinear(data_cat, echo_times, adaptive_mask, report=True):
     """
     """
-    RepLGR.info("A monoexponential model was fit to the data at each voxel "
-                "using log-linear regression in order to estimate T2* and S0 "
-                "maps. For each voxel, the value from the adaptive mask was "
-                "used to determine which echoes would be used to estimate T2* "
-                "and S0.")
+    if report:
+        RepLGR.info("A monoexponential model was fit to the data at each voxel "
+                    "using log-linear regression in order to estimate T2* and S0 "
+                    "maps. For each voxel, the value from the adaptive mask was "
+                    "used to determine which echoes would be used to estimate T2* "
+                    "and S0.")
     n_samp, n_echos, n_vols = data_cat.shape
     t2s_asc_maps = np.zeros([n_samp, n_echos - 1])
     s0_asc_maps = np.zeros([n_samp, n_echos - 1])

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -83,8 +83,8 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
                       '({3:.2f}%) voxel(s), used log linear estimate '
                       'instead'.format(echo_num, fail_count, len(voxel_idx), fail_percent))
 
-        t2s_asc_maps[..., i_echo] = t2s_full
-        s0_asc_maps[..., i_echo] = s0_full
+        t2s_asc_maps[:, i_echo] = t2s_full
+        s0_asc_maps[:, i_echo] = s0_full
 
     # create limited T2* and S0 maps
     t2s_limited = utils.unmask(t2s_asc_maps[echo_masks], adaptive_mask > 1)
@@ -136,8 +136,8 @@ def fit_loglinear(data_cat, echo_times, adaptive_mask):
         t2s = 1. / betas[1, :].T
         s0 = np.exp(betas[0, :]).T
 
-        t2s_asc_maps[..., i_echo] = t2s
-        s0_asc_maps[..., i_echo] = s0
+        t2s_asc_maps[:, i_echo] = t2s
+        s0_asc_maps[:, i_echo] = s0
 
     # create limited T2* and S0 maps
     t2s_limited = utils.unmask(t2s_asc_maps[echo_masks], adaptive_mask > 1)

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -50,7 +50,6 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
     n_samp, n_echos, n_vols = data_cat.shape
     t2s_asc_maps = np.zeros([n_samp, n_echos - 1])
     s0_asc_maps = np.zeros([n_samp, n_echos - 1])
-    echo_masks = np.zeros([n_samp, n_echos - 1], dtype=bool)
 
     # Currently unused
     # fit_data = np.mean(data_cat, axis=2)
@@ -62,6 +61,9 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask):
     echos_to_run = np.unique(adaptive_mask)
     if 1 in echos_to_run:
         echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+
+    echo_masks = np.zeros([n_samp, len(echos_to_run)], dtype=bool)
 
     for i_echo, echo_num in enumerate(echos_to_run):
         if echo_num == 2:
@@ -125,11 +127,12 @@ def fit_loglinear(data_cat, echo_times, adaptive_mask):
     n_samp, n_echos, n_vols = data_cat.shape
     t2s_asc_maps = np.zeros([n_samp, n_echos - 1])
     s0_asc_maps = np.zeros([n_samp, n_echos - 1])
-    echo_masks = np.zeros([n_samp, n_echos - 1], dtype=bool)
 
     echos_to_run = np.unique(adaptive_mask)
     if 1 in echos_to_run:
         echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+    echo_masks = np.zeros([n_samp, len(echos_to_run)], dtype=bool)
 
     for i_echo, echo_num in enumerate(echos_to_run):
         if echo_num == 2:

--- a/tedana/tests/data/tedana_outputs.txt
+++ b/tedana/tests/data/tedana_outputs.txt
@@ -1,5 +1,6 @@
 figures/Component_Overview.png
 figures/Kappa_vs_Rho_Scatter.png
+adaptive_mask.nii.gz
 betas_OC.nii.gz
 betas_hik_OC.nii.gz
 figures/comp_000.png

--- a/tedana/tests/data/tedana_outputs_verbose.txt
+++ b/tedana/tests/data/tedana_outputs_verbose.txt
@@ -37,8 +37,6 @@ pca_mixing.tsv
 report.txt
 s0v.nii.gz
 s0vG.nii.gz
-s0vs.nii.gz
-t2ss.nii.gz
 t2sv.nii.gz
 t2svG.nii.gz
 ts_OC.nii.gz

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -17,12 +17,12 @@ def testdata1():
     in_files = [op.join(get_test_data_path(), 'echo{0}.nii.gz'.format(i + 1))
                 for i in range(3)]
     data, _ = io.load_data(in_files, n_echos=len(tes))
-    mask, mask_sum = utils.make_adaptive_mask(data, getsum=True)
+    mask, adaptive_mask = utils.make_adaptive_mask(data, getsum=True)
     fittype = 'loglin'
     data_dict = {'data': data,
                  'tes': tes,
                  'mask': mask,
-                 'mask_sum': mask_sum,
+                 'adaptive_mask': adaptive_mask,
                  'fittype': fittype,
                  }
     return data_dict
@@ -35,7 +35,7 @@ def test_fit_decay(testdata1):
     t2sv, s0v, t2svG, s0vG = me.fit_decay(testdata1['data'],
                                           testdata1['tes'],
                                           testdata1['mask'],
-                                          testdata1['mask_sum'],
+                                          testdata1['adaptive_mask'],
                                           testdata1['fittype'])
     assert t2sv.ndim == 1
     assert s0v.ndim == 1
@@ -50,7 +50,7 @@ def test_fit_decay_ts(testdata1):
     t2sv, s0v, t2svG, s0vG = me.fit_decay_ts(testdata1['data'],
                                              testdata1['tes'],
                                              testdata1['mask'],
-                                             testdata1['mask_sum'],
+                                             testdata1['adaptive_mask'],
                                              testdata1['fittype'])
     assert t2sv.ndim == 2
     assert s0v.ndim == 2
@@ -71,10 +71,10 @@ def test_smoke_fit_decay():
     data = np.random.random((n_samples, n_echos, n_times))
     tes = np.random.random((n_echos)).tolist()
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
-    masksum = np.random.random((n_samples))
+    adaptive_mask = np.random.random((n_samples))
     fittype = 'loglin'
     t2s_limited, s0_limited, t2s_full, s0_full = me.fit_decay(
-        data, tes, mask, masksum, fittype)
+        data, tes, mask, adaptive_mask, fittype)
     assert t2s_limited is not None
     assert s0_limited is not None
     assert t2s_full is not None
@@ -93,10 +93,10 @@ def test_smoke_fit_decay_curvefit():
     data = np.random.random((n_samples, n_echos, n_times))
     tes = np.random.random((n_echos)).tolist()
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
-    masksum = np.random.random((n_samples))
+    adaptive_mask = np.random.random((n_samples))
     fittype = 'curvefit'
     t2s_limited, s0_limited, t2s_full, s0_full = me.fit_decay(
-        data, tes, mask, masksum, fittype)
+        data, tes, mask, adaptive_mask, fittype)
     assert t2s_limited is not None
     assert s0_limited is not None
     assert t2s_full is not None
@@ -114,10 +114,10 @@ def test_smoke_fit_decay_ts():
     data = np.random.random((n_samples, n_echos, n_times))
     tes = np.random.random((n_echos)).tolist()
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
-    masksum = np.random.random((n_samples))
+    adaptive_mask = np.random.random((n_samples))
     fittype = 'loglin'
     t2s_limited_ts, s0_limited_ts, t2s_full_ts, s0_full_ts = me.fit_decay_ts(
-        data, tes, mask, masksum, fittype)
+        data, tes, mask, adaptive_mask, fittype)
     assert t2s_limited_ts is not None
     assert s0_limited_ts is not None
     assert t2s_full_ts is not None
@@ -136,10 +136,10 @@ def test_smoke_fit_decay_curvefit_ts():
     data = np.random.random((n_samples, n_echos, n_times))
     tes = np.random.random((n_echos)).tolist()
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
-    masksum = np.random.random((n_samples))
+    adaptive_mask = np.random.random((n_samples))
     fittype = 'curvefit'
     t2s_limited_ts, s0_limited_ts, t2s_full_ts, s0_full_ts = me.fit_decay_ts(
-        data, tes, mask, masksum, fittype)
+        data, tes, mask, adaptive_mask, fittype)
     assert t2s_limited_ts is not None
     assert s0_limited_ts is not None
     assert t2s_full_ts is not None

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -32,15 +32,13 @@ def test_fit_decay(testdata1):
     """
     fit_decay should return data in (samples,) shape.
     """
-    t2sv, s0v, t2ss, s0vs, t2svG, s0vG = me.fit_decay(testdata1['data'],
-                                                      testdata1['tes'],
-                                                      testdata1['mask'],
-                                                      testdata1['mask_sum'],
-                                                      testdata1['fittype'])
+    t2sv, s0v, t2svG, s0vG = me.fit_decay(testdata1['data'],
+                                          testdata1['tes'],
+                                          testdata1['mask'],
+                                          testdata1['mask_sum'],
+                                          testdata1['fittype'])
     assert t2sv.ndim == 1
     assert s0v.ndim == 1
-    assert t2ss.ndim == 2
-    assert s0vs.ndim == 2
     assert t2svG.ndim == 1
     assert s0vG.ndim == 1
 
@@ -75,14 +73,10 @@ def test_smoke_fit_decay():
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
     masksum = np.random.random((n_samples))
     fittype = 'loglin'
-    t2s_limited, s0_limited, t2ss, s0vs, t2s_full, s0_full = me.fit_decay(
-                                                            data, tes,
-                                                            mask, masksum,
-                                                            fittype)
+    t2s_limited, s0_limited, t2s_full, s0_full = me.fit_decay(
+        data, tes, mask, masksum, fittype)
     assert t2s_limited is not None
     assert s0_limited is not None
-    assert t2ss is not None
-    assert s0vs is not None
     assert t2s_full is not None
     assert s0_full is not None
 
@@ -101,15 +95,10 @@ def test_smoke_fit_decay_curvefit():
     mask = np.random.randint(2, size=n_samples)  # generate binary mask of random 0s and 1s
     masksum = np.random.random((n_samples))
     fittype = 'curvefit'
-    t2s_limited, s0_limited, t2ss, s0vs, t2s_full, s0_full = me.fit_decay(
-                                                                data, tes,
-                                                                mask,
-                                                                masksum,
-                                                                fittype)
+    t2s_limited, s0_limited, t2s_full, s0_full = me.fit_decay(
+        data, tes, mask, masksum, fittype)
     assert t2s_limited is not None
     assert s0_limited is not None
-    assert t2ss is not None
-    assert s0vs is not None
     assert t2s_full is not None
     assert s0_full is not None
 
@@ -128,10 +117,7 @@ def test_smoke_fit_decay_ts():
     masksum = np.random.random((n_samples))
     fittype = 'loglin'
     t2s_limited_ts, s0_limited_ts, t2s_full_ts, s0_full_ts = me.fit_decay_ts(
-                                                                data, tes,
-                                                                mask,
-                                                                masksum,
-                                                                fittype)
+        data, tes, mask, masksum, fittype)
     assert t2s_limited_ts is not None
     assert s0_limited_ts is not None
     assert t2s_full_ts is not None
@@ -153,10 +139,7 @@ def test_smoke_fit_decay_curvefit_ts():
     masksum = np.random.random((n_samples))
     fittype = 'curvefit'
     t2s_limited_ts, s0_limited_ts, t2s_full_ts, s0_full_ts = me.fit_decay_ts(
-                                                                data, tes,
-                                                                mask,
-                                                                masksum,
-                                                                fittype)
+        data, tes, mask, masksum, fittype)
     assert t2s_limited_ts is not None
     assert s0_limited_ts is not None
     assert t2s_full_ts is not None

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -205,7 +205,6 @@ def t2smap_workflow(data, tes, mask=None, fitmode='all', combmode='t2s',
     LGR.info('Computing adaptive T2* map')
     if fitmode == 'all':
         (t2s_limited, s0_limited,
-         t2ss, s0s,
          t2s_full, s0_full) = decay.fit_decay(catd, tes, mask, masksum,
                                               fittype)
     else:

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -437,13 +437,12 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
 
     mask, masksum = utils.make_adaptive_mask(catd, mask=mask, getsum=True)
     LGR.debug('Retaining {}/{} samples'.format(mask.sum(), n_samp))
-    if verbose:
-        io.filewrite(masksum, op.join(out_dir, 'adaptive_mask.nii'), ref_img)
+    io.filewrite(masksum, op.join(out_dir, 'adaptive_mask.nii'), ref_img)
 
     os.chdir(out_dir)
 
     LGR.info('Computing T2* map')
-    t2s, s0, t2ss, s0s, t2sG, s0G = decay.fit_decay(catd, tes, mask, masksum, fittype)
+    t2s, s0, t2sG, s0G = decay.fit_decay(catd, tes, mask, masksum, fittype)
 
     # set a hard cap for the T2* map
     # anything that is 10x higher than the 99.5 %ile will be reset to 99.5 %ile
@@ -455,8 +454,6 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
     io.filewrite(s0, op.join(out_dir, 's0v.nii'), ref_img)
 
     if verbose:
-        io.filewrite(t2ss, op.join(out_dir, 't2ss.nii'), ref_img)
-        io.filewrite(s0s, op.join(out_dir, 's0vs.nii'), ref_img)
         io.filewrite(t2sG, op.join(out_dir, 't2svG.nii'), ref_img)
         io.filewrite(s0G, op.join(out_dir, 's0vG.nii'), ref_img)
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -442,23 +442,24 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
     os.chdir(out_dir)
 
     LGR.info('Computing T2* map')
-    t2s, s0, t2sG, s0G = decay.fit_decay(catd, tes, mask, masksum, fittype)
+    t2s_limited, s0_limited, t2s_full, s0_full = decay.fit_decay(
+        catd, tes, mask, masksum, fittype)
 
     # set a hard cap for the T2* map
     # anything that is 10x higher than the 99.5 %ile will be reset to 99.5 %ile
-    cap_t2s = stats.scoreatpercentile(t2s.flatten(), 99.5,
+    cap_t2s = stats.scoreatpercentile(t2s_limited.flatten(), 99.5,
                                       interpolation_method='lower')
     LGR.debug('Setting cap on T2* map at {:.5f}'.format(cap_t2s * 10))
-    t2s[t2s > cap_t2s * 10] = cap_t2s
-    io.filewrite(t2s, op.join(out_dir, 't2sv.nii'), ref_img)
-    io.filewrite(s0, op.join(out_dir, 's0v.nii'), ref_img)
+    t2s_limited[t2s_limited > cap_t2s * 10] = cap_t2s
+    io.filewrite(t2s_limited, op.join(out_dir, 't2sv.nii'), ref_img)
+    io.filewrite(s0_limited, op.join(out_dir, 's0v.nii'), ref_img)
 
     if verbose:
-        io.filewrite(t2sG, op.join(out_dir, 't2svG.nii'), ref_img)
-        io.filewrite(s0G, op.join(out_dir, 's0vG.nii'), ref_img)
+        io.filewrite(t2s_full, op.join(out_dir, 't2svG.nii'), ref_img)
+        io.filewrite(s0_full, op.join(out_dir, 's0vG.nii'), ref_img)
 
     # optimally combine data
-    data_oc = combine.make_optcom(catd, tes, mask, t2s=t2sG, combmode=combmode)
+    data_oc = combine.make_optcom(catd, tes, mask, t2s=t2s_full, combmode=combmode)
 
     # regress out global signal unless explicitly not desired
     if 'gsr' in gscontrol:
@@ -467,7 +468,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
     if mixm is None:
         # Identify and remove thermal noise from data
         dd, n_components = decomposition.tedpca(catd, data_oc, combmode, mask,
-                                                t2s, t2sG, ref_img,
+                                                t2s_limited, t2s_full, ref_img,
                                                 tes=tes, algorithm=tedpca,
                                                 source_tes=source_tes,
                                                 kdaw=10., rdaw=1.,
@@ -486,7 +487,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         # generated from dimensionally reduced data using full data (i.e., data
         # with thermal noise)
         comptable, metric_maps, betas, mmix = metrics.dependence_metrics(
-                    catd, data_oc, mmix_orig, t2s, tes,
+                    catd, data_oc, mmix_orig, t2s_limited, tes,
                     ref_img, reindex=True, label='meica_', out_dir=out_dir,
                     algorithm='kundu_v2', verbose=verbose)
         comp_names = [io.add_decomp_prefix(comp, prefix='ica', max_value=comptable.index.max())
@@ -504,7 +505,7 @@ def tedana_workflow(data, tes, mask=None, mixm=None, ctab=None, manacc=None,
         LGR.info('Using supplied mixing matrix from ICA')
         mmix_orig = pd.read_table(op.join(out_dir, 'ica_mixing.tsv')).values
         comptable, metric_maps, betas, mmix = metrics.dependence_metrics(
-                    catd, data_oc, mmix_orig, t2s, tes,
+                    catd, data_oc, mmix_orig, t2s_limited, tes,
                     ref_img, label='meica_', out_dir=out_dir,
                     algorithm='kundu_v2', verbose=verbose)
         betas_oc = utils.unmask(computefeats2(data_oc, mmix, mask), mask)


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #440 and closes #439.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Split the actual decay-fitting parts of `decay.fit_decay` into `fit_loglinear` and `fit_monoexponential`.
- Only fit curve to voxels that will be used in the limited or full S0/T2* maps. This should speed up curve-fitting with large number of echoes.
- Remove ascending T2*/S0 estimates from `fit_decay` outputs.
- Write out adaptive_mask.nii.gz by default.
