### PR TITLE
[MAINT] Support Windows' paths; Update zenodo & contributor count

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,6 +4,11 @@
             "name": "The tedana Community"
         },
         {
+            "name": "Ahmed, Zaki",
+            "affiliation": "Mayo Clinic",
+            "orcid": "0000-0001-5648-0590"
+        },
+        {
             "name": "Bandettini, Peter A.",
             "affiliation": "National Institutes of Health",
             "orcid": "0000-0001-9038-4746"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ multi-echo functional magnetic resonance imaging (fMRI) data.
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/ME-ICA/tedana.svg)](http://isitmaintained.com/project/ME-ICA/tedana "Percentage of issues still open")
 [![Join the chat at https://gitter.im/ME-ICA/tedana](https://badges.gitter.im/ME-ICA/tedana.svg)](https://gitter.im/ME-ICA/tedana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join our tinyletter mailing list](https://img.shields.io/badge/receive-our%20newsletter%20❤%EF%B8%8F-blueviolet.svg)](https://tinyletter.com/tedana-devs)
-[![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square)](#contributors)
 
 
 ## About

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -49,6 +49,7 @@ def check_integration_outputs(fname, outpath):
     # Compares remaining files with those expected
     with open(fname, 'r') as f:
         tocheck = f.read().splitlines()
+    tocheck = [os.path.normpath(path) for path in tocheck]
     assert sorted(tocheck) == sorted(existing)
 
 


### PR DESCRIPTION
Closes None.

Few small changes:

- Use platform-specific path when comparing output files in integration tests
  + This was causing tests on Windows to fails because it expects `paths\like\this` instead of `/like/that`
- Updated the number of contributors on the readme badge
  + There is a [configuration option](https://github.com/all-contributors/all-contributors/blob/master/docs/bot/configuration.md) which might automatically do this
  + Looks like there is a mismatch in the number of total contributors between all-contributors and [github's contributor list](https://github.com/ME-ICA/tedana/graphs/contributors). I went with number of all-contributors.
- Added myself to `.zenodo.json`
  + Should this follow the order in the planned JOSS paper? That might be better for consistency, but that means getting rid of `The tedana Community` and bit of shuffling
  + There is also [`info/__credits__`](https://github.com/ME-ICA/tedana/blob/14be8520da0ba577c130c56d0835c55321cd0aed/tedana/info.py#L14-L15) which is out of sync and could be removed to simplify maintenance

The full test suite passed on windows, mac, and ubuntu with Python 3.7-3.9 [[log]](https://github.com/notZaki/tedana/actions/runs/535359775) 
