### PR TITLE
Move long description logic from info.py to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def main():
     root_dir = op.dirname(op.abspath(getfile(currentframe())))
 
     with open(op.join(root_dir, 'README.md'), encoding='utf-8') as f:
-            long_description = f.read()
+        long_description = f.read()
 
     version = None
     cmdclass = {}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def main():
         __maintainer__,
         __license__,
         __description__,
-        __longdesc__,
+        #__longdesc__,
         __url__,
         DOWNLOAD_URL,
         CLASSIFIERS,
@@ -27,6 +27,9 @@ def main():
         EXTRA_REQUIRES,
         PYTHON_REQUIRES
     )
+    this_directory = op.abspath(op.dirname(__file__))
+    with open(op.join(this_directory, 'README.md'), encoding='utf-8') as f:
+            __longdesc__ = f.read()
 
     pkg_data = {
         'tedana': [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ def main():
         __maintainer__,
         __license__,
         __description__,
-        #__longdesc__,
         __url__,
         DOWNLOAD_URL,
         CLASSIFIERS,
@@ -27,9 +26,6 @@ def main():
         EXTRA_REQUIRES,
         PYTHON_REQUIRES
     )
-    this_directory = op.abspath(op.dirname(__file__))
-    with open(op.join(this_directory, 'README.md'), encoding='utf-8') as f:
-            __longdesc__ = f.read()
 
     pkg_data = {
         'tedana': [
@@ -40,6 +36,9 @@ def main():
     }
 
     root_dir = op.dirname(op.abspath(getfile(currentframe())))
+
+    with open(op.join(root_dir, 'README.md'), encoding='utf-8') as f:
+            long_description = f.read()
 
     version = None
     cmdclass = {}
@@ -56,7 +55,7 @@ def main():
         name=__packagename__,
         version=__version__,
         description=__description__,
-        long_description=__longdesc__,
+        long_description=long_description,
         author=__author__,
         author_email=__email__,
         maintainer=__maintainer__,

--- a/tedana/__init__.py
+++ b/tedana/__init__.py
@@ -19,7 +19,6 @@ from .info import (
     __url__,
     __packagename__,
     __description__,
-#    __longdesc__
 )
 
 import warnings

--- a/tedana/__init__.py
+++ b/tedana/__init__.py
@@ -19,7 +19,7 @@ from .info import (
     __url__,
     __packagename__,
     __description__,
-    __longdesc__
+#    __longdesc__
 )
 
 import warnings

--- a/tedana/info.py
+++ b/tedana/info.py
@@ -23,7 +23,7 @@ __url__ = 'https://github.com/me-ica/tedana'
 __packagename__ = 'tedana'
 __description__ = ('TE-Dependent Analysis (tedana) of multi-echo functional '
                    'magnetic resonance imaging (fMRI) data.')
-__longdesc__ = readme_path.open().read()
+# __longdesc__ = readme_path.open().read()
 
 DOWNLOAD_URL = (
     'https://github.com/ME-ICA/{name}/archive/{ver}.tar.gz'.format(

--- a/tedana/info.py
+++ b/tedana/info.py
@@ -23,7 +23,6 @@ __url__ = 'https://github.com/me-ica/tedana'
 __packagename__ = 'tedana'
 __description__ = ('TE-Dependent Analysis (tedana) of multi-echo functional '
                    'magnetic resonance imaging (fMRI) data.')
-# __longdesc__ = readme_path.open().read()
 
 DOWNLOAD_URL = (
     'https://github.com/ME-ICA/{name}/archive/{ver}.tar.gz'.format(

--- a/tedana/info.py
+++ b/tedana/info.py
@@ -4,8 +4,6 @@
 """
 Base module variables
 """
-from pathlib import Path
-readme_path = Path(__file__).parent.parent.joinpath("README.md")
 
 from ._version import get_versions
 __version__ = get_versions()['version']


### PR DESCRIPTION
References #668 

The `README.md` file is used as the module's long description. The relevant code is defined in `tedana/info.py`. This causes an error when importing the module because it tries to load the readme file, but the readme file does not get copied over once the module is installed

This PR moves the relevant code to `setup.py` so that the readme file is only read when the module is first being installed. This should get rid of the error. Remains to be seen if the long description will correctly show up on pypi. 
