### PR TITLE
Run getelbow only if there are enough components

### DIFF
--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -43,9 +43,9 @@ def getelbow_cons(arr, return_val=False):
     if arr.ndim != 1:
         raise ValueError("Parameter arr should be 1d, not {0}d".format(arr.ndim))
 
-    if not arr.size:
+    if arr.size < 5:
         raise ValueError(
-            "Empty array detected during elbow calculation. "
+            f"Only {arr.size} components used in elbow calculation. >=5 are required. "
             "This error happens when getelbow_cons is incorrectly called on no components. "
             "If you see this message, please open an issue at "
             "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
@@ -94,9 +94,9 @@ def getelbow(arr, return_val=False):
     if arr.ndim != 1:
         raise ValueError("Parameter arr should be 1d, not {0}d".format(arr.ndim))
 
-    if arr.size <= 1:
+    if arr.size < 5:
         raise ValueError(
-            "Only 0 or 1 components used in elbow calculation. "
+            f"Only {arr.size} components used in elbow calculation. >=5 are required. "
             "This error happens when getelbow is incorrectly called on too few components. "
             "If you see this message, please open an issue at "
             "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -94,10 +94,10 @@ def getelbow(arr, return_val=False):
     if arr.ndim != 1:
         raise ValueError("Parameter arr should be 1d, not {0}d".format(arr.ndim))
 
-    if not arr.size:
+    if arr.size <= 1:
         raise ValueError(
-            "Empty array detected during elbow calculation. "
-            "This error happens when getelbow is incorrectly called on no components. "
+            "Only 0 or 1 components used in elbow calculation. "
+            "This error happens when getelbow is incorrectly called on too few components. "
             "If you see this message, please open an issue at "
             "https://github.com/ME-ICA/tedana/issues with the full traceback and any data "
             "necessary to reproduce this error, so that we create additional data checks to "

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -259,9 +259,9 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     # Compute elbows from other elbows
     f05, _, f01 = getfbounds(n_echos)
     kappas_nonsig = comptable.loc[comptable["kappa"] < f01, "kappa"]
-    if not kappas_nonsig.size:
+    if kappas_nonsig.size <= 1:
         LGR.warning(
-            "No nonsignificant kappa values detected. "
+            "Only 0 or 1 nonsignificant kappa values detected. "
             "Only using elbow calculated from all kappa values."
         )
         kappas_nonsig_elbow = np.nan

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -273,9 +273,16 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     # NOTE: Would an elbow from all Kappa values *ever* be lower than one from
     # a subset of lower (i.e., nonsignificant) values?
     kappa_elbow = np.nanmin((kappas_all_elbow, kappas_nonsig_elbow))
+    if kappa_elbow == kappas_all_elbow:
+        LGR.info(f"Kappa elbow is {kappa_elbow} and calculated based on all components")
+    else:
+        LGR.info(
+            f"Kappa elbow is {kappa_elbow} and calculated based on {kappas_nonsig.size} components with non-significant kappa fits"
+        )
     rhos_ncls_elbow = getelbow(comptable.loc[ncls, "rho"], return_val=True)
     rhos_all_elbow = getelbow(comptable["rho"], return_val=True)
     rho_elbow = np.mean((rhos_ncls_elbow, rhos_all_elbow, f05))
+    LGR.info(f"Rho elbow is {rho_elbow}")
 
     # Provisionally accept components based on Kappa and Rho elbows
     acc_prov = ncls[

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -277,7 +277,8 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
         LGR.info(f"Kappa elbow is {kappa_elbow} and calculated based on all components")
     else:
         LGR.info(
-            f"Kappa elbow is {kappa_elbow} and calculated based on {kappas_nonsig.size} components with non-significant kappa fits"
+            f"Kappa elbow is {kappa_elbow} and calculated based on {kappas_nonsig.size}"
+            f" components with non-significant kappa fits"
         )
     rhos_ncls_elbow = getelbow(comptable.loc[ncls, "rho"], return_val=True)
     rhos_all_elbow = getelbow(comptable["rho"], return_val=True)

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -259,9 +259,10 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     # Compute elbows from other elbows
     f05, _, f01 = getfbounds(n_echos)
     kappas_nonsig = comptable.loc[comptable["kappa"] < f01, "kappa"]
-    if kappas_nonsig.size <= 1:
+    if kappas_nonsig.size < 5:
         LGR.warning(
             f"Only {kappas_nonsig.size} nonsignificant kappa values detected. "
+            "A minimum of 5 values are required to calculate an elbow."
             "Only using elbow calculated from all kappa values."
         )
         kappas_nonsig_elbow = np.nan

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -262,7 +262,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     if kappas_nonsig.size < 5:
         LGR.warning(
             f"Only {kappas_nonsig.size} nonsignificant kappa values detected. "
-            "A minimum of 5 values are required to calculate an elbow."
+            "A minimum of 5 values are required to calculate an elbow. "
             "Only using elbow calculated from all kappa values."
         )
         kappas_nonsig_elbow = np.nan

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -261,7 +261,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     kappas_nonsig = comptable.loc[comptable["kappa"] < f01, "kappa"]
     if kappas_nonsig.size <= 1:
         LGR.warning(
-            "Only 0 or 1 nonsignificant kappa values detected. "
+            f"Only {kappas_nonsig.size} nonsignificant kappa values detected. "
             "Only using elbow calculated from all kappa values."
         )
         kappas_nonsig_elbow = np.nan
@@ -278,7 +278,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
     else:
         LGR.info(
             f"Kappa elbow is {kappa_elbow} and calculated based on {kappas_nonsig.size}"
-            f" components with non-significant kappa fits"
+            f" components with non-significant kappa values"
         )
     rhos_ncls_elbow = getelbow(comptable.loc[ncls, "rho"], return_val=True)
     rhos_all_elbow = getelbow(comptable["rho"], return_val=True)


### PR DESCRIPTION
Closes #808.

Changes proposed in this pull request:

- Don't run getelbow if there are fewer than 2 non-significant kappa components and return `nan`. It previously wouldn't run if there was 0 components, but would run and give a divide by zero error if there was one component.
- Add an error if getelbow is run with 0 or 1 components (previously only gave an error for 0 components)
- Update warning and error messages accordingly
- Added lgr.info output to say which kappa threshold was used and to output the kappa and rho elbow values (I don't think they're documented anywhere else)

As discussed in #808 it is mathematically problematic to calculate an elbow on only 2 components, but, for the way this is used in the code, this is the most conservative option. A kappa elbow based on the non-significant components can only lower the kappa threshold used for component selection which would mean fewer components would be removed as noise. That makes this choice the least aggressive (most conservative) denoising option.

I'm not sure how often this an elbow is changed based on the elbow for 2-5 non-significant components being lower than the elbow for all components. Therefore I added some info to the logger output which may help us track how often this actually happens.
