### PR TITLE
[FIX] Calculate Kappa and Rho on full F-statistic maps

### DIFF
--- a/tedana/metrics/kundu_fit.py
+++ b/tedana/metrics/kundu_fit.py
@@ -199,8 +199,8 @@ def dependence_metrics(catd, tsoc, mmix, adaptive_mask, tes, ref_img,
         F_S0[F_S0 > F_MAX] = F_MAX
         F_R2[F_R2 > F_MAX] = F_MAX
         norm_weights = np.abs(wtsZ ** 2.)
-        kappas[i_comp] = np.average(F_R2, weights=norm_weights)
-        rhos[i_comp] = np.average(F_S0, weights=norm_weights)
+        kappas[i_comp] = np.average(F_R2_maps[:, i_comp], weights=norm_weights)
+        rhos[i_comp] = np.average(F_S0_maps[:, i_comp], weights=norm_weights)
     del SSE_S0, SSE_R2, wtsZ, F_S0, F_R2, norm_weights, comp_betas
     if algorithm != 'kundu_v3':
         del WTS, PSC, tsoc_B

--- a/tedana/tests/data/fiu_four_echo_outputs.txt
+++ b/tedana/tests/data/fiu_four_echo_outputs.txt
@@ -70,9 +70,3 @@ figures/comp_017.png
 figures/comp_018.png
 figures/comp_019.png
 figures/comp_020.png
-figures/comp_021.png
-figures/comp_022.png
-figures/comp_023.png
-figures/comp_024.png
-figures/comp_025.png
-figures/comp_026.png

--- a/tedana/tests/data/fiu_four_echo_outputs.txt
+++ b/tedana/tests/data/fiu_four_echo_outputs.txt
@@ -70,3 +70,9 @@ figures/comp_017.png
 figures/comp_018.png
 figures/comp_019.png
 figures/comp_020.png
+figures/comp_021.png
+figures/comp_022.png
+figures/comp_023.png
+figures/comp_024.png
+figures/comp_025.png
+figures/comp_026.png


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #713, which was probably introduced in #358.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Calculate Rho and Kappa from the F-statistic maps compiled across adaptive mask values, instead of maps where only voxels where adaptive mask == number of echoes are filled in.
