### PR TITLE
add_na_to_rationale: Add n/a to accepted components rationale

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -266,7 +266,9 @@ class OutputGenerator:
         data_type = type(data)
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
-        data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
+        if 'rationale' in data.columns and 'classification' in data.columns:
+            data.loc[data['classification'] == 'accepted', 'rationale'] = 'n/a'
+        data.to_csv(path_or_buf=name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
 
 
 def get_fields(name):

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -267,7 +267,7 @@ class OutputGenerator:
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
         if "rationale" in data.columns and "classification" in data.columns:
-            data.loc[data['classification'] == 'accepted', 'rationale'] = 'n/a'
+            data.loc[data["classification"] == "accepted", "rationale"] = "n/a"
         data.to_csv(path_or_buf=name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
 
 

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -266,7 +266,7 @@ class OutputGenerator:
         data_type = type(data)
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
-        if 'rationale' in data.columns and 'classification' in data.columns:
+        if "rationale" in data.columns and "classification" in data.columns:
             data.loc[data['classification'] == 'accepted', 'rationale'] = 'n/a'
         data.to_csv(path_or_buf=name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
--> save_tsv, OutputGenerator

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #892
Add "n/a" to accepted components rationale 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- in tedana/io.py, I modified the OutputGenerator.save_tsv method:
    rows with accepted classifications get the value 'n/a' in rationale  
    'n/a' will be read as NaN by pandas when loading the file