### PR TITLE
[REF] Eliminate component sorting from metric calculation

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -236,7 +236,7 @@ def tedpca(data_cat, data_oc, combmode, mask, adaptive_mask, t2sG,
     comptable, _ = metrics.collect.generate_metrics(
         data_cat, data_oc, comp_ts, adaptive_mask,
         tes, io_generator, 'PCA',
-        metrics=required_metrics, sort_by=None
+        metrics=required_metrics,
     )
 
     # varex_norm from PCA overrides varex_norm from dependence_metrics,

--- a/tedana/metrics/_utils.py
+++ b/tedana/metrics/_utils.py
@@ -109,44 +109,6 @@ def flip_components(*args, signs):
     return [arg * signs for arg in args]
 
 
-def sort_df(df, by="kappa", ascending=False):
-    """Sort DataFrame and get index.
-
-    Parameters
-    ----------
-    df : :obj:`pandas.DataFrame`
-        DataFrame to sort.
-    by : :obj:`str` or None, optional
-        Column by which to sort the DataFrame. Default is 'kappa'.
-    ascending : :obj:`bool`, optional
-        Whether to sort the DataFrame in ascending (True) or descending (False)
-        order. Default is False.
-
-    Returns
-    -------
-    df : :obj:`pandas.DataFrame`
-        DataFrame after sorting, with index resetted.
-    argsort : array_like
-        Sorting index.
-    """
-    if by is None:
-        return df, df.index.values
-
-    # Order of kwargs is preserved at 3.6+
-    argsort = df[by].argsort()
-    if not ascending:
-        argsort = argsort[::-1]
-    df = df.loc[argsort].reset_index(drop=True)
-    return df, argsort
-
-
-def apply_sort(*args, sort_idx, axis=0):
-    """Apply a sorting index to an arbitrary set of arrays."""
-    for arg in args:
-        assert arg.shape[axis] == len(sort_idx)
-    return [np.take(arg, sort_idx, axis=axis) for arg in args]
-
-
 def check_mask(data, mask):
     """Check that no zero-variance voxels remain in masked data.
 

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -6,13 +6,7 @@ import numpy as np
 import pandas as pd
 
 from . import dependence
-from ._utils import (
-    determine_signs,
-    flip_components,
-    sort_df,
-    apply_sort,
-    dependency_resolver,
-)
+from ._utils import determine_signs, flip_components, dependency_resolver
 
 from tedana import io
 from tedana import utils
@@ -33,8 +27,6 @@ def generate_metrics(
     io_generator,
     label,
     metrics=None,
-    sort_by="kappa",
-    ascending=False,
 ):
     """Fit TE-dependence and -independence models to components.
 
@@ -60,11 +52,6 @@ def generate_metrics(
         The label for this metric generation type
     metrics : list
         List of metrics to return
-    sort_by : str, optional
-        Metric to sort component table by. Default is 'kappa'.
-    ascending : bool, optional
-        Whether to sort the table in ascending or descending order.
-        Default is False.
 
     Returns
     -------
@@ -339,10 +326,6 @@ def generate_metrics(
             comptable["countnoise"],
             comptable["countsigFT2"],
         )
-
-    # Sort the component table and mixing matrix
-    comptable, sort_idx = sort_df(comptable, by=sort_by, ascending=ascending)
-    (mixing,) = apply_sort(mixing, sort_idx=sort_idx, axis=1)
 
     # Write verbose metrics if needed
     if io_generator.verbose:

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -59,7 +59,7 @@ def generate_metrics(
         Component metric table. One row for each component, with a column for
         each metric. The index is the component number.
     mixing : :obj:`numpy.ndarray`
-        Mixing matrix after sign flipping and sorting.
+        Mixing matrix after sign flipping.
     """
     # Load metric dependency tree from json file
     dependency_config = op.join(utils.get_resource_path(), "config", "metrics.json")

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -57,8 +57,6 @@ def test_smoke_generate_metrics(testdata1):
         testdata1["generator"],
         'ICA',
         metrics=metrics,
-        sort_by="kappa",
-        ascending=False,
     )
     assert isinstance(comptable, pd.DataFrame)
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -635,8 +635,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     decomp_metadata = {
         "Method": (
             "Independent components analysis with FastICA "
-            "algorithm implemented by sklearn. Components "
-            "are sorted by Kappa in descending order. "
+            "algorithm implemented by sklearn. "
             "Component signs are flipped to best match the "
             "data."
         ),

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -570,7 +570,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             comptable, mmix = metrics.collect.generate_metrics(
                 catd, data_oc, mmix_orig, masksum, tes,
                 io_generator, 'ICA',
-                metrics=required_metrics, sort_by='kappa', ascending=False,
+                metrics=required_metrics,
             )
             comptable, metric_metadata = selection.kundu_selection_v2(
                 comptable, n_echos, n_vols
@@ -599,7 +599,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             comptable, mmix = metrics.collect.generate_metrics(
                 catd, data_oc, mmix_orig, masksum, tes,
                 io_generator, 'ICA',
-                metrics=required_metrics, sort_by='kappa', ascending=False
+                metrics=required_metrics,
             )
             comptable, metric_metadata = selection.kundu_selection_v2(
                     comptable, n_echos, n_vols


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #564.

**NOTE**: While the proposed changes do affect the order of rows in the component table and the mixing matrix, they should not impact the actual classifications at all.

I have one question- should we also eliminate the component flipping step? I'm thinking specifically that we could (1) keep components with the same signs in our outputs, but (2) add a new "flip" column to the metrics TSV indicating if the component was flipped prior to calculating metrics. Then, the mixing matrix would not be changed at all by `tedana`, but the results would be the same. The only things that would change would be the saved weight maps and the signs of the maps in the report. We could even use the "flip" column in the report figure generation to retain the preferred signs.

To do:

- [x] Resolve sign-flipping question
    - Opened #748.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove the functions `metrics._utils.sort_df()` and `metrics._utils.apply_sort()`.
- Remove `sort_by` and `ascending` parameters from `metrics.collect.generate_metrics()`.
- Update docstrings and metadata to reflect that components are not re-sorted.
