### PR TITLE
[FIX] Fixes broken component figures in report when there are more than 99 components

### DIFF
--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -17,11 +17,8 @@ tap_callback_jscode = """
         // -----------------------------
         var components = data['component']
         var selected = components[selected_idx]
-        var selected_padded = '' + selected;
-        while (selected_padded.length < 2) {
-            selected_padded = '0' + selected_padded;
-        }
-        var selected_padded_forIMG = '0' + selected_padded
+        var selected_padded = String(selected).padStart(3,0);
+        var selected_padded_forIMG = selected_padded
         var selected_padded_C = 'ica_' + selected_padded
 
         // Find color for selected component

--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -17,7 +17,7 @@ tap_callback_jscode = """
         // -----------------------------
         var components = data['component']
         var selected = components[selected_idx]
-        var selected_padded = String(selected).padStart(3,0);
+        var selected_padded = String(selected).padStart(3,0)
         var selected_padded_forIMG = selected_padded
         var selected_padded_C = 'ica_' + selected_padded
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

This is a very minor bug fix that makes the 0-padding in the report Javascript code more robust. Specifically, the component figures didn't display correctly for any components > 99 since they were padded to 0100, 0101 etc instead of just 100. 

-
-
