### PR TITLE
[FIX] Show logs in re-runs

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -667,6 +667,8 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
 
     log_handler.close()
     logging.root.removeHandler(log_handler)
+    sh.close()
+    logging.root.removeHandler(sh)
     for local_logger in (RefLGR, RepLGR):
         for handler in local_logger.handlers[:]:
             handler.close()

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -664,13 +664,13 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     report += '\n\nReferences:\n\n' + references
     with open(repname, 'w') as fo:
         fo.write(report)
-    
+
     log_handler.close()
     logging.root.removeHandler(log_handler)
     for local_logger in (RefLGR, RepLGR):
         for handler in local_logger.handlers[:]:
             handler.close()
-            local_logger.removeHandler(handler)        
+            local_logger.removeHandler(handler)
     os.remove(refname)
 
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -355,23 +355,17 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     # Removing handlers after basicConfig doesn't work, so we use filters
     # for the relevant handlers themselves.
     log_handler.addFilter(ContextFilter())
+    logging.root.addHandler(log_handler)
     sh = logging.StreamHandler()
     sh.addFilter(ContextFilter())
     logging.root.addHandler(sh)
-    logging.root.addHandler(log_handler)
 
     if quiet:
         logging.root.setLevel(logging.WARNING)
-        #logging.basicConfig(level=logging.WARNING,
-        #                    handlers=[log_handler, sh])
     elif debug:
         logging.root.setLevel(logging.DEBUG)
-        #logging.basicConfig(level=logging.DEBUG,
-        #                    handlers=[log_handler, sh])
     else:
         logging.root.setLevel(logging.INFO)
-        #logging.basicConfig(level=logging.INFO,
-        #                    handlers=[log_handler, sh])
 
     # Loggers for report and references
     rep_handler = logging.FileHandler(repname)
@@ -673,13 +667,10 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     
     log_handler.close()
     logging.root.removeHandler(log_handler)
-    for handler in RepLGR.handlers[:]:
-        handler.close()
-        RepLGR.removeHandler(handler)
-    for handler in RefLGR.handlers[:]:
-        handler.close()
-        RefLGR.removeHandler(handler)
-        
+    for local_logger in (RefLGR, RepLGR):
+        for handler in local_logger.handlers[:]:
+            handler.close()
+            local_logger.removeHandler(handler)        
     os.remove(refname)
 
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -357,16 +357,21 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     log_handler.addFilter(ContextFilter())
     sh = logging.StreamHandler()
     sh.addFilter(ContextFilter())
+    logging.root.addHandler(sh)
+    logging.root.addHandler(log_handler)
 
     if quiet:
-        logging.basicConfig(level=logging.WARNING,
-                            handlers=[log_handler, sh])
+        logging.root.setLevel(logging.WARNING)
+        #logging.basicConfig(level=logging.WARNING,
+        #                    handlers=[log_handler, sh])
     elif debug:
-        logging.basicConfig(level=logging.DEBUG,
-                            handlers=[log_handler, sh])
+        logging.root.setLevel(logging.DEBUG)
+        #logging.basicConfig(level=logging.DEBUG,
+        #                    handlers=[log_handler, sh])
     else:
-        logging.basicConfig(level=logging.INFO,
-                            handlers=[log_handler, sh])
+        logging.root.setLevel(logging.INFO)
+        #logging.basicConfig(level=logging.INFO,
+        #                    handlers=[log_handler, sh])
 
     # Loggers for report and references
     rep_handler = logging.FileHandler(repname)
@@ -666,9 +671,8 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     with open(repname, 'w') as fo:
         fo.write(report)
     
-    for handler in logging.root.handlers[:]:
-        handler.close()
-        logging.root.removeHandler(handler)
+    log_handler.close()
+    logging.root.removeHandler(log_handler)
     for handler in RepLGR.handlers[:]:
         handler.close()
         RepLGR.removeHandler(handler)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -375,7 +375,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     ref_handler.setFormatter(text_formatter)
     RepLGR.setLevel(logging.INFO)
     RepLGR.addHandler(rep_handler)
-    RepLGR.setLevel(logging.INFO)
+    RefLGR.setLevel(logging.INFO)
     RefLGR.addHandler(ref_handler)
 
     LGR.info('Using output directory: {}'.format(out_dir))
@@ -666,9 +666,9 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     with open(repname, 'w') as fo:
         fo.write(report)
     
-    for handler in LGR.handlers[:]:
+    for handler in logging.root.handlers[:]:
         handler.close()
-        LGR.removeHandler(handler)
+        logging.root.removeHandler(handler)
     for handler in RepLGR.handlers[:]:
         handler.close()
         RepLGR.removeHandler(handler)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -665,10 +665,18 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     report += '\n\nReferences:\n\n' + references
     with open(repname, 'w') as fo:
         fo.write(report)
+    
+    for handler in LGR.handlers[:]:
+        handler.close()
+        LGR.removeHandler(handler)
+    for handler in RepLGR.handlers[:]:
+        handler.close()
+        RepLGR.removeHandler(handler)
+    for handler in RefLGR.handlers[:]:
+        handler.close()
+        RefLGR.removeHandler(handler)
+        
     os.remove(refname)
-
-    for handler in logging.root.handlers[:]:
-        logging.root.removeHandler(handler)
 
 
 def _main(argv=None):


### PR DESCRIPTION
Closes #606.

Changes proposed in this pull request:

- Instead of removing all handlers from `logging.root` at the end of the worklow, only remove `sh` and `log_handler`
    + The root logger contains other handlers if pytest is being used, and one of those handlers is responsible for printing to the terminal, so we don't want to remove these handlers.
- Manually add handlers to `logging.root` instead of using `logging.basicConfig()`
    + `basicConfig` does nothing if `logging.root` already has handlers
        + `logging.root` will have no handlers if a user is calling tedana, but it does have handlers if pytest is being used
    + In the current tests, `basicConfig` does nothing in the first run because `logging.root` already has handlers, but then these handlers are deleted at the end of the first run. On the second run, `basicConfig` works properly. 
        + This is probably why the first run doesn't produce any `tedana_$DATE.tsv` file in the output directory (or it is created, but file is empty)
- Close and remove the handlers for `RefLGR` and `RepLGR` at the end of workflow
    + Otherwise, the logger keeps printing to the old file when re-running, e.g. `report.txt` from the first run will contain appended text from the second run
- Typo: One of the `RepLGR` should've been `RefLGR`
    + Previously, the references would only be included in `report.txt` if verbose mode was enabled (or maybe it had to be debug mode, forgot which one specifically)

Possible discussion points:

- When calling tedana (not through pytest) the terminal printout used to look like:
```
INFO:tedana.workflows.tedana:Computing EPI mask from first echo
DEBUG:tedana.workflows.tedana:Retaining 38643/178752 samples
INFO:tedana.workflows.tedana:Computing T2* map
DEBUG:tedana.workflows.tedana:Setting cap on T2* map at 0.10164s
INFO:tedana.combine:Optimally combining data with voxel-wise T2* estimates
INFO:tedana.decomposition.pca:Computing PCA of optimally combined multi-echo data
INFO:tedana.decomposition.ma_pca:Performing SVD on original OC data...
```
but after this PR, it looks like
```
Computing EPI mask from first echo
Retaining 38643/178752 samples
Computing T2* map
Setting cap on T2* map at 0.10164s
Optimally combining data with voxel-wise T2* estimates
Computing PCA of optimally combined multi-echo data
Performing SVD on original OC data...
```
The `tedana_$DATE.tsv` still looks like the former, so it remains unchanged.