### PR TITLE
[FIX] Check data type in `io.load_data`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -217,7 +217,7 @@ API
    tedana.utils.andb
    tedana.utils.dice
    tedana.utils.get_spectrum
-   tedana.utils.load_image
+   tedana.utils.reshape_niimg
    tedana.utils.make_adaptive_mask
    tedana.utils.threshold_map
    tedana.utils.unmask

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -589,14 +589,14 @@ def load_data(data, n_echos=None):
         elif len(data) == 2:  # inviable -- need more than 2 echos
             raise ValueError(f"Cannot run `tedana` with only two echos: {data}")
         else:  # individual echo files were provided (surface or volumetric)
-            fdata = np.stack([utils.load_image(f) for f in data], axis=1)
+            fdata = np.stack([utils.reshape_niimg(f) for f in data], axis=1)
             ref_img = check_niimg(data[0])
             ref_img.header.extensions = []
             return np.atleast_3d(fdata), ref_img
 
     img = check_niimg(data)
     (nx, ny), nz = img.shape[:2], img.shape[2] // n_echos
-    fdata = utils.load_image(img.get_fdata().reshape(nx, ny, nz, n_echos, -1, order="F"))
+    fdata = utils.reshape_niimg(img.get_fdata().reshape(nx, ny, nz, n_echos, -1, order="F"))
     # create reference image
     ref_img = img.__class__(
         np.zeros((nx, ny, nz, 1)), affine=img.affine, header=img.header, extra=img.extra

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -594,6 +594,7 @@ def load_data(data, n_echos=None):
             ref_img.header.extensions = []
             return np.atleast_3d(fdata), ref_img
 
+    # Z-concatenated file/img
     img = check_niimg(data)
     (nx, ny), nz = img.shape[:2], img.shape[2] // n_echos
     fdata = utils.reshape_niimg(img.get_fdata().reshape(nx, ny, nz, n_echos, -1, order="F"))

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -554,38 +554,40 @@ def writeresults_echoes(catd, mmix, mask, comptable, io_generator):
 
 # File Loading Functions
 def load_data(data, n_echos=None):
-    """
-    Coerces input `data` files to required 3D array output
+    """Coerce input `data` files to required 3D array output.
 
     Parameters
     ----------
-    data : (X x Y x M x T) array_like or :obj:`list` of img_like
-        Input multi-echo data array, where `X` and `Y` are spatial dimensions,
-        `M` is the Z-spatial dimensions with all the input echos concatenated,
-        and `T` is time. A list of image-like objects (e.g., .nii) are
-        accepted, as well
+    data : :obj:`list` of img_like, :obj:`list` of :obj:`str`, :obj:`str`, or img_like
+        A list of echo-wise img objects or paths to files.
+        Single img objects or filenames are allowed as well, to support z-concatenated data.
     n_echos : :obj:`int`, optional
-        Number of echos in provided data array. Only necessary if `data` is
-        array_like. Default: None
+        Number of echos in provided data array. Only necessary if `data` is a single,
+        z-concatenated file. Default: None
 
     Returns
     -------
     fdata : (S x E x T) :obj:`numpy.ndarray`
-        Output data where `S` is samples, `E` is echos, and `T` is time
-    ref_img : :obj:`str` or :obj:`numpy.ndarray`
-        Filepath to reference image for saving output files or NIFTI-like array
+        Output data where `S` is samples, `E` is echos, and `T` is time.
+    ref_img : img_like
+        Reference image object for saving output files.
     """
-    if n_echos is None:
+    if n_echos is None and (isinstance(data, str) or len(data) == 1):
         raise ValueError(
-            "Number of echos must be specified. "
-            "Confirm that TE times are provided with the `-e` argument."
+            "Number of echos must be specified when a single z-concatenated file is supplied."
         )
 
-    if isinstance(data, list):
+    if not isinstance(data, (list, str, nib.spatialimages.SpatialImage)):
+        raise TypeError(f"Unsupported type: {type(data)}")
+    elif isinstance(data, list):
+        for item in data:
+            if not isinstance(item, (str, nib.spatialimages.SpatialImage)):
+                raise TypeError(f"Unsupported type: {type(item)}")
+
         if len(data) == 1:  # a z-concatenated file was provided
             data = data[0]
         elif len(data) == 2:  # inviable -- need more than 2 echos
-            raise ValueError("Cannot run `tedana` with only two echos: {}".format(data))
+            raise ValueError(f"Cannot run `tedana` with only two echos: {data}")
         else:  # individual echo files were provided (surface or volumetric)
             fdata = np.stack([utils.load_image(f) for f in data], axis=1)
             ref_img = check_niimg(data[0])

--- a/tedana/tests/test_io.py
+++ b/tedana/tests/test_io.py
@@ -67,6 +67,10 @@ def test_load_data():
     with pytest.raises(TypeError):
         d, ref = me.load_data(fimg_tuple)
 
+    # two echos should raise value error
+    with pytest.raises(ValueError):
+        me.load_data(fnames[:2])
+
     # imagine z-cat img
     d, ref = me.load_data(fnames[0], n_echos=3)
     assert d.shape == (21450, 3, 5)

--- a/tedana/tests/test_io.py
+++ b/tedana/tests/test_io.py
@@ -34,11 +34,38 @@ def test_load_data():
     assert isinstance(ref, nib.Nifti1Image)
     assert np.allclose(ref.get_fdata(), nib.load(fnames[0]).get_fdata())
 
+    # list of filepath to images *without n_echos*
+    d, ref = me.load_data(fnames)
+    assert d.shape == exp_shape
+    assert isinstance(ref, nib.Nifti1Image)
+    assert np.allclose(ref.get_fdata(), nib.load(fnames[0]).get_fdata())
+
     # list of img_like
     d, ref = me.load_data(fimg, n_echos=len(tes))
     assert d.shape == exp_shape
     assert isinstance(ref, nib.Nifti1Image)
     assert ref == fimg[0]
+
+    # list of img_like *without n_echos*
+    d, ref = me.load_data(fimg)
+    assert d.shape == exp_shape
+    assert isinstance(ref, nib.Nifti1Image)
+    assert ref == fimg[0]
+
+    # bad entry
+    fimg_with_bad_item = fimg[:]
+    fimg_with_bad_item[-1] = 5
+    with pytest.raises(TypeError):
+        d, ref = me.load_data(fimg_with_bad_item)
+
+    # unsupported tuple of img_like
+    fimg_tuple = tuple(fimg)
+    with pytest.raises(TypeError):
+        d, ref = me.load_data(fimg_tuple, n_echos=len(tes))
+
+    # tuple of img_like *without n_echos*
+    with pytest.raises(TypeError):
+        d, ref = me.load_data(fimg_tuple)
 
     # imagine z-cat img
     d, ref = me.load_data(fnames[0], n_echos=3)
@@ -46,8 +73,19 @@ def test_load_data():
     assert isinstance(ref, nib.Nifti1Image)
     assert ref.shape == (39, 50, 11, 1)
 
+    # z-cat without n_echos should raise an error
     with pytest.raises(ValueError):
         me.load_data(fnames[0])
+
+    # imagine z-cat img in list
+    d, ref = me.load_data(fnames[:1], n_echos=3)
+    assert d.shape == (21450, 3, 5)
+    assert isinstance(ref, nib.Nifti1Image)
+    assert ref.shape == (39, 50, 11, 1)
+
+    # z-cat in list without n_echos should raise an error
+    with pytest.raises(ValueError):
+        me.load_data(fnames[:1])
 
 
 # SMOKE TESTS

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -64,16 +64,16 @@ def test_andb():
         utils.andb([rs.randint(10, size=(10, 10)), rs.randint(10, size=(20, 20))])
 
 
-def test_load_image():
+def test_reshape_niimg():
     fimg = nib.load(fnames[0])
     exp_shape = (64350, 5)
 
     # load filepath to image
-    assert utils.load_image(fnames[0]).shape == exp_shape
+    assert utils.reshape_niimg(fnames[0]).shape == exp_shape
     # load img_like object
-    assert utils.load_image(fimg).shape == exp_shape
+    assert utils.reshape_niimg(fimg).shape == exp_shape
     # load array
-    assert utils.load_image(fimg.get_fdata()).shape == exp_shape
+    assert utils.reshape_niimg(fimg.get_fdata()).shape == exp_shape
 
 
 def test_make_adaptive_mask():
@@ -104,17 +104,17 @@ def test_make_adaptive_mask():
 # SMOKE TESTS
 
 
-def test_smoke_load_image():
+def test_smoke_reshape_niimg():
     """
-    ensure that load_image returns reasonable objects with random inputs
+    ensure that reshape_niimg returns reasonable objects with random inputs
     in the correct format
-    Note: load_image could take in 3D or 4D array
+    Note: reshape_niimg could take in 3D or 4D array
     """
     data_3d = np.random.random((100, 5, 20))
     data_4d = np.random.random((100, 5, 20, 50))
 
-    assert utils.load_image(data_3d) is not None
-    assert utils.load_image(data_4d) is not None
+    assert utils.reshape_niimg(data_3d) is not None
+    assert utils.reshape_niimg(data_4d) is not None
 
 
 def test_smoke_make_adaptive_mask():

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -116,6 +116,12 @@ def test_smoke_reshape_niimg():
     assert utils.reshape_niimg(data_3d) is not None
     assert utils.reshape_niimg(data_4d) is not None
 
+    with pytest.raises(TypeError):
+        utils.reshape_niimg(5)
+
+    with pytest.raises(ValueError):
+        utils.reshape_niimg("/path/to/nonexistent/file")
+
 
 def test_smoke_make_adaptive_mask():
     """

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -17,9 +17,8 @@ RepLGR = logging.getLogger("REPORT")
 RefLGR = logging.getLogger("REFERENCES")
 
 
-def load_image(data):
-    """
-    Takes input `data` and returns a sample x time array
+def reshape_niimg(data):
+    """Take input `data` and return a sample x time array.
 
     Parameters
     ----------
@@ -31,11 +30,10 @@ def load_image(data):
     fdata : (S [x T]) :obj:`numpy.ndarray`
         Reshaped `data`, where `S` is samples and `T` is time
     """
-
-    if isinstance(data, str):
+    if isinstance(data, (str, nib.spatialimages.SpatialImage)):
         data = check_niimg(data).get_fdata()
-    elif isinstance(data, nib.spatialimages.SpatialImage):
-        data = check_niimg(data).get_fdata()
+    elif not isinstance(data, np.ndarray):
+        raise TypeError(f"Unsupported type {type(data)}")
 
     fdata = data.reshape((-1,) + data.shape[3:]).squeeze()
 
@@ -101,7 +99,7 @@ def make_adaptive_mask(data, mask=None, getsum=False, threshold=1):
         masksum[masksum < threshold] = 0
     else:
         # if the user has supplied a binary mask
-        mask = load_image(mask).astype(bool)
+        mask = reshape_niimg(mask).astype(bool)
         masksum = masksum * mask
         # reduce mask based on masksum
         # TODO: Use visual report to make checking the reduced mask easier

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -537,16 +537,16 @@ def tedana_workflow(
         RepLGR.info("A user-defined mask was applied to the data.")
     elif t2smap and not mask:
         LGR.info("Using user-defined T2* map to generate mask")
-        t2s_limited_sec = utils.load_image(t2smap)
+        t2s_limited_sec = utils.reshape_niimg(t2smap)
         t2s_limited = utils.sec2millisec(t2s_limited_sec)
         t2s_full = t2s_limited.copy()
         mask = (t2s_limited != 0).astype(int)
     elif t2smap and mask:
         LGR.info("Combining user-defined mask and T2* map to generate mask")
-        t2s_limited_sec = utils.load_image(t2smap)
+        t2s_limited_sec = utils.reshape_niimg(t2smap)
         t2s_limited = utils.sec2millisec(t2s_limited_sec)
         t2s_full = t2s_limited.copy()
-        mask = utils.load_image(mask)
+        mask = utils.reshape_niimg(mask)
         mask[t2s_limited == 0] = 0  # reduce mask based on T2* map
     else:
         LGR.info("Computing EPI mask from first echo")


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #801.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Explicitly check input against valid types in `load_data`. This will raise an exception when a tuple is provided, rather than silently treating the tupled files as a single z-cat file.
- Fix the `load_data` docstring, which was out-of-date.
- Rename `utils.load_image` to `utils.reshape_niimg`. While this function does support image loading, its primary purpose is to reshape `X x Y x Z [x T]` data to `S [x T]`.
