### PR TITLE
[ENH] Coerce images to 32-bit

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -214,6 +214,10 @@ class OutputGenerator():
             Data to save to a file.
         name : str
             Full file path for output file.
+
+        Notes
+        -----
+        Will coerce 64-bit float and int arrays into 32-bit arrays.
         """
         data_type = type(data)
         if not isinstance(data, np.ndarray):
@@ -225,6 +229,14 @@ class OutputGenerator():
                 "Data must have number of dimensions in (1, 2), not "
                 f"{data.ndim}"
             )
+        # Coerce data to be 32-bit max in the cases of float64, int64
+        # Note that int64 niftis cannot be read by mricroGL, AFNI
+        vox_type = data.dtype
+        if vox_type == np.int64:
+            data = np.int32(data)
+        elif vox_type == np.float64:
+            data = np.float32(data)
+        # Make new img and save
         img = new_nii_like(self.reference_img, data)
         img.to_filename(name)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #757  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Downscales 64-bit float, int arrays to 32-bit arrays just before image save
- Adds some notes to the `io.save_img` docstring
