### PR TITLE
[NO-MRG] Changes from Power replication

### DIFF
--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -100,11 +100,10 @@ def make_adaptive_mask(data, mask=None, getsum=False, threshold=1, ignore_zeros=
     else:
         # if the user has supplied a binary mask
         mask = reshape_niimg(mask).astype(bool)
+        masksum = masksum * mask
         if ignore_zeros:
             # Use value of 1 when mask include voxel but masksum says it's all bad data
             masksum = np.maximum(masksum, mask, dtype=int)
-        else:
-            masksum = masksum * mask
 
         # reduce mask based on masksum
         # TODO: Use visual report to make checking the reduced mask easier

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -99,12 +99,11 @@ def make_adaptive_mask(data, mask=None, getsum=False, threshold=1, ignore_zeros=
         masksum[masksum < threshold] = 0
     else:
         # if the user has supplied a binary mask
-        mask = reshape_niimg(mask)
+        mask = reshape_niimg(mask).astype(bool)
         if ignore_zeros:
             # Use value of 1 when mask include voxel but masksum says it's all bad data
-            masksum = np.maximum(masksum, mask)
+            masksum = np.maximum(masksum, mask, dtype=int)
         else:
-            mask = mask.astype(bool)
             masksum = masksum * mask
 
         # reduce mask based on masksum

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -40,7 +40,7 @@ def reshape_niimg(data):
     return fdata
 
 
-def make_adaptive_mask(data, mask=None, getsum=False, threshold=1):
+def make_adaptive_mask(data, mask=None, getsum=False, threshold=1, ignore_zeros=False):
     """
     Makes map of `data` specifying longest echo a voxel can be sampled with
 
@@ -99,8 +99,14 @@ def make_adaptive_mask(data, mask=None, getsum=False, threshold=1):
         masksum[masksum < threshold] = 0
     else:
         # if the user has supplied a binary mask
-        mask = reshape_niimg(mask).astype(bool)
-        masksum = masksum * mask
+        mask = reshape_niimg(mask)
+        if ignore_zeros:
+            # Use value of 1 when mask include voxel but masksum says it's all bad data
+            masksum = np.maximum(masksum, mask)
+        else:
+            mask = mask.astype(bool)
+            masksum = masksum * mask
+
         # reduce mask based on masksum
         # TODO: Use visual report to make checking the reduced mask easier
         if np.any(masksum[mask] < threshold):

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -531,10 +531,12 @@ def tedana_workflow(
         raise IOError("Argument 't2smap' must be an existing file.")
 
     RepLGR.info("TE-dependence analysis was performed on input data.")
+    ignore_zeros = False
     if mask and not t2smap:
         # TODO: add affine check
         LGR.info("Using user-defined mask")
         RepLGR.info("A user-defined mask was applied to the data.")
+        ignore_zeros = True
     elif t2smap and not mask:
         LGR.info("Using user-defined T2* map to generate mask")
         t2s_limited_sec = utils.reshape_niimg(t2smap)
@@ -548,6 +550,7 @@ def tedana_workflow(
         t2s_full = t2s_limited.copy()
         mask = utils.reshape_niimg(mask)
         mask[t2s_limited == 0] = 0  # reduce mask based on T2* map
+        ignore_zeros = True
     else:
         LGR.info("Computing EPI mask from first echo")
         first_echo_img = io.new_nii_like(io_generator.reference_img, catd[:, 0, :])
@@ -563,6 +566,7 @@ def tedana_workflow(
         mask=mask,
         getsum=True,
         threshold=1,
+        ignore_zeros=ignore_zeros,
     )
     LGR.debug("Retaining {}/{} samples for denoising".format(mask_denoise.sum(), n_samp))
     io_generator.save_file(masksum_denoise, "adaptive mask img")


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. This PR includes changes I made to tedana for a manuscript of mine. The big problem I had to solve was that voxels necessary for CSF/WM extraction (e.g., for aCompCor) were being masked out with the adaptive mask (see #827 and https://github.com/NBCLab/power-replication/issues/14).

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Retain all voxels in the explicit mask.
