### PR TITLE
[REF] Replaces master with main where possible

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ If there is other information that would be helpful to include, please don't hes
 
 Please also label your pull request with the relevant tags.
 See here for more information and a list of available options:
-https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
+https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
 -->
 
 <!-- Please indicate after the # which issue you're closing with this PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,7 +324,7 @@ You're awesome. :wave::smiley:
 [markdown]: https://daringfireball.net/projects/markdown
 [rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
 [restructuredtext]: http://www.sphinx-doc.org/en/main/usage/restructuredtext/index.html
-[sphinx]: http://www.sphinx-doc.org/en/main/index.html
+[sphinx]: http://www.sphinx-doc.org/en/master/index.html
 [readthedocs]: https://docs.readthedocs.io/en/latest/index.html
 
 [link_issues]: https://github.com/ME-ICA/tedana/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ This is now your own unique and online copy of `tedana`. Changes here won't affe
 
 Remember to [clone your fork][link_clonerepo] of `tedana` to your local machine, which will allow you to make local changes to `tedana`.
 
-Make sure to always [keep your fork up to date][link_updateupstreamwiki] with the master repository before and after making changes.
+Make sure to always [keep your fork up to date][link_updateupstreamwiki] with the upstream repository before and after making changes.
 
 ### 3. Run the developer setup
 
@@ -146,12 +146,12 @@ Try to keep the changes focused to the issue.
 We've found that working on a [new branch][link_branches] for each issue makes it easier to keep your changes targeted.
 Using a new branch allows you to follow the standard GitHub workflow when making changes.
 [This guide][link_gitworkflow] provides a useful overview for this workflow.
-Before making a new branch, make sure your master is up to date with the following commands:
+Before making a new branch, make sure your main is up to date with the following commands:
 
 ```
-git checkout master
-git fetch upstream master
-git merge upstream/master
+git checkout main
+git fetch upstream main
+git merge upstream/main
 ```
 
 Then, make your new branch.
@@ -323,15 +323,15 @@ You're awesome. :wave::smiley:
 [writing_formatting_github]: https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github
 [markdown]: https://daringfireball.net/projects/markdown
 [rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
-[restructuredtext]: http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
-[sphinx]: http://www.sphinx-doc.org/en/master/index.html
+[restructuredtext]: http://www.sphinx-doc.org/en/main/usage/restructuredtext/index.html
+[sphinx]: http://www.sphinx-doc.org/en/main/index.html
 [readthedocs]: https://docs.readthedocs.io/en/latest/index.html
 
 [link_issues]: https://github.com/ME-ICA/tedana/issues
 [link_milestones]: https://github.com/ME-ICA/tedana/milestones/
 [link_project_boards]: https://github.com/ME-ICA/tedana/projects
 [link_gitter]: https://gitter.im/me-ica/tedana
-[link_coc]: https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md
+[link_coc]: https://github.com/ME-ICA/tedana/blob/main/CODE_OF_CONDUCT.md
 [link_stale-bot]: https://github.com/probot/stale
 
 [link_labels]: https://github.com/ME-ICA/tedana/labels

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,7 +323,7 @@ You're awesome. :wave::smiley:
 [writing_formatting_github]: https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github
 [markdown]: https://daringfireball.net/projects/markdown
 [rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
-[restructuredtext]: http://www.sphinx-doc.org/en/main/usage/restructuredtext/index.html
+[restructuredtext]: http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 [sphinx]: http://www.sphinx-doc.org/en/master/index.html
 [readthedocs]: https://docs.readthedocs.io/en/latest/index.html
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ multi-echo functional magnetic resonance imaging (fMRI) data.
 [![License](https://img.shields.io/badge/License-LGPL%202.0-blue.svg)](https://opensource.org/licenses/LGPL-2.1)
 [![CircleCI](https://circleci.com/gh/ME-ICA/tedana.svg?style=shield)](https://circleci.com/gh/ME-ICA/tedana)
 [![Documentation Status](https://readthedocs.org/projects/tedana/badge/?version=latest)](http://tedana.readthedocs.io/en/latest/?badge=latest)
-[![Codecov](https://codecov.io/gh/me-ica/tedana/branch/master/graph/badge.svg)](https://codecov.io/gh/me-ica/tedana)
+[![Codecov](https://codecov.io/gh/me-ica/tedana/branch/main/graph/badge.svg)](https://codecov.io/gh/me-ica/tedana)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/ME-ICA/tedana.svg)](http://isitmaintained.com/project/ME-ICA/tedana "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/ME-ICA/tedana.svg)](http://isitmaintained.com/project/ME-ICA/tedana "Percentage of issues still open")
 [![Join the chat at https://gitter.im/ME-ICA/tedana](https://badges.gitter.im/ME-ICA/tedana.svg)](https://gitter.im/ME-ICA/tedana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -75,12 +75,12 @@ You can read more about managing conda environments and this discrepancy [here](
 
 ### Use and contribute to `tedana` as a developer
 
-If you aim to contribute to the `tedana` code base and/or documentation, please first read the developer installation instructions in [our contributing section](https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md). You can then continue to set up your preferred development environment.
+If you aim to contribute to the `tedana` code base and/or documentation, please first read the developer installation instructions in [our contributing section](https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md). You can then continue to set up your preferred development environment.
 
 ## Getting involved
 
 We :yellow_heart: new contributors!
-To get started, check out [our contributing guidelines](https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md)
+To get started, check out [our contributing guidelines](https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md)
 and our [developer's guide](https://tedana.readthedocs.io/en/latest/developing.html).
 
 Want to learn more about our plans for developing ``tedana``?
@@ -93,7 +93,7 @@ We will be happy to help you find somewhere to get started.
 If you don't want to get lots of notifications, we send out newsletters approximately once per month though our TinyLetter mailing list.
 You can view the [previous newsletters](https://tinyletter.com/tedana-devs/archive) and/or sign up to receive future ones at [https://tinyletter.com/tedana-devs](https://tinyletter.com/tedana-devs).
 
-We ask that all contributors to ``tedana`` across all project-related spaces (including but not limited to: GitHub, Gitter, and project emails), adhere to our [code of conduct](https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md).
+We ask that all contributors to ``tedana`` across all project-related spaces (including but not limited to: GitHub, Gitter, and project emails), adhere to our [code of conduct](https://github.com/ME-ICA/tedana/blob/main/CODE_OF_CONDUCT.md).
 
 ## Contributors
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,7 +6,7 @@ with a focus on project governance and development philosophy.
 For a more practical guide to the tedana development, please see our
 `contributing guide`_.
 
-.. _contributing guide: https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md
+.. _contributing guide: https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md
 
 Code of conduct
 ```````````````
@@ -19,7 +19,7 @@ in-person workshops or development sprints, and when giving talks about the soft
 As stated in the code, severe or repeated violations by community members may result in exclusion
 from collective decision-making and rejection of future contributions to the ``tedana`` project.
 
-.. _The full code of conduct is here: https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md
+.. _The full code of conduct is here: https://github.com/ME-ICA/tedana/blob/main/CODE_OF_CONDUCT.md
 
 Scope of tedana
 ```````````````
@@ -172,7 +172,7 @@ options within the existing framework, but we have chosen to focus on `the 80 pe
 You can provide feedback on this philosophy through any of the channels
 listed on the ``tedana`` :ref:`support_ref` page.
 
-.. _an LGPL2 license: https://github.com/ME-ICA/tedana/blob/master/LICENSE
+.. _an LGPL2 license: https://github.com/ME-ICA/tedana/blob/main/LICENSE
 .. _the 80 percent use cases: https://en.wikipedia.org/wiki/Pareto_principle#In_software
 
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -111,7 +111,7 @@ Worked Example
 Suppose we want to add a function in ``tedana`` that creates a file called ```hello_world.txt`` to
 be stored along the outputs of the ``tedana`` workflow.
 
-First, we merge the repository's ``master`` branch into our own to make sure we're up to date, and
+First, we merge the repository's ``main`` branch into our own to make sure we're up to date, and
 then we make a new branch called something like ``feature/say_hello``.
 Any changes we make will stay on this branch.
 We make the new function and call it ``say_hello`` and locate this function inside of ``io.py``.
@@ -143,13 +143,13 @@ If not, we should continue editing the function until it passes our test.
 Let's suppose that suddenly, you realize that what would be even more useful is a function that
 takes an argument, ``place``, so that the output filename is actually ``hello_PLACE``, with
 ``PLACE`` the value passed and ``'world'`` as the default value.
-We merge any changes from the upstream master branch into our branch via
+We merge any changes from the upstream main branch into our branch via
 
 .. code-block:: bash
 
     git checkout feature/say_hello
-    git fetch upstream master
-    git merge upstream/master
+    git fetch upstream main
+    git merge upstream/main
 
 and then begin work on our test.
 We need to our unit test to be more complete, so we update it to look more like the following,
@@ -199,9 +199,9 @@ We should then do the following cleanup with our git repository:
 
 .. code-block:: bash
 
-    git checkout master
-    git fetch upstream master
-    git merge upstream/master
+    git checkout main
+    git fetch upstream main
+    git merge upstream/main
     git branch -d feature/say_hello
     git push --delete origin feature/say_hello
 
@@ -218,10 +218,10 @@ and we're good to go!
 .. _`GitHub Desktop`: https://desktop.github.com/
 .. _SourceTree: https://www.sourcetreeapp.com/
 .. _`GitHub UI`: https://help.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository
-.. _this: https://github.com/ME-ICA/tedana/tree/master/docs
+.. _this: https://github.com/ME-ICA/tedana/tree/main/docs
 .. _ReStructuredText: http://docutils.sourceforge.net/rst.html#user-documentation
 .. _`five echo set`: https://github.com/ME-ICA/tedana/blob/37368f802f77b4327fc8d3f788296ca0f01074fd/tedana/tests/test_integration.py#L71-L95
 .. _here: https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci
 .. _`getting one`: https://circleci.com/docs/2.0/managing-api-tokens/?gclid=CjwKCAiAqqTuBRBAEiwA7B66heDkdw6l68GAYAHtR2xS1xvDNNUzy7l1fmtwQWvVN0OIa97QL8yfhhoCejoQAvD_BwE#creating-a-personal-api-token
 .. _`google calendar`: https://calendar.google.com/calendar/embed?src=pl6vb4t9fck3k6mdo2mok53iss%40group.calendar.google.com
-.. _`contributing guide`: https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md
+.. _`contributing guide`: https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md

--- a/docs/governance.rst
+++ b/docs/governance.rst
@@ -296,7 +296,7 @@ The outcome of a vote is based on a simple majority.
 .. _Joshua Teves: https://github.com/jbteves
 .. _Eneko Uruñuela: https://github.com/eurunuela
 .. _Kirstie Whitaker: https://github.com/KirstieJane
-.. _code of conduct: https://github.com/ME-ICA/tedana/blob/master/CODE_OF_CONDUCT.md
-.. _all-contributors file: https://github.com/ME-ICA/tedana/blob/master/.all-contributorsrc
+.. _code of conduct: https://github.com/ME-ICA/tedana/blob/main/CODE_OF_CONDUCT.md
+.. _all-contributors file: https://github.com/ME-ICA/tedana/blob/main/.all-contributorsrc
 .. _bus factor: https://en.wikipedia.org/wiki/Bus_factor
 .. _Repository: https://github.com/ME-ICA/tedana>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ multi-echo functional magnetic resonance imaging (fMRI) data.
    :target: http://tedana.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/me-ica/tedana/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/me-ica/tedana/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/me-ica/tedana
    :alt: Codecov
 

--- a/docs/sphinxext/github_link.py
+++ b/docs/sphinxext/github_link.py
@@ -1,6 +1,6 @@
 """
 This script comes from scikit-learn:
-https://github.com/scikit-learn/scikit-learn/blob/master/doc/sphinxext/github_link.py
+https://github.com/scikit-learn/scikit-learn/blob/main/doc/sphinxext/github_link.py
 """
 from operator import attrgetter
 import inspect

--- a/tedana/due.py
+++ b/tedana/due.py
@@ -10,7 +10,7 @@ Note that it might be better to avoid naming it duecredit.py to avoid shadowing
 installed duecredit.
 Then use in your code as
     from .due import due, Doi, BibTeX
-See  https://github.com/duecredit/duecredit/blob/main/README.md for examples.
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
 Origin:     Originally a part of the duecredit
 Copyright:  2015-2016  DueCredit developers
 License:    BSD-2

--- a/tedana/due.py
+++ b/tedana/due.py
@@ -10,7 +10,7 @@ Note that it might be better to avoid naming it duecredit.py to avoid shadowing
 installed duecredit.
 Then use in your code as
     from .due import due, Doi, BibTeX
-See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+See  https://github.com/duecredit/duecredit/blob/main/README.md for examples.
 Origin:     Originally a part of the duecredit
 Copyright:  2015-2016  DueCredit developers
 License:    BSD-2


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Addresses but does not close #619 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Switch `master` to `main` where applicable
-

NOTE: due to versioneer and the document doc tree, there are some references to `master` that cannot be changed from my read. All examples below:
```
docs/conf.py:67:# The master toctree document.
docs/conf.py:68:master_doc = 'index'
docs/governance.rst:184:`decision-making rules for the BIDS standard <https://github.com/bids-standard/bids-specification/blob/master/DECISION-MAKING.md>`_,
tedana/_version.py:192:        # "stabilization", as well as "HEAD" and "master".
versioneer.py:18:(https://travis-ci.org/warner/python-versioneer.png?branch=master)
versioneer.py:179:  "master" and "slave" subprojects, each with their own `setup.py`,
versioneer.py:612:        # "stabilization", as well as "HEAD" and "master".
versioneer.py:1004:        # "stabilization", as well as "HEAD" and "master".
```