### PR TITLE
[REF] Update t2smap workflow for fMRIPrep compatibility

### DIFF
--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -23,7 +23,7 @@ class TestT2smap():
                 op.join(data_dir, 'echo3.nii.gz')]
         out_dir = 'TED.echo1.t2smap'
         workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
-                                  fitmode='all', label='t2smap', out_dir=out_dir)
+                                  fitmode='all', out_dir=out_dir)
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
@@ -49,7 +49,7 @@ class TestT2smap():
                 op.join(data_dir, 'echo3.nii.gz')]
         out_dir = 'TED.echo1.t2smap'
         workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
-                                  fitmode='ts', label='t2smap', out_dir=out_dir)
+                                  fitmode='ts', out_dir=out_dir)
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
@@ -75,7 +75,7 @@ class TestT2smap():
                 op.join(data_dir, 'echo3.nii.gz')]
         out_dir = 'TED.echo1.t2smap'
         workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
-                                  fitmode='all', label='t2smap', out_dir=out_dir)
+                                  fitmode='all', out_dir=out_dir)
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
@@ -101,7 +101,7 @@ class TestT2smap():
                 op.join(data_dir, 'echo3.nii.gz')]
         out_dir = 'TED.echo1.t2smap'
         workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
-                                  fitmode='ts', label='t2smap', out_dir=out_dir)
+                                  fitmode='ts', out_dir=out_dir)
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -124,11 +124,11 @@ class TestT2smap():
         data = [op.join(data_dir, 'echo1.nii.gz'),
                 op.join(data_dir, 'echo2.nii.gz'),
                 op.join(data_dir, 'echo3.nii.gz')]
+        out_dir = 'TED.echo1.t2smap'
         args = (['-d'] + data +
                 ['-e', '14.5', '38.5', '62.5', '--combmode', 't2s',
-                 '--fitmode', 'all', '--label', 't2smap'])
+                 '--fitmode', 'all', '--out-dir', out_dir])
         workflows.t2smap._main(args)
-        out_dir = 'TED.echo1.t2smap'
 
         # Check outputs
         img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -21,21 +21,21 @@ class TestT2smap():
         data = [op.join(data_dir, 'echo1.nii.gz'),
                 op.join(data_dir, 'echo2.nii.gz'),
                 op.join(data_dir, 'echo3.nii.gz')]
-        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
-                                  fitmode='all', label='t2smap')
         out_dir = 'TED.echo1.t2smap'
+        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
+                                  fitmode='all', label='t2smap', out_dir=out_dir)
 
         # Check outputs
-        assert op.isfile(op.join(out_dir, 'ts_OC.nii.gz'))
-        img = nib.load(op.join(out_dir, 't2sv.nii.gz'))
+        assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0v.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 't2svG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0vG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'ts_OC.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
 
     def test_basic_t2smap2(self):
@@ -47,21 +47,21 @@ class TestT2smap():
         data = [op.join(data_dir, 'echo1.nii.gz'),
                 op.join(data_dir, 'echo2.nii.gz'),
                 op.join(data_dir, 'echo3.nii.gz')]
-        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
-                                  fitmode='ts', label='t2smap')
         out_dir = 'TED.echo1.t2smap'
+        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='t2s',
+                                  fitmode='ts', label='t2smap', out_dir=out_dir)
 
         # Check outputs
-        assert op.isfile(op.join(out_dir, 'ts_OC.nii.gz'))
-        img = nib.load(op.join(out_dir, 't2sv.nii.gz'))
+        assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 's0v.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 't2svG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 's0vG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'ts_OC.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
 
     def test_basic_t2smap3(self):
@@ -73,21 +73,21 @@ class TestT2smap():
         data = [op.join(data_dir, 'echo1.nii.gz'),
                 op.join(data_dir, 'echo2.nii.gz'),
                 op.join(data_dir, 'echo3.nii.gz')]
-        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
-                                  fitmode='all', label='t2smap')
         out_dir = 'TED.echo1.t2smap'
+        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
+                                  fitmode='all', label='t2smap', out_dir=out_dir)
 
         # Check outputs
-        assert op.isfile(op.join(out_dir, 'ts_OC.nii.gz'))
-        img = nib.load(op.join(out_dir, 't2sv.nii.gz'))
+        assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0v.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 't2svG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0vG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'ts_OC.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
 
     def test_basic_t2smap4(self):
@@ -99,21 +99,21 @@ class TestT2smap():
         data = [op.join(data_dir, 'echo1.nii.gz'),
                 op.join(data_dir, 'echo2.nii.gz'),
                 op.join(data_dir, 'echo3.nii.gz')]
-        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
-                                  fitmode='ts', label='t2smap')
         out_dir = 'TED.echo1.t2smap'
+        workflows.t2smap_workflow(data, [14.5, 38.5, 62.5], combmode='paid',
+                                  fitmode='ts', label='t2smap', out_dir=out_dir)
 
         # Check outputs
-        assert op.isfile(op.join(out_dir, 'ts_OC.nii.gz'))
-        img = nib.load(op.join(out_dir, 't2sv.nii.gz'))
+        assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 's0v.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 't2svG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 's0vG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'ts_OC.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
 
     def test_t2smap_cli(self):
@@ -131,15 +131,15 @@ class TestT2smap():
         out_dir = 'TED.echo1.t2smap'
 
         # Check outputs
-        img = nib.load(op.join(out_dir, 't2sv.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0v.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 't2svG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 's0vG.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'ts_OC.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
 
     def teardown_method(self):

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -159,21 +159,21 @@ def t2smap_workflow(data, tes, out_dir='.', mask=None,
     -----
     This workflow writes out several files, which are described below:
 
-    ======================    =================================================
-    Filename                  Content
-    ======================    =================================================
-    t2sv.nii                  Limited estimated T2* 3D map or 4D timeseries.
-                              Will be a 3D map if ``fitmode`` is 'all' and a
-                              4D timeseries if it is 'ts'.
-    s0v.nii                   Limited S0 3D map or 4D timeseries.
-    t2svG.nii                 Full T2* map/timeseries. The difference between
-                              the limited and full maps is that, for voxels
-                              affected by dropout where only one echo contains
-                              good data, the full map uses the single echo's
-                              value while the limited map has a NaN.
-    s0vG.nii                  Full S0 map/timeseries.
-    ts_OC.nii                 Optimally combined timeseries.
-    ======================    =================================================
+    ==========================    =================================================
+    Filename                      Content
+    ==========================    =================================================
+    T2StarMap.nii.gz              Limited estimated T2* 3D map or 4D timeseries.
+                                  Will be a 3D map if ``fitmode`` is 'all' and a
+                                  4D timeseries if it is 'ts'.
+    S0Map.nii.gz                  Limited S0 3D map or 4D timeseries.
+    desc-full_T2StarMap.nii.gz    Full T2* map/timeseries. The difference between
+                                  the limited and full maps is that, for voxels
+                                  affected by dropout where only one echo contains
+                                  good data, the full map uses the single echo's
+                                  value while the limited map has a NaN.
+    desc-full_S0Map.nii.gz        Full S0 map/timeseries.
+    desc-optcom_bold.nii.gz       Optimally combined timeseries.
+    ==========================    =================================================
     """
     out_dir = op.abspath(out_dir)
     if not op.isdir(out_dir):
@@ -237,11 +237,13 @@ def t2smap_workflow(data, tes, out_dir='.', mask=None,
     s0_limited[s0_limited < 0] = 0
     t2s_limited[t2s_limited < 0] = 0
 
-    io.filewrite(utils.millisec2sec(t2s_limited), op.join(out_dir, 't2sv.nii'), ref_img)
-    io.filewrite(s0_limited, op.join(out_dir, 's0v.nii'), ref_img)
-    io.filewrite(utils.millisec2sec(t2s_full), op.join(out_dir, 't2svG.nii'), ref_img)
-    io.filewrite(s0_full, op.join(out_dir, 's0vG.nii'), ref_img)
-    io.filewrite(OCcatd, op.join(out_dir, 'ts_OC.nii'), ref_img)
+    io.filewrite(utils.millisec2sec(t2s_limited),
+                 op.join(out_dir, 'T2StarMap.nii.gz'), ref_img)
+    io.filewrite(s0_limited, op.join(out_dir, 'S0Map.nii.gz'), ref_img)
+    io.filewrite(utils.millisec2sec(t2s_full),
+                 op.join(out_dir, 'desc-full_T2StarMap.nii.gz'), ref_img)
+    io.filewrite(s0_full, op.join(out_dir, 'desc-full_S0Map.nii.gz'), ref_img)
+    io.filewrite(OCcatd, op.join(out_dir, 'desc-optcom_bold.nii.gz'), ref_img)
 
 
 def _main(argv=None):


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
References #540. This is currently limited to the t2smap workflow because the focus is on fMRIPrep compatibility, but I can also rename the output files in the tedana workflow as well, if folks want.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Change output files for t2smap_workflow and corresponding outputs in tedana_workflow to be more BIDS-like:
    - t2sv.nii --> T2StarMap.nii.gz
    - s0v.nii --> S0Map.nii.gz
    - t2svG.nii --> desc-full_T2StarMap.nii.gz
    - s0vG.nii --> desc-full_S0Map.nii.gz
    - ts_OC.nii --> desc-optcom_bold.nii.gz
- Add out-dir argument to t2smap_workflow, defaulting to CWD.