### PR TITLE
[FIX] Address divide by 0 issue in decay.py

### DIFF
--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -37,7 +37,11 @@ def _apply_t2s_floor(t2s, echo_times):
         echo_times = echo_times[:, None]
 
     eps = np.finfo(dtype=t2s.dtype).eps  # smallest value for datatype
-    temp_arr = np.exp(-echo_times / t2s)  # (E x V) array
+    nonzerovox = t2s != 0
+    # Exclude values where t2s is 0 when dividing by t2s.
+    # These voxels are also excluded from bad_voxel_idx
+    temp_arr = np.zeros((len(echo_times), len(t2s)))
+    temp_arr[:, nonzerovox] = np.exp(-echo_times / t2s[nonzerovox])  # (E x V) array
     bad_voxel_idx = np.any(temp_arr == 0, axis=0) & (t2s != 0)
     n_bad_voxels = np.sum(bad_voxel_idx)
     if n_bad_voxels > 0:


### PR DESCRIPTION
For 5 echo data, I was noticing the following warning:
```
INFO     tedana:tedana_workflow:584 Computing T2* map
/Users/handwerkerd/code/tedana_community/me-ica/tedana/tedana/decay.py:40: RuntimeWarning: divide by zero encountered in true_divide
  temp_arr = np.exp(-echo_times / t2s)  # (E x V) array
INFO     combine:make_optcom:242 Optimally combining data with voxel-wise T2* estimates
```
 
This warning was created by #736 when it became possible to to send a t2s volume with 0's to  `_apply_t2s_floor` The function correctly ignored voxels where t2s was zero, but only after dividing by t2s and triggering this warning

Changes proposed in this pull request:

- Edited  `_apply_t2s_floor` so that voxels with 0 in t2s are excluded from the denominator when dividing