### PR TITLE
[FIX] Add non-zero floor to T2* values

### DIFF
--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -18,22 +18,26 @@ def _apply_t2s_floor(t2s, echo_times):
 
     Parameters
     ----------
-    t2s : (S,) array
-    echo_times : (E,) array
+    t2s : (S,) array_like
+        T2* estimates.
+    echo_times : (E,) array_like
+        Echo times in milliseconds.
 
     Returns
     -------
-    t2s : (S,) array
+    t2s_corrected : (S,) array_like
+        T2* estimates with very small, positive values replaced with a floor value.
     """
+    t2s_corrected = t2s.copy()
     echo_times = np.asarray(echo_times)
     if echo_times.ndim == 1:
         echo_times = echo_times[:, None]
 
     eps = np.finfo(dtype=t2s.dtype).eps  # smallest value for datatype
-    temp_arr = np.exp(-echo_times / t2s)
+    temp_arr = np.exp(-echo_times / t2s)  # (E x V) array
     bad_voxel_idx = np.any(temp_arr == 0, axis=0) & (t2s != 0)
-    t2s[bad_voxel_idx] = np.min(-echo_times) / np.log(eps)
-    return t2s
+    t2s_corrected[bad_voxel_idx] = np.min(-echo_times) / np.log(eps)
+    return t2s_corrected
 
 
 def monoexponential(tes, s0, t2star):

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -7,7 +7,7 @@ import os.path as op
 import numpy as np
 import pytest
 
-from tedana import io, utils, decay as me
+from tedana import io, utils, combine, decay as me
 from tedana.tests.utils import get_test_data_path
 
 
@@ -56,6 +56,30 @@ def test_fit_decay_ts(testdata1):
     assert s0v.ndim == 2
     assert t2svG.ndim == 2
     assert s0vG.ndim == 2
+
+
+def test__apply_t2s_floor():
+    """
+    _apply_t2s_floor applies a floor to T2* values to prevent a ZeroDivisionError during
+    optimal combination.
+    """
+    n_voxels, n_echos, n_trs = 100, 5, 25
+    echo_times = np.array([2, 23, 54, 75, 96])
+    me_data = np.random.random((n_voxels, n_echos, n_trs))
+    t2s = np.random.random((n_voxels)) * 1000
+    t2s[t2s < 1] = 1  # Crop at 1 ms to be safe
+    t2s[0] = 0.001
+
+    # First establish a failure
+    with pytest.raises(ZeroDivisionError):
+        _ = combine._combine_t2s(me_data, echo_times[None, :], t2s[:, None])
+
+    # Now correct the T2* map and get a successful result.
+    t2s_corrected = me._apply_t2s_floor(t2s, echo_times)
+    assert t2s_corrected[0] != t2s[0]  # First value should be corrected
+    assert np.array_equal(t2s_corrected[1:], t2s[1:])  # No other values should be corrected
+    combined = combine._combine_t2s(me_data, echo_times[None, :], t2s_corrected[:, None])
+    assert np.all(combined != 0)
 
 
 # SMOKE TESTS


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #513.

Todo:
- [x] Write test

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a new function to determine smallest non-zero T2* value that will not resolve to zero in optimal combination step. Replace values in the T2* maps > 0 and < this value with the value.
- Add a new unit test for the function. This test doesn't improve coverage, but is important.