### PR TITLE
[ENH] Add diagonal reference line to kappa/rho plot

### DIFF
--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -147,6 +147,8 @@ def _create_kr_plt(comptable_cds):
     fig = plotting.figure(plot_width=400, plot_height=400,
                           tools=["tap,wheel_zoom,reset,pan,crosshair,save", kr_hovertool],
                           title="Kappa / Rho Plot")
+    diagonal = models.Slope(gradient=1, y_intercept=0, line_color='#D3D3D3')
+    fig.add_layout(diagonal)
     fig.circle('kappa', 'rho', size='size', color='color', alpha=0.5, source=comptable_cds,
                legend_group='classif')
     fig.xaxis.axis_label = 'Kappa'


### PR DESCRIPTION
Closes #582.

Changes proposed in this pull request:

- Add a diagonal line (y = x) in kappa/rho scatter plot to make it easier to identify which of the two is greater for each component

---

Other notes:

- Here's what the figure looks like the for the three test datasets
![diagonalref](https://user-images.githubusercontent.com/9019681/101269582-ef266f80-3735-11eb-9d2c-177d78e658dc.png)
- The above scatter plots do not match the ones in the [three-echo](https://me-ica.github.io/tedana-ohbm-2020/three-echo-report/tedana_report.html) and [five-echo](https://me-ica.github.io/tedana-ohbm-2020/five-echo-report/tedana_report.html) reports from an older run
    + Assuming the older run used the same data, the differences could be due to changes in the code (#622) or if different input arguments were used
- Perhaps a bit more troubling: I got different results by changing the python environment. Gif below shows the scatter plot from the three-echo test using Python 3.6 (pre-installed/configured on server) and 3.8 (conda environment). 🤷
![three-echo](https://user-images.githubusercontent.com/9019681/101269640-a6bb8180-3736-11eb-851a-f5416ce9e75e.gif)


