### PR TITLE
Fixed desc-ICAOrth_mixing.tsv to have capital ICA prefix column names…

### DIFF
--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -771,9 +771,10 @@ def tedana_workflow(
         resid = rej_ts - pred_rej_ts
         mmix[:, rej_idx] = resid
         comp_names = [
-            io.add_decomp_prefix(comp, prefix="ica", max_value=comptable.index.max())
+            io.add_decomp_prefix(comp, prefix="ICA", max_value=comptable.index.max())
             for comp in comptable.index.values
         ]
+
         mixing_df = pd.DataFrame(data=mmix, columns=comp_names)
         io_generator.save_file(mixing_df, "ICA orthogonalized mixing tsv")
         RepLGR.info(


### PR DESCRIPTION
Fixes isue #904 to write the `desc-ICAOrth_mixing.tsv`  with the ICA column prefix in capital letters as in the other matrices.
[FIX]
Closes #904  

Changes proposed in this pull request:
- Changed "ica" to "ICA" in the prefix argument of the io.add_decomp_prefix call.
