### PR TITLE
Made AIC the default maPCA option

### DIFF
--- a/docs/approach.rst
+++ b/docs/approach.rst
@@ -244,8 +244,8 @@ to select the PCA components based on three widely-used model selection criteria
 
 .. note::
     Please, bear in mind that this is a data-driven dimensionality reduction approach. The default
-    option ``aic`` might not yield perfect results on your data. We suggest you explore the ``kic``
-    and ``mdl`` options if running ``tedana`` with ``aic`` returns more components than expected.
+    option ``aic`` might not yield perfect results on your data. Consider ``kic``
+    and ``mdl`` options if running ``tedana`` with ``aic`` returns more components than expected. There is no definitively right number of components, but, for typical fMRI datasets, if the PCA explains more than 98% of the variance or if the number of components is more than half the number of time points, then it may be worth considering more aggressive threshold.
 
 The simplest approach uses a user-supplied threshold applied to the cumulative variance explained
 by the PCA.

--- a/docs/approach.rst
+++ b/docs/approach.rst
@@ -219,7 +219,7 @@ These components are subjected to component selection, the specifics of which
 vary according to algorithm.
 Specifically, ``tedana`` offers three different approaches that perform this step.
 
-The recommended approach (the default ``mdl`` option, along with the ``aic`` and ``kic`` options, for
+The recommended approach (the default ``aic`` option, along with the ``kic`` and ``mdl`` options, for
 ``--tedpca``) is based on a moving average (stationary Gaussian) process
 proposed by `Li et al (2007)`_ and used primarily in the Group ICA of fMRI Toolbox (GIFT).
 A moving average process is the output of a linear system (which, in this case, is
@@ -233,17 +233,19 @@ For this PCA method in particular, ``--tedpca`` provides three different options
 to select the PCA components based on three widely-used model selection criteria:
 
 * ``mdl``: the Minimum Description Length (`MDL`_), which is the most aggressive option;
-  i.e. returns the least number of components. This option is the **default and recommeded**
-  as we have seen it yields the most reasonable results.
+  i.e. returns the least number of components.
 * ``kic``: the Kullback-Leibler Information Criterion (`KIC`_), which stands in the
   middle in terms of aggressiveness. You can see how KIC is related to AIC `here`_.
 * ``aic``: the Akaike Information Criterion (`AIC`_), which is the least aggressive option;
-  i.e., returns the largest number of components.
+  i.e., returns the largest number of components. We have chosen AIC as the default PCA
+  criterion because it tends to result in fewer components than the Kundu methods, which increases
+  the likelihood that the ICA step will successfully converge, but also, in our experience, retains
+  enough components for meaningful interpretation later on.
 
 .. note::
     Please, bear in mind that this is a data-driven dimensionality reduction approach. The default
-    option ``mdl`` might not yield perfect results on your data. We suggest you explore the ``kic``
-    and ``aic`` options if running ``tedana`` with ``mdl`` returns less components than expected.
+    option ``aic`` might not yield perfect results on your data. We suggest you explore the ``kic``
+    and ``mdl`` options if running ``tedana`` with ``aic`` returns more components than expected.
 
 The simplest approach uses a user-supplied threshold applied to the cumulative variance explained
 by the PCA.

--- a/docs/approach.rst
+++ b/docs/approach.rst
@@ -245,7 +245,10 @@ to select the PCA components based on three widely-used model selection criteria
 .. note::
     Please, bear in mind that this is a data-driven dimensionality reduction approach. The default
     option ``aic`` might not yield perfect results on your data. Consider ``kic``
-    and ``mdl`` options if running ``tedana`` with ``aic`` returns more components than expected. There is no definitively right number of components, but, for typical fMRI datasets, if the PCA explains more than 98% of the variance or if the number of components is more than half the number of time points, then it may be worth considering more aggressive threshold.
+    and ``mdl`` options if running ``tedana`` with ``aic`` returns more components than expected.
+    There is no definitively right number of components, but, for typical fMRI datasets, if the PCA
+    explains more than 98% of the variance or if the number of components is more than half the number
+    of time points, then it may be worth considering more aggressive thresholds.
 
 The simplest approach uses a user-supplied threshold applied to the cumulative variance explained
 by the PCA.

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -225,7 +225,9 @@ def tedpca(
 
     n_samp, n_echos, n_vols = data_cat.shape
 
-    LGR.info("Computing PCA of optimally combined multi-echo data")
+    LGR.info(
+        f"Computing PCA of optimally combined multi-echo data with selection criteria: {algorithm}"
+    )
     data = data_oc[mask, :]
 
     data_z = ((data.T - data.T.mean(axis=0)) / data.T.std(axis=0)).T  # var normalize ts

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -56,7 +56,7 @@ def tedpca(
     t2sG,
     io_generator,
     tes,
-    algorithm="mdl",
+    algorithm="aic",
     kdaw=10.0,
     rdaw=1.0,
     verbose=False,
@@ -96,7 +96,7 @@ def tedpca(
         (see Li et al., 2007).
         If a float is provided, then it is assumed to represent percentage of variance
         explained (0-1) to retain from PCA.
-        Default is 'mdl'.
+        Default is 'aic'.
     kdaw : :obj:`float`, optional
         Dimensionality augmentation weight for Kappa calculations. Must be a
         non-negative float, or -1 (a special value). Default is 10.

--- a/tedana/tests/data/cornell_three_echo_outputs.txt
+++ b/tedana/tests/data/cornell_three_echo_outputs.txt
@@ -91,3 +91,8 @@ figures/comp_061.png
 figures/comp_062.png
 figures/comp_063.png
 figures/comp_064.png
+figures/comp_065.png
+figures/comp_066.png
+figures/comp_067.png
+figures/comp_068.png
+figures/comp_069.png

--- a/tedana/tests/data/cornell_three_echo_outputs.txt
+++ b/tedana/tests/data/cornell_three_echo_outputs.txt
@@ -19,8 +19,6 @@ desc-optcomAccepted_bold.nii.gz
 desc-optcomDenoised_bold.nii.gz
 desc-optcomRejected_bold.nii.gz
 desc-optcom_bold.nii.gz
-report.txt
-tedana_report.html
 figures
 figures/carpet_optcom.svg
 figures/carpet_denoised.svg
@@ -95,4 +93,5 @@ figures/comp_065.png
 figures/comp_066.png
 figures/comp_067.png
 figures/comp_068.png
-figures/comp_069.png
+report.txt
+tedana_report.html

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -186,8 +186,6 @@ def test_integration_three_echo(skip_integration):
         tedpca="aic",
     )
 
-    breakpoint()
-
     # Test re-running, but use the CLI
     args = [
         "-d",

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -183,8 +183,10 @@ def test_integration_three_echo(skip_integration):
         tes=[14.5, 38.5, 62.5],
         out_dir=out_dir,
         low_mem=True,
-        tedpca="mdl",
+        tedpca="aic",
     )
+
+    breakpoint()
 
     # Test re-running, but use the CLI
     args = [

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -324,7 +324,7 @@ def tedana_workflow(
     prefix="",
     fittype="loglin",
     combmode="t2s",
-    tedpca="mdl",
+    tedpca="aic",
     fixed_seed=42,
     maxit=500,
     maxrestart=10,
@@ -371,7 +371,7 @@ def tedana_workflow(
         Method with which to select components in TEDPCA.
         If a float is provided, then it is assumed to represent percentage of variance
         explained (0-1) to retain from PCA.
-        Default is 'mdl'.
+        Default is 'aic'.
     tedort : :obj:`bool`, optional
         Orthogonalize rejected components w.r.t. accepted ones prior to
         denoising. Default is False.


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #843 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Updated all references to the default maPCA option from `mdl` to `aic`.
- Made `aic` the default maPCA option.
- Updated three-echo test to use `aic`.
