### PR TITLE
[DOC] Add information about using tedana with fMRIPrep v21.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 docs/generated/
 .pytest_cache/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,14 +161,14 @@ htmlhelp_basename = "tedanadoc"
 
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
-    "tedana", "https://github.com/me-ica/" "tedana/blob/{revision}/" "{package}/{path}#L{lineno}"
+    "tedana", "https://github.com/me-ica/tedana/blob/{revision}/{package}/{path}#L{lineno}"
 )
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/", None),
     "nibabel": ("https://nipy.org/nibabel/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -57,32 +57,9 @@ The actual filenames of fMRIPrep derivatives depend on the filenames in the BIDS
 but in this example we chose to use the simple example of "sub-01" and "task-rest".
 The standard space template in this example is "MNI152NLin2009cAsym", but will depend on fMRIPrep settings in practice.
 
-.. code-block:: bash
+.. raw:: html
 
-    # First, let's define some paths to the fMRIPrep and tedana outputs
-    fmriprep_dir="/path/to/fmriprep/derivatives/of/subject"
-    tedana_dir="/path/to/tedana/derivatives"
-
-    # Result of denoising the scanner-space multi-echo data with tedana
-    file_to_warp="${tedana_dir}/sub-01_task-rest_desc-optcomDenoised_bold.nii.gz"
-
-    # Name of the standard-space denoised data file to be written out
-    out_file="${tedana_dir}/sub-01_task-rest_space-MNI152NLin2009cAsym_desc-optcomDenoised_bold.nii.gz"
-
-    # An existing standard-space
-    standard_space_file="${fmriprep_dir}/func/sub-01_task-rest_space-MNI152NLin2009cAsym_boldref.nii.gz"
-
-    # Transforms
-    xform_native_to_t1w="${fmriprep_dir}/func/sub-01_task-rest_from-scanner_to-T1w_mode-image_xfm.txt"
-    xform_t1w_to_std="${fmriprep_dir}/anat/sub-01_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5"
-
-    antsApplyTransforms \
-        -e 3 \
-        -i ${file_to_warp} \
-        -r ${standard_space_file} \
-        -o ${out_file} \
-        -n LanczosWindowedSinc \
-        -t ${xform_native_to_t1w} ${xform_t1w_to_std}
+    <script src="https://gist.github.com/tsalo/f9f38e9aba901e99ddb720465bb5222b.js"></script>
 
 ************************************
 [tedana] ICA has failed to converge.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -18,6 +18,14 @@ which outputs individual echoes after slice timing, motion correction, and disto
 These preprocessed echoes can be denoised with tedana,
 after which warps written out by fMRIPrep can be applied to transform the denoised data to standard space.
 
+As the fMRIPrep outputs become more formalized,
+it is possible to write functions that can select the appropriate derivative files and run tedana on them.
+Below is one example of such a function.
+
+.. raw:: html
+
+    <script src="https://gist.github.com/jbdenniso/73ec8281229d584721563a41aba410cf.js"></script>
+
 fMRIPrep versions < 21.0.0
 ==========================
 


### PR DESCRIPTION
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add information about fMRIPrep's new `--me-output-echos` parameter.
- Add instructions for applying fMRIPrep's transforms to warp native-space data to standard space.
- Fix a couple of small bugs in the documentation.
