### PR TITLE
[DOC] Update resource page with dataset and link to Dash app visualizations

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -107,12 +107,29 @@ This list is not necessarily up to date, so please check out OpenNeuro to potent
 
 Publications using multi-echo fMRI
 ----------------------------------
-You can view and suggest additions to this spreadsheet `here`_
-This is a volunteer-led effort so, if you know of a excluded publication, whether or not it is yours,
-please add it.
+The sheet at the bottom of this page contains an extensive list of multi-echo
+fMRI publications. You can view and suggest additions to this spreadsheet `here`_.
+This is a volunteer-led effort so, if you know of a excluded publication,
+whether or not it is yours, please add it.
+
+.. _here: https://docs.google.com/spreadsheets/d/1WERojJyxFoqcg_tndUm5Kj0H1UfUc9Ban0jFGGfPaBk/edit#gid=0
+
+
+Interactive visualizations of publications and parameters
+---------------------------------------------------------
+
+You can explore interactive and accessible information about multi-echo
+studies from the list of publications below, their study design parameters,
+and MRI sequence parameter options using `this web application`_. If you'd
+like to add more studies, parameters or visualization options to the
+application, feel free to create an issue or send a pull request on the
+application's `GitHub repository`_.
+
+.. _this web application: https://me-fmri-overview.herokuapp.com/
+.. _GitHub repository: https://github.com/jsheunis/me-fmri-overview
+
+------------
 
 .. raw:: html
 
-    <iframe style="position: absolute; height: 60%; width: 60%; border: none" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vS0nEVp27NpwdzPunvMLflyKzcZbCo4k2qPk5zxEiaoJTD_IY1OGbWICizogAEZlTyL7d_7aDA92uwf/pubhtml?widget=true&amp;headers=false"></iframe>
-
-.. _here: https://docs.google.com/spreadsheets/d/1WERojJyxFoqcg_tndUm5Kj0H1UfUc9Ban0jFGGfPaBk/edit#gid=0
+  <iframe style="position: absolute; height: 60%; width: 60%; border: none" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vS0nEVp27NpwdzPunvMLflyKzcZbCo4k2qPk5zxEiaoJTD_IY1OGbWICizogAEZlTyL7d_7aDA92uwf/pubhtml?widget=true&amp;headers=false"></iframe>

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -96,12 +96,14 @@ This list is not necessarily up to date, so please check out OpenNeuro to potent
 * `Multiband multi-echo imaging of simultaneous oxygenation and flow timeseries for resting state connectivity`_
 * `Valence processing differs across stimulus modalities`_
 * `Cambridge Centre for Ageing Neuroscience (Cam-CAN)`_
+* `rt-me-fMRI - A task and resting state dataset for real-time, multi-echo fMRI methods development and validation`_
 
 .. _Multi-echo fMRI replication sample of autobiographical memory, prospection and theory of mind reasoning tasks: https://openneuro.org/datasets/ds000210/
 .. _Multi-echo Cambridge: https://openneuro.org/datasets/ds000258
 .. _Multiband multi-echo imaging of simultaneous oxygenation and flow timeseries for resting state connectivity: https://openneuro.org/datasets/ds000254
 .. _Valence processing differs across stimulus modalities: https://openneuro.org/datasets/ds001491
 .. _Cambridge Centre for Ageing Neuroscience (Cam-CAN): https://camcan-archive.mrc-cbu.cam.ac.uk/dataaccess/
+.. _rt-me-fMRI - A task and resting state dataset for real-time, multi-echo fMRI methods development and validation: https://doi.org/10.34894/R1TNL8
 
 .. _spreadsheet of publications:
 


### PR DESCRIPTION
Addresses #552 and closes #633.

Changes proposed in this pull request:

- Added a new section to the resource page to introduce and link to the Dash app for visualizing study parameters and MRI sequence parameters. NOTE: when adding a new section below the iframe for the google sheet, this section wouldn't render when building locally. To circumvent this, I added the new section above the iframe, and updated the reference to the sheet in the "Publications using multi-echo fMRI" section, to point to it being at the bottom of the page. If anyone feels there's a more intuitive way of ordering these sections and iframe on the resource page, feel free to update.
- Added the `rt-me-fMRI` dataset link to the list of open datasets.
