### PR TITLE
Add F-T2 and F-S0 maps to verbose outputs

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -101,6 +101,8 @@ echo-[echo]_desc-[PCA|ICA]S0ModelPredictions_components.nii.gz  Component- and v
                                                                 separated by echo.
 desc-[PCA|ICA]AveragingWeights_components.nii.gz                Component-wise averaging weights for metric
                                                                 calculation.
+desc-[PCA|ICA]S0_stat-F_statmap.nii.gz                          F-statistic map for each component, for the S0 model.
+desc-[PCA|ICA]T2_stat-F_statmap.nii.gz                          F-statistic map for each component, for the T2 model.
 desc-optcomPCAReduced_bold.nii.gz                               Optimally combined data after dimensionality
                                                                 reduction with PCA. This is the input to the ICA.
 echo-[echo]_desc-Accepted_bold.nii.gz                           High-Kappa time series for echo number ``echo``

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -160,6 +160,16 @@ def generate_metrics(
         metric_maps["map predicted T2"] = p_m_T2
         metric_maps["map predicted S0"] = p_m_S0
 
+        if io_generator.verbose:
+            io_generator.save_file(
+                utils.unmask(metric_maps["map FT2"], mask),
+                label + " component F-T2 img",
+            )
+            io_generator.save_file(
+                utils.unmask(metric_maps["map FS0"], mask),
+                label + " component F-S0 img",
+            )
+
     if "map Z clusterized" in required_metrics:
         LGR.info("Thresholding z-statistic maps")
         z_thresh = 1.95

--- a/tedana/resources/config/outputs.json
+++ b/tedana/resources/config/outputs.json
@@ -75,11 +75,11 @@
         "orig": "pca_weights",
         "bidsv1.5.0": "desc-PCAAveragingWeights_components"
     },
-    "PCA component T2 img": {
+    "PCA component F-T2 img": {
         "orig": "pca_FT2",
         "bidsv1.5.0": "desc-PCAT2_stat-F_statmap"
     },
-    "PCA component S0 img": {
+    "PCA component F-S0 img": {
         "orig": "pca_FS0",
         "bidsv1.5.0": "desc-PCAS0_stat-F_statmap"
     },
@@ -103,11 +103,11 @@
         "orig": "ica_weights",
         "bidsv1.5.0": "desc-ICAAveragingWeights_components"
     },
-    "ICA component T2 img": {
+    "ICA component F-T2 img": {
         "orig": "ica_FT2",
         "bidsv1.5.0": "desc-ICAT2_stat-F_statmap"
     },
-    "ICA component S0 img": {
+    "ICA component F-S0 img": {
         "orig": "ica_FS0",
         "bidsv1.5.0": "desc-ICAS0_stat-F_statmap"
     },

--- a/tedana/resources/config/outputs.json
+++ b/tedana/resources/config/outputs.json
@@ -75,6 +75,14 @@
         "orig": "pca_weights",
         "bidsv1.5.0": "desc-PCAAveragingWeights_components"
     },
+    "PCA component T2 img": {
+        "orig": "pca_FT2",
+        "bidsv1.5.0": "desc-PCAT2_stat-F_statmap"
+    },
+    "PCA component S0 img": {
+        "orig": "pca_FS0",
+        "bidsv1.5.0": "desc-PCAS0_stat-F_statmap"
+    },
     "PCA reduced img": {
         "orig": "oc_reduced",
         "bidsv1.5.0": "desc-optcomPCAReduced_bold"
@@ -94,6 +102,14 @@
     "ICA component weights img": {
         "orig": "ica_weights",
         "bidsv1.5.0": "desc-ICAAveragingWeights_components"
+    },
+    "ICA component T2 img": {
+        "orig": "ica_FT2",
+        "bidsv1.5.0": "desc-ICAT2_stat-F_statmap"
+    },
+    "ICA component S0 img": {
+        "orig": "ica_FS0",
+        "bidsv1.5.0": "desc-ICAS0_stat-F_statmap"
     },
     "high kappa ts split img": {
         "orig": "hik_ts_e{echo}",

--- a/tedana/tests/data/fiu_four_echo_outputs.txt
+++ b/tedana/tests/data/fiu_four_echo_outputs.txt
@@ -10,9 +10,13 @@ desc-ICA_components.nii.gz
 desc-ICA_decomposition.json
 desc-tedana_metrics.json
 desc-tedana_metrics.tsv
+desc-ICAS0_stat-F_statmap.nii.gz
+desc-ICAT2_stat-F_statmap.nii.gz
 desc-ICA_mixing.tsv
 desc-ICA_stat-z_components.nii.gz
 desc-PCAAveragingWeights_components.nii.gz
+desc-PCAS0_stat-F_statmap.nii.gz
+desc-PCAT2_stat-F_statmap.nii.gz
 desc-PCA_decomposition.json
 desc-PCA_metrics.json
 desc-PCA_metrics.tsv

--- a/tedana/tests/data/nih_five_echo_outputs_verbose.txt
+++ b/tedana/tests/data/nih_five_echo_outputs_verbose.txt
@@ -9,9 +9,13 @@ desc-ICA_components.nii.gz
 desc-ICA_decomposition.json
 desc-tedana_metrics.json
 desc-tedana_metrics.tsv
+desc-ICAS0_stat-F_statmap.nii.gz
+desc-ICAT2_stat-F_statmap.nii.gz
 desc-ICA_mixing.tsv
 desc-ICA_stat-z_components.nii.gz
 desc-PCAAveragingWeights_components.nii.gz
+desc-PCAS0_stat-F_statmap.nii.gz
+desc-PCAT2_stat-F_statmap.nii.gz
 desc-PCA_decomposition.json
 desc-PCA_metrics.json
 desc-PCA_metrics.tsv


### PR DESCRIPTION
Closes #891.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add PCA and ICA F-statistic maps for the T2* and S0 models (for each component) to verbose outputs.
