### PR TITLE
[FIX] The rationale column of comptable gets updated when no manacc is given

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -738,7 +738,12 @@ def tedana_workflow(
         else:
             comptable = pd.read_table(ctab)
 
-            if manacc is not None:
+            # If manacc is None and if comptable has a column named original_classification
+            if manacc is None and "original_classification" in comptable.columns:
+                # Get index of rows that have accepted on their classification column in comptable
+                manacc = comptable.index[comptable['classification']=="accepted"].tolist()
+                comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)
+            elif manacc is not None:
                 comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)
 
     # Write out ICA files.

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -737,8 +737,8 @@ def tedana_workflow(
             comptable, metric_metadata = selection.kundu_selection_v2(comptable, n_echos, n_vols)
         else:
             comptable = pd.read_table(ctab)
-            # Change rationale value of rows with classification "accepted" to empty strings
-            comptable.loc[comptable.classification == "accepted", "rationale"] = ""
+            # Change rationale value of rows with NaN to empty strings
+            comptable.loc[comptable.rationale.isna(), "rationale"] = ""
 
             if manacc is not None:
                 comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -737,13 +737,10 @@ def tedana_workflow(
             comptable, metric_metadata = selection.kundu_selection_v2(comptable, n_echos, n_vols)
         else:
             comptable = pd.read_table(ctab)
+            # Change rationale value of rows with classification "accepted" to empty strings
+            comptable.loc[comptable.classification == "accepted", "rationale"] = ""
 
-            # If manacc is None and if comptable has a column named original_classification
-            if manacc is None and "original_classification" in comptable.columns:
-                # Get index of rows that have accepted on their classification column in comptable
-                manacc = comptable.index[comptable["classification"] == "accepted"].tolist()
-                comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)
-            elif manacc is not None:
+            if manacc is not None:
                 comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)
 
     # Write out ICA files.

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -738,10 +738,10 @@ def tedana_workflow(
         else:
             comptable = pd.read_table(ctab)
 
-            # If manacc is None and if comptable has a column named original_classification
+            # If manacc is None and if comptable has a column named original_classification
             if manacc is None and "original_classification" in comptable.columns:
-                # Get index of rows that have accepted on their classification column in comptable
-                manacc = comptable.index[comptable['classification']=="accepted"].tolist()
+                # Get index of rows that have accepted on their classification column in comptable
+                manacc = comptable.index[comptable["classification"] == "accepted"].tolist()
                 comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)
             elif manacc is not None:
                 comptable, metric_metadata = selection.manual_selection(comptable, acc=manacc)


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #854 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Check that the given `ctab` is Rica's by looking at the column names.
- Update the rationale of `comptable` with `selection.manual_selection(comptable, acc=manacc)`.
