### PR TITLE
[FIX] Drop use of eimask

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -10,7 +10,7 @@ from scipy import stats
 from sklearn.decomposition import PCA
 
 from tedana import metrics, utils, io
-from tedana.decomposition import (ma_pca, _utils)
+from tedana.decomposition import ma_pca
 from tedana.stats import computefeats2
 from tedana.selection import kundu_tedpca
 
@@ -181,19 +181,14 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
     n_samp, n_echos, n_vols = data_cat.shape
 
     LGR.info('Computing PCA of optimally combined multi-echo data')
-    data = data_oc[mask, :][:, np.newaxis, :]
-
-    eim = np.squeeze(_utils.eimask(data))
-    data = np.squeeze(data[eim])
+    data = data_oc[mask, :]
 
     data_z = ((data.T - data.T.mean(axis=0)) / data.T.std(axis=0)).T  # var normalize ts
     data_z = (data_z - data_z.mean()) / data_z.std()  # var normalize everything
 
     if algorithm in ['mdl', 'aic', 'kic']:
-        data_img = io.new_nii_like(
-            ref_img, utils.unmask(utils.unmask(data, eim), mask))
-        mask_img = io.new_nii_like(ref_img,
-                                   utils.unmask(eim, mask).astype(int))
+        data_img = io.new_nii_like(ref_img, utils.unmask(data, mask))
+        mask_img = io.new_nii_like(ref_img, mask.astype(int))
         voxel_comp_weights, varex, varex_norm, comp_ts = ma_pca.ma_pca(
             data_img, mask_img, algorithm)
     elif low_mem:
@@ -209,13 +204,6 @@ def tedpca(data_cat, data_oc, combmode, mask, t2s, t2sG,
         varex_norm = varex / varex.sum()
 
     # Compute Kappa and Rho for PCA comps
-    eimum = np.atleast_2d(eim)
-    eimum = np.transpose(eimum, np.argsort(eimum.shape)[::-1])
-    eimum = eimum.prod(axis=1)
-    o = np.zeros((mask.shape[0], *eimum.shape[1:]))
-    o[mask, ...] = eimum
-    eimum = np.squeeze(o).astype(bool)
-
     # Normalize each component's time series
     vTmixN = stats.zscore(comp_ts, axis=0)
     comptable, _, _, _ = metrics.dependence_metrics(data_cat,


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #490. This acts as a quick fix for the PCA masking issue, but we will ultimately use the outlier-based mask (i.e., `eimask`) in the adaptive masking procedure at the beginning of the workflow (see #491).

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- No longer use eimask at all. 
