### PR TITLE
[ENH] Match BokehJS with BokehPy version

### DIFF
--- a/tedana/reporting/data/html/report_head_template.html
+++ b/tedana/reporting/data/html/report_head_template.html
@@ -4,11 +4,11 @@
 <head>
 <title>tedana report</title>
 <meta name="viewport" content="width = device-width, initial-scale = 1" charset="UTF-8">
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.1.min.js"
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-$bokehversion.min.js"
         crossorigin="anonymous"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.1.min.js"
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-$bokehversion.min.js"
         crossorigin="anonymous"></script>
-<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.1.min.js"
+<script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-$bokehversion.min.js"
         crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.1/build/pure-min.css"
     integrity="sha384-oAOxQR6DkCoMliIh8yFnu25d7Eq/PHS21PClpwjOTeU2jRSq11vu66rf90/cZr47" crossorigin="anonymous">

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from bokeh import (embed, layouts, models)
+from bokeh import __version__ as bokehversion
 from pathlib import Path
 from os.path import join as opj
 from string import Template
@@ -50,7 +51,7 @@ def _save_as_html(body):
     with open(str(head_template_path), 'r') as head_file:
         head_tpl = Template(head_file.read())
 
-    html = head_tpl.substitute(version=__version__, body=body)
+    html = head_tpl.substitute(version=__version__, bokehversion=bokehversion, body=body)
     return html
 
 


### PR DESCRIPTION
Closes none.

Context: There are two bokeh libraries: one is in python, the other in javascript. Ideally, they should both be the same version. Currently, the javascript version is pinned at 2.0.1 in the html report. This can create a conflict if the user has a different python version of bokeh.

Changes proposed in this pull request:

- Dynamically set the javascript version of bokeh to match the python version
