### PR TITLE
[MNT] Drop versioneer from requirements

### DIFF
--- a/tedana/info.py
+++ b/tedana/info.py
@@ -33,7 +33,6 @@ REQUIRES = [
     'nilearn',
     'nibabel>=2.1.0',
     'scipy',
-    'versioneer',
     'pandas',
     'matplotlib'
 ]

--- a/tedana/info.py
+++ b/tedana/info.py
@@ -44,6 +44,7 @@ TESTS_REQUIRES = [
 ]
 
 EXTRA_REQUIRES = {
+    'dev': ['versioneer'],
     'doc': [
         'sphinx>=1.5.3',
         'sphinx_rtd_theme',


### PR DESCRIPTION
The versioneer package is not a requirement to use versioneer, only to update it. `install_requires` should only list packages needed to use the package, not to maintain it. If you like, I could add a `dev` extra that includes versioneer.

Context: fMRIPrep indirectly requires versioneer because it requires tedana. I'd rather keep the dependencies to a minimum.

<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Removes the versioneer package from `install_requires`.
