### PR TITLE
[FIX] Ignore non-significant kappa elbow when no non-significant kappa values exist

### DIFF
--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -45,9 +45,11 @@ def getelbow_cons(arr, return_val=False):
     if not arr.size:
         raise ValueError(
             "Empty array detected during elbow calculation. "
-            "The cause behind this failure is not currently known, so please open an issue at "
+            "This error happens when getelbow_cons is incorrectly called on no components. "
+            "If you see this message, please open an issue at "
             "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
-            "necessary to reproduce this error."
+            "necessary to reproduce this error, so that we create additional data checks to "
+            "prevent this from happening."
         )
 
     arr = np.sort(arr)[::-1]
@@ -92,9 +94,11 @@ def getelbow(arr, return_val=False):
     if not arr.size:
         raise ValueError(
             "Empty array detected during elbow calculation. "
-            "The cause behind this failure is not currently known, so please open an issue at "
+            "This error happens when getelbow is incorrectly called on no components. "
+            "If you see this message, please open an issue at "
             "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
-            "necessary to reproduce this error."
+            "necessary to reproduce this error, so that we create additional data checks to "
+            "prevent this from happening."
         )
 
     arr = np.sort(arr)[::-1]

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -41,6 +41,13 @@ def getelbow_cons(arr, return_val=False):
     """
     if arr.ndim != 1:
         raise ValueError('Parameter arr should be 1d, not {0}d'.format(arr.ndim))
+
+    if not arr.size:
+        raise ValueError(
+            "Empty array detected. This is often a random error, so consider re-running tedana "
+            "with a different random seed."
+        )
+
     arr = np.sort(arr)[::-1]
     nk = len(arr)
     temp1 = [(arr[nk - 5 - ii - 1] > arr[nk - 5 - ii:nk].mean() + 2 * arr[nk - 5 - ii:nk].std())
@@ -79,6 +86,13 @@ def getelbow(arr, return_val=False):
     """
     if arr.ndim != 1:
         raise ValueError('Parameter arr should be 1d, not {0}d'.format(arr.ndim))
+
+    if not arr.size:
+        raise ValueError(
+            "Empty array detected. This is often a random error, so consider re-running tedana "
+            "with a different random seed."
+        )
+
     arr = np.sort(arr)[::-1]
     n_components = arr.shape[0]
     coords = np.array([np.arange(n_components), arr])

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -44,8 +44,10 @@ def getelbow_cons(arr, return_val=False):
 
     if not arr.size:
         raise ValueError(
-            "Empty array detected. This is often a random error, so consider re-running tedana "
-            "with a different random seed."
+            "Empty array detected during elbow calculation. "
+            "The cause behind this failure is not currently known, so please open an issue at "
+            "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
+            "necessary to reproduce this error."
         )
 
     arr = np.sort(arr)[::-1]
@@ -89,8 +91,10 @@ def getelbow(arr, return_val=False):
 
     if not arr.size:
         raise ValueError(
-            "Empty array detected. This is often a random error, so consider re-running tedana "
-            "with a different random seed."
+            "Empty array detected during elbow calculation. "
+            "The cause behind this failure is not currently known, so please open an issue at "
+            "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
+            "necessary to reproduce this error."
         )
 
     arr = np.sort(arr)[::-1]

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -248,7 +248,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     if not kappas_nonsig.size:
         LGR.warning(
             "No nonsignificant kappa values detected. "
-            "Only calculating elbow from all values instead."
+            "Only using elbow calculated from all kappa values."
         )
         kappas_nonsig_elbow = np.nan
     else:

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -246,12 +246,13 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     f05, _, f01 = getfbounds(n_echos)
     kappas_nonsig = comptable.loc[comptable['kappa'] < f01, 'kappa']
     # NOTE: Would an elbow from all Kappa values *ever* be lower than one from
-    # a subset of lower values?
-    kappa_elbow = np.min((getelbow(kappas_nonsig, return_val=True),
-                          getelbow(comptable['kappa'], return_val=True)))
-    rho_elbow = np.mean((getelbow(comptable.loc[ncls, 'rho'], return_val=True),
-                         getelbow(comptable['rho'], return_val=True),
-                         f05))
+    # a subset of lower (i.e., nonsignificant) values?
+    kappas_nonsig_elbow = getelbow(kappas_nonsig, return_val=True)
+    kappas_all_elbow = getelbow(comptable['kappa'], return_val=True)
+    kappa_elbow = np.min((kappas_all_elbow, kappas_nonsig_elbow))
+    rhos_ncls_elbow = getelbow(comptable.loc[ncls, 'rho'], return_val=True)
+    rhos_all_elbow = getelbow(comptable['rho'], return_val=True)
+    rho_elbow = np.mean((rhos_ncls_elbow, rhos_all_elbow, f05))
 
     # Provisionally accept components based on Kappa and Rho elbows
     acc_prov = ncls[(comptable.loc[ncls, 'kappa'] >= kappa_elbow) &

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -245,11 +245,20 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     # Compute elbows from other elbows
     f05, _, f01 = getfbounds(n_echos)
     kappas_nonsig = comptable.loc[comptable['kappa'] < f01, 'kappa']
+    if not kappas_nonsig.size:
+        LGR.warning(
+            "No nonsignificant kappa values detected. "
+            "Only calculating elbow from all values instead."
+        )
+        kappas_nonsig_elbow = np.nan
+    else:
+        kappas_nonsig_elbow = getelbow(kappas_nonsig, return_val=True)
+
+    kappas_all_elbow = getelbow(comptable['kappa'], return_val=True)
+
     # NOTE: Would an elbow from all Kappa values *ever* be lower than one from
     # a subset of lower (i.e., nonsignificant) values?
-    kappas_nonsig_elbow = getelbow(kappas_nonsig, return_val=True)
-    kappas_all_elbow = getelbow(comptable['kappa'], return_val=True)
-    kappa_elbow = np.min((kappas_all_elbow, kappas_nonsig_elbow))
+    kappa_elbow = np.nanmin((kappas_all_elbow, kappas_nonsig_elbow))
     rhos_ncls_elbow = getelbow(comptable.loc[ncls, 'rho'], return_val=True)
     rhos_all_elbow = getelbow(comptable['rho'], return_val=True)
     rho_elbow = np.mean((rhos_ncls_elbow, rhos_all_elbow, f05))

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -1,0 +1,45 @@
+"""Tests for the tedana.selection._utils module."""
+import numpy as np
+import pytest
+
+from tedana.selection import _utils
+
+
+def test_getelbow_smoke():
+    """A smoke test for the getelbow function."""
+    arr = np.random.random(100)
+    idx = _utils.getelbow(arr)
+    assert isinstance(idx, np.integer)
+
+    val = _utils.getelbow(arr, return_val=True)
+    assert isinstance(val, float)
+
+    # Running an empty array should raise a ValueError
+    arr = np.array([])
+    with pytest.raises(ValueError):
+        _utils.getelbow(arr)
+
+    # Running a 2D array should raise a ValueError
+    arr = np.random.random((100, 100))
+    with pytest.raises(ValueError):
+        _utils.getelbow(arr)
+
+
+def test_getelbow_cons():
+    """A smoke test for the getelbow_cons function."""
+    arr = np.random.random(100)
+    idx = _utils.getelbow_cons(arr)
+    assert isinstance(idx, np.integer)
+
+    val = _utils.getelbow_cons(arr, return_val=True)
+    assert isinstance(val, float)
+
+    # Running an empty array should raise a ValueError
+    arr = np.array([])
+    with pytest.raises(ValueError):
+        _utils.getelbow_cons(arr)
+
+    # Running a 2D array should raise a ValueError
+    arr = np.random.random((100, 100))
+    with pytest.raises(ValueError):
+        _utils.getelbow_cons(arr)


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #752. In the ICA decision tree, there is a step where two elbows are calculated: one from all kappa values and one from non-significant kappa values. When there are no non-significant kappa values, this step fails.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Ignore the non-significant kappa value-based elbow when there are no non-significant kappa values. Log a warning about this when it comes up.
- For any other cases where `getelbow` or `getelbow_cons` fail, raise a more informative exception and include in that message a request to open an issue here.
- Add new smoke test for `getelbow` and `getelbow_cons`.