### PR TITLE
[DOC] Generalize installation instructions to work with Windows in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,13 +132,12 @@ Make sure to always [keep your fork up to date][link_updateupstreamwiki] with th
 To test a change, you may need to set up your local repository to run a `tedana` workflow.
 To do so, run
 ```
-pip install -e .'[all]'
-```
-from within your local `tedana` repository. This should ensure all packages are correctly organized and linked on your user profile.
-If the above command didnot worked for you try using the following command :
-```
+# UNIX (MacOS/Linux)
+pip install -e '.[all]'
+# Windows
 pip install -e .[all]
 ```
+from within your local `tedana` repository. This should ensure all packages are correctly organized and linked on your user profile.
 We recommend including the `[all]` flag when you install `tedana` so that "extra" requirements necessary for running tests and building the documentation will also be installed.
 
 Once you've run this, your repository should be set for most changes (i.e., you do not have to re-run with every change).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,10 @@ To do so, run
 pip install -e .'[all]'
 ```
 from within your local `tedana` repository. This should ensure all packages are correctly organized and linked on your user profile.
-
+If the above command didnot worked for you try using the following command :
+```
+pip install -e .[all]
+```
 We recommend including the `[all]` flag when you install `tedana` so that "extra" requirements necessary for running tests and building the documentation will also be installed.
 
 Once you've run this, your repository should be set for most changes (i.e., you do not have to re-run with every change).


### PR DESCRIPTION
Closes #844, #845

Changes proposed in this pull request:
 - `pip install -e .'[all]'` does not work on Windows while `pip install -e .[all]` does. This changes CONTRIBUTING.md to recommend this step without the added quotes.