### PR TITLE
[FIX] Remove colons from log filename

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -37,8 +37,8 @@ def check_integration_outputs(fname, outpath):
 
     # Checks for log file
     log_regex = ('^tedana_'
-                 '[12][0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}:'
-                 '[0-9]{2}:[0-9]{2}.tsv$')
+                 '[12][0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}'
+                 '[0-9]{2}[0-9]{2}.tsv$')
     logfiles = [out for out in existing if re.match(log_regex, out)]
     assert len(logfiles) == 1
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -330,8 +330,8 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     # create logfile name
     basename = 'tedana_'
     extension = 'tsv'
-    isotime = datetime.datetime.now().replace(microsecond=0).isoformat()
-    logname = op.join(out_dir, (basename + isotime + '.' + extension))
+    start_time = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
+    logname = op.join(out_dir, (basename + start_time + '.' + extension))
 
     # set logging format
     log_formatter = logging.Formatter(


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #541.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Removes colons from the log-file's filename, for Windows compatibility.
- Changes variable `isotime` to `start_time`, to reflect that the string is no longer in ISO format.
- Updates regular expression in `test_integration` used to find and remove the log-file based on the new filename structure.
