### PR TITLE
[FIX] Address SameFileErrors when running manual classification on an existing output directory

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -115,7 +115,7 @@ def test_integration_five_echo(skip_integration):
         + [str(te) for te in echo_times]
         + [
             "--out-dir",
-            out_dir2,
+            out_dir,
             "--debug",
             "--verbose",
             "--manacc",


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #853 and addresses a bug identified in https://neurostars.org/t/question-about-rica-tedana-manual-ica-classification/21654.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
