### PR TITLE
[ENH, FIX] PCA variance enhancements and consistency improvements

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -99,7 +99,7 @@ def tedpca(
         (see Li et al., 2007).
         If a float is provided, then it is assumed to represent percentage of variance
         explained (0-1) to retain from PCA.
-        If an int is provide, then it is assumed to be the number of components
+        If an int is provided, then it is assumed to be the number of components
         to select
         Default is 'aic'.
     kdaw : :obj:`float`, optional

--- a/tedana/tests/test_workflows_parser_utils.py
+++ b/tedana/tests/test_workflows_parser_utils.py
@@ -20,6 +20,10 @@ def test_check_tedpca_value():
     with pytest.raises(ValueError):
         check_tedpca_value(1.5, is_parser=False)
 
+    with pytest.raises(ValueError):
+        check_tedpca_value(-1, is_parser=False)
+
     assert check_tedpca_value(0.95) == 0.95
     assert check_tedpca_value("0.95") == 0.95
     assert check_tedpca_value("mdl") == "mdl"
+    assert check_tedpca_value(52) == 52

--- a/tedana/workflows/parser_utils.py
+++ b/tedana/workflows/parser_utils.py
@@ -6,7 +6,7 @@ import os.path as op
 
 
 def check_tedpca_value(string, is_parser=True):
-    """Check if argument is a float in range 0-1 or one of a list of strings."""
+    """Check if argument is a float in range (0,1), an int greater than 1 or one of a list of strings."""
     valid_options = ("mdl", "aic", "kic", "kundu", "kundu-stabilize")
     if string in valid_options:
         return string
@@ -15,12 +15,18 @@ def check_tedpca_value(string, is_parser=True):
     try:
         floatarg = float(string)
     except ValueError:
-        msg = "Argument to tedpca must be a float or one of: {}".format(", ".join(valid_options))
+        msg = "Argument to tedpca must be a number or one of: {}".format(", ".join(valid_options))
         raise error(msg)
 
-    if not (0 <= floatarg <= 1):
-        raise error("Float argument to tedpca must be between 0 and 1.")
-    return floatarg
+    if floatarg != int(floatarg):
+        if not (0 < floatarg < 1):
+            raise error("Float argument to tedpca must be between 0 and 1.")
+        return floatarg
+    else:
+        intarg = int(floatarg)
+        if floatarg < 1:
+            raise error("Int argument must be greater than 1")
+        return intarg
 
 
 def is_valid_file(parser, arg):

--- a/tedana/workflows/parser_utils.py
+++ b/tedana/workflows/parser_utils.py
@@ -6,7 +6,10 @@ import os.path as op
 
 
 def check_tedpca_value(string, is_parser=True):
-    """Check if argument is a float in range (0,1), an int greater than 1 or one of a list of strings."""
+    """
+    Check if argument is a float in range (0,1),
+    an int greater than 1 or one of a list of strings.
+    """
     valid_options = ("mdl", "aic", "kic", "kundu", "kundu-stabilize")
     if string in valid_options:
         return string

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -476,7 +476,7 @@ def tedana_workflow(
         gscontrol = [gscontrol]
 
     # Check value of tedpca *if* it is a predefined string,
-    # a float between 0 & 1 or an int >= 1
+    # a float on [0, 1] or an int >= 1
     tedpca = check_tedpca_value(tedpca, is_parser=False)
 
     LGR.info("Loading input data: {}".format([f for f in data]))

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -146,10 +146,12 @@ def _get_parser():
             "process and are ordered from most to least aggressive. "
             "Users may also provide a float from 0 to 1, "
             "in which case components will be selected based on the "
-            "cumulative variance explained. "
-            "Default='mdl'."
+            "cumulative variance explained or an integer greater than 1"
+            "in which case the specificed number of components will be"
+            "selected."
+            "Default='aic'."
         ),
-        default="mdl",
+        default="aic",
     )
     optional.add_argument(
         "--seed",
@@ -473,7 +475,8 @@ def tedana_workflow(
     if not isinstance(gscontrol, list):
         gscontrol = [gscontrol]
 
-    # Check value of tedpca *if* it is a float
+    # Check value of tedpca *if* it is a predefined string,
+    # a float between 0 & 1 or an int >= 1
     tedpca = check_tedpca_value(tedpca, is_parser=False)
 
     LGR.info("Loading input data: {}".format([f for f in data]))


### PR DESCRIPTION
Closes #876.

Changes proposed in this pull request:
- We changed AIC to the default PCA selection criterion in #849 for the API. I noticed it was still defaulting to MDL for the command line interface, so I fixed that
- As discussed in #876, normalized variance explained was calculated one way for mdl, kic, & aic, and a different way for the low_mem option or if a specific variance explained as selected. Everything now matches the calculation used for mdl, kic, & aic
- The sum of the normalized variances across PCA components is the % variance of the original data that's explained by the PCA according to the PCA function in sklearn. I am now including this value in the info logger. It doesn't match the percent variance explained values that are given as later outputs. Figuring out how to make sense of the difference is a good future goal.
- The PCA function from sklearn has an option to input a pre-specified number of components as an integer. We were unnecessarily blocking off that option (which I wanted to use for testing some stuff). I updated `check_tedpca_value` to allow integers >=1 and added unit tests for valid and invalid integers.
- doc strings and logging messages were edited in response to the above changes.

Notes: 
- Just to this is cleanly documented, the current version of the code calculated `varex_norm = varex / varex.sum()` for the pre-defined variance-explained option and also for the low-mem option. It uses `varex_norm = ppca.explained_variance_ratio_` for mdl, kic, & aic.
- The testing coverage drops slightly because only integration testing covers `decomposition/pca.py` and `tedana.py` We can add another integration test for when a fixed integer number of components are predefined, but since that would non-trivially increase the duration of the tests, I didn't want to do that without some discussion. Adding direct tests for `pca.py` and modularizing `tedana.py` more would be a better approach, but well beyond the scope of this PR.