### PR TITLE
[FIX] Correct t2smap outputs

### DIFF
--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -27,13 +27,13 @@ class TestT2smap():
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
-        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0map.nii.gz'))
         assert len(img.shape) == 3
         img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
@@ -53,13 +53,13 @@ class TestT2smap():
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
-        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2starmap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2starmap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0map.nii.gz'))
         assert len(img.shape) == 4
         img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
@@ -79,13 +79,13 @@ class TestT2smap():
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
-        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0map.nii.gz'))
         assert len(img.shape) == 3
         img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
@@ -105,13 +105,13 @@ class TestT2smap():
 
         # Check outputs
         assert op.isfile(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
-        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2starmap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0map.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2starmap.nii.gz'))
         assert len(img.shape) == 4
-        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0map.nii.gz'))
         assert len(img.shape) == 4
         img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4
@@ -131,13 +131,13 @@ class TestT2smap():
         workflows.t2smap._main(args)
 
         # Check outputs
-        img = nib.load(op.join(out_dir, 'T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'S0map.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_T2StarMap.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_T2starmap.nii.gz'))
         assert len(img.shape) == 3
-        img = nib.load(op.join(out_dir, 'desc-full_S0Map.nii.gz'))
+        img = nib.load(op.join(out_dir, 'desc-full_S0map.nii.gz'))
         assert len(img.shape) == 3
         img = nib.load(op.join(out_dir, 'desc-optcom_bold.nii.gz'))
         assert len(img.shape) == 4

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -162,16 +162,16 @@ def t2smap_workflow(data, tes, out_dir='.', mask=None,
     ==========================    =================================================
     Filename                      Content
     ==========================    =================================================
-    T2StarMap.nii.gz              Limited estimated T2* 3D map or 4D timeseries.
+    T2starmap.nii.gz              Limited estimated T2* 3D map or 4D timeseries.
                                   Will be a 3D map if ``fitmode`` is 'all' and a
                                   4D timeseries if it is 'ts'.
-    S0Map.nii.gz                  Limited S0 3D map or 4D timeseries.
-    desc-full_T2StarMap.nii.gz    Full T2* map/timeseries. The difference between
+    S0map.nii.gz                  Limited S0 3D map or 4D timeseries.
+    desc-full_T2starmap.nii.gz    Full T2* map/timeseries. The difference between
                                   the limited and full maps is that, for voxels
                                   affected by dropout where only one echo contains
                                   good data, the full map uses the single echo's
                                   value while the limited map has a NaN.
-    desc-full_S0Map.nii.gz        Full S0 map/timeseries.
+    desc-full_S0map.nii.gz        Full S0 map/timeseries.
     desc-optcom_bold.nii.gz       Optimally combined timeseries.
     ==========================    =================================================
     """
@@ -238,11 +238,11 @@ def t2smap_workflow(data, tes, out_dir='.', mask=None,
     t2s_limited[t2s_limited < 0] = 0
 
     io.filewrite(utils.millisec2sec(t2s_limited),
-                 op.join(out_dir, 'T2StarMap.nii.gz'), ref_img)
-    io.filewrite(s0_limited, op.join(out_dir, 'S0Map.nii.gz'), ref_img)
+                 op.join(out_dir, 'T2starmap.nii.gz'), ref_img)
+    io.filewrite(s0_limited, op.join(out_dir, 'S0map.nii.gz'), ref_img)
     io.filewrite(utils.millisec2sec(t2s_full),
-                 op.join(out_dir, 'desc-full_T2StarMap.nii.gz'), ref_img)
-    io.filewrite(s0_full, op.join(out_dir, 'desc-full_S0Map.nii.gz'), ref_img)
+                 op.join(out_dir, 'desc-full_T2starmap.nii.gz'), ref_img)
+    io.filewrite(s0_full, op.join(out_dir, 'desc-full_S0map.nii.gz'), ref_img)
     io.filewrite(OCcatd, op.join(out_dir, 'desc-optcom_bold.nii.gz'), ref_img)
 
 

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -152,7 +152,7 @@ def t2smap_workflow(data, tes, out_dir='.', mask=None,
     debug : :obj:`bool`, optional
         Whether to run in debugging mode or not. Default is False.
     quiet : :obj:`bool`, optional
-        If True, suppresses logging/printing of messages. Default is False.
+        If True, suppress logging/printing of messages. Default is False.
 
 
     Notes


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. I was reading the BEP001 supported extensions list and realized I made a mistake in #557. This will fix that.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- In the `t2smap` workflow: T2StarMap --> T2starmap
- In the `t2smap` workflow: S0Map --> S0map
