### PR TITLE
[ENH] Add ability to re-run ICA when no BOLD components are found

### DIFF
--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -38,8 +38,8 @@ def tedica(data, n_components, fixed_seed, maxit=500, maxrestart=10):
     mmix : (T x C) :obj:`numpy.ndarray`
         Z-scored mixing matrix for converting input data to component space,
         where `C` is components and `T` is the same as in `data`
-    n_restarts : :obj:`int`
-        Number of restarts used.
+    fixed_seed : :obj:`int`
+        Random seed from final decomposition.
 
     Notes
     -----

--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -66,8 +66,8 @@ def tedica(data, n_components, fixed_seed, maxit=500, maxrestart=10):
 
             w = list(filter(lambda i: issubclass(i.category, UserWarning), w))
             if len(w):
-                LGR.warning('ICA attempt {0} failed to converge after {1} '
-                            'iterations'.format(i_attempt + 1, ica.n_iter_))
+                LGR.warning('ICA with random seed {0} failed to converge after {1} '
+                            'iterations'.format(fixed_seed, ica.n_iter_))
                 if i_attempt < maxrestart - 1:
                     fixed_seed += 1
                     LGR.warning('Random seed updated to {0}'.format(fixed_seed))

--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -72,8 +72,8 @@ def tedica(data, n_components, fixed_seed, maxit=500, maxrestart=10):
                     fixed_seed += 1
                     LGR.warning('Random seed updated to {0}'.format(fixed_seed))
             else:
-                LGR.info('ICA attempt {0} converged in {1} '
-                         'iterations'.format(i_attempt + 1, ica.n_iter_))
+                LGR.info('ICA with random seed {0} converged in {1} '
+                         'iterations'.format(fixed_seed, ica.n_iter_))
                 break
 
     mmix = ica.mixing_

--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -38,6 +38,8 @@ def tedica(data, n_components, fixed_seed, maxit=500, maxrestart=10):
     mmix : (T x C) :obj:`numpy.ndarray`
         Z-scored mixing matrix for converting input data to component space,
         where `C` is components and `T` is the same as in `data`
+    n_restarts : :obj:`int`
+        Number of restarts used.
 
     Notes
     -----
@@ -76,4 +78,4 @@ def tedica(data, n_components, fixed_seed, maxit=500, maxrestart=10):
 
     mmix = ica.mixing_
     mmix = stats.zscore(mmix, axis=0)
-    return mmix
+    return mmix, fixed_seed

--- a/tedana/tests/data/fiu_four_echo_outputs.txt
+++ b/tedana/tests/data/fiu_four_echo_outputs.txt
@@ -1,6 +1,7 @@
 T1gs.nii.gz
 adaptive_mask.nii.gz
 betas_OC.nii.gz
+betas_hik_OC.nii.gz
 betas_hik_OC_MIR.nii.gz
 dn_ts_OC.nii.gz
 dn_ts_OC_MIR.nii.gz
@@ -8,8 +9,14 @@ dn_ts_e1.nii.gz
 dn_ts_e2.nii.gz
 dn_ts_e3.nii.gz
 dn_ts_e4.nii.gz
+feats_OC2.nii.gz
 glsig.1D
+hik_ts_OC.nii.gz
 hik_ts_OC_MIR.nii.gz
+hik_ts_e1.nii.gz
+hik_ts_e2.nii.gz
+hik_ts_e3.nii.gz
+hik_ts_e4.nii.gz
 ica_components.nii.gz
 ica_decomposition.json
 ica_mixing.tsv

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -524,11 +524,11 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         n_restarts = 0
         seed = fixed_seed
         while bad_decomp:
-            mmix_orig, n_restarts = decomposition.tedica(
+            mmix_orig, seed = decomposition.tedica(
                 dd, n_components, seed,
                 maxit, maxrestart=(maxrestart - n_restarts)
             )
-            seed += (n_restarts + 1)
+            n_restarts = (seed + 1) - fixed_seed
 
             # Estimate betas and compute selection metrics for mixing matrix
             # generated from dimensionally reduced data using full data (i.e., data

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -520,10 +520,10 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
 
         # Perform ICA, calculate metrics, and apply decision tree
         # Restart when ICA fails to converge or too few BOLD components found
-        bad_decomp = True
+        keep_restarting = True
         n_restarts = 0
         seed = fixed_seed
-        while bad_decomp:
+        while keep_restarting:
             mmix_orig, seed = decomposition.tedica(
                 dd, n_components, seed,
                 maxit, maxrestart=(maxrestart - n_restarts)
@@ -548,8 +548,9 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
                 LGR.warning("No BOLD components found. Re-attempting ICA.")
             elif (n_bold_comps == 0):
                 LGR.warning("No BOLD components found, but maximum number of restarts reached.")
+                keep_restarting = False
             elif (n_restarts >= maxrestart) or (n_bold_comps != 0):
-                bad_decomp = False
+                keep_restarting = False
 
         # Write out ICA files.
         comp_names = [io.add_decomp_prefix(comp, prefix='ica', max_value=comptable.index.max())

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -522,11 +522,13 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         # Restart when ICA fails to converge or too few BOLD components found
         bad_decomp = True
         n_restarts = 0
+        seed = fixed_seed
         while bad_decomp:
             mmix_orig, n_restarts = decomposition.tedica(
-                dd, n_components, fixed_seed,
+                dd, n_components, seed,
                 maxit, maxrestart=(maxrestart - n_restarts)
             )
+            seed += (n_restarts + 1)
 
             # Estimate betas and compute selection metrics for mixing matrix
             # generated from dimensionally reduced data using full data (i.e., data

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -528,7 +528,8 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
                 dd, n_components, seed,
                 maxit, maxrestart=(maxrestart - n_restarts)
             )
-            n_restarts = (seed + 1) - fixed_seed
+            seed += 1
+            n_restarts = seed - fixed_seed
 
             # Estimate betas and compute selection metrics for mixing matrix
             # generated from dimensionally reduced data using full data (i.e., data

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -514,21 +514,41 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
                                                 out_dir=out_dir,
                                                 verbose=verbose,
                                                 low_mem=low_mem)
-        mmix_orig = decomposition.tedica(dd, n_components, fixed_seed,
-                                         maxit, maxrestart)
-
         if verbose:
             io.filewrite(utils.unmask(dd, mask),
                          op.join(out_dir, 'ts_OC_whitened.nii.gz'), ref_img)
 
-        LGR.info('Making second component selection guess from ICA results')
-        # Estimate betas and compute selection metrics for mixing matrix
-        # generated from dimensionally reduced data using full data (i.e., data
-        # with thermal noise)
-        comptable, metric_maps, betas, mmix = metrics.dependence_metrics(
-                    catd, data_oc, mmix_orig, masksum, tes,
-                    ref_img, reindex=True, label='meica_', out_dir=out_dir,
-                    algorithm='kundu_v2', verbose=verbose)
+        # Perform ICA, calculate metrics, and apply decision tree
+        # Restart when ICA fails to converge or too few BOLD components found
+        bad_decomp = True
+        n_restarts = 0
+        while bad_decomp:
+            mmix_orig, n_restarts = decomposition.tedica(
+                dd, n_components, fixed_seed,
+                maxit, maxrestart=(maxrestart - n_restarts)
+            )
+
+            # Estimate betas and compute selection metrics for mixing matrix
+            # generated from dimensionally reduced data using full data (i.e., data
+            # with thermal noise)
+            LGR.info('Making second component selection guess from ICA results')
+            comptable, metric_maps, betas, mmix = metrics.dependence_metrics(
+                catd, data_oc, mmix_orig, masksum, tes,
+                ref_img, reindex=True, label='meica_', out_dir=out_dir,
+                algorithm='kundu_v2', verbose=verbose
+            )
+            comptable = metrics.kundu_metrics(comptable, metric_maps)
+            comptable = selection.kundu_selection_v2(comptable, n_echos, n_vols)
+
+            n_bold_comps = comptable[comptable.classification == 'accepted'].shape[0]
+            if (n_restarts < maxrestart) and (n_bold_comps == 0):
+                LGR.warning("No BOLD components found. Re-attempting ICA.")
+            elif (n_bold_comps == 0):
+                LGR.warning("No BOLD components found, but maximum number of restarts reached.")
+            elif (n_restarts >= maxrestart) or (n_bold_comps != 0):
+                bad_decomp = False
+
+        # Write out ICA files.
         comp_names = [io.add_decomp_prefix(comp, prefix='ica', max_value=comptable.index.max())
                       for comp in comptable.index.values]
         mixing_df = pd.DataFrame(data=mmix, columns=comp_names)
@@ -537,9 +557,6 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         io.filewrite(betas_oc,
                      op.join(out_dir, 'ica_components.nii.gz'),
                      ref_img)
-
-        comptable = metrics.kundu_metrics(comptable, metric_maps)
-        comptable = selection.kundu_selection_v2(comptable, n_echos, n_vols)
     else:
         LGR.info('Using supplied mixing matrix from ICA')
         mmix_orig = pd.read_table(op.join(out_dir, 'ica_mixing.tsv')).values
@@ -561,7 +578,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
                      op.join(out_dir, 'ica_components.nii.gz'),
                      ref_img)
 
-    # Save decomposition
+    # Save component table
     comptable['Description'] = 'ICA fit to dimensionally-reduced optimally combined data.'
     mmix_dict = {}
     mmix_dict['Method'] = ('Independent components analysis with FastICA '

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -549,7 +549,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             elif (n_bold_comps == 0):
                 LGR.warning("No BOLD components found, but maximum number of restarts reached.")
                 keep_restarting = False
-            elif (n_restarts >= maxrestart) or (n_bold_comps != 0):
+            else:
                 keep_restarting = False
 
         # Write out ICA files.


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #662. This is just a first pass, although I think it should work.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Re-run ICA (within constraints of `maxrestarts` parameter) when no BOLD components are found by the decision tree.
