### PR TITLE
[FIX] Enable normalization in mapca call

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -207,7 +207,7 @@ def tedpca(data_cat, data_oc, combmode, mask, adaptive_mask, t2sG,
         data_img = io.new_nii_like(ref_img, utils.unmask(data, mask))
         mask_img = io.new_nii_like(ref_img, mask.astype(int))
         voxel_comp_weights, varex, varex_norm, comp_ts = ma_pca(
-            data_img, mask_img, algorithm)
+            data_img, mask_img, algorithm, normalize=True)
     elif isinstance(algorithm, Number):
         ppca = PCA(copy=False, n_components=algorithm, svd_solver="full")
         ppca.fit(data_z)


### PR DESCRIPTION
Closes none.

The results for the three-echo test changed when the `mapca` library was added:

- [before](https://13314-110845855-gh.circle-artifacts.com/0/tmp/data/three-echo/TED.three-echo/tedana_report.html)
- [after](https://13347-110845855-gh.circle-artifacts.com/0/tmp/data/three-echo/TED.three-echo/tedana_report.html)
- EDIT: [this PR](https://13446-110845855-gh.circle-artifacts.com/0/tmp/data/three-echo/TED.three-echo/tedana_report.html)

This might be because the data is no longer being normalized. This PR sets `normalize=True` when calling `ma_pca`, and hopefully that should match the old results.
