### PR TITLE
Sorting varex for decision tree criterion I011

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -72,7 +72,6 @@ class OutputGenerator:
         make_figures=True,
         verbose=False,
     ):
-
         if config == "auto":
             config = op.join(utils.get_resource_path(), "config", "outputs.json")
 

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -58,7 +58,7 @@ def getelbow_cons(arr, return_val=False):
         (arr[nk - 5 - ii - 1] > arr[nk - 5 - ii : nk].mean() + 2 * arr[nk - 5 - ii : nk].std())
         for ii in range(nk - 5)
     ]
-    ds = np.array(temp1[::-1], dtype=np.int)
+    ds = np.array(temp1[::-1], dtype=np.integer)
     dsum = []
     c_ = 0
     for d_ in ds:

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -58,7 +58,7 @@ def getelbow_cons(arr, return_val=False):
         (arr[nk - 5 - ii - 1] > arr[nk - 5 - ii : nk].mean() + 2 * arr[nk - 5 - ii : nk].std())
         for ii in range(nk - 5)
     ]
-    ds = np.array(temp1[::-1], dtype=np.integer)
+    ds = np.array(temp1[::-1], dtype=np.int32)
     dsum = []
     c_ = 0
     for d_ in ds:

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -386,10 +386,10 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
         unclf = np.setdiff1d(unclf, midk)
 
         # Find components to ignore
-        # Ignore high variance explained, poor decision tree scored components
-        new_varex_lower = stats.scoreatpercentile(
-            comptable.loc[unclf[:num_acc_guess], "variance explained"], LOW_PERC
-        )
+        # Of the remaining components, ignore ones with higher variance even if their
+        # decision tree scores are poor
+        sorted_varex = np.flip(np.sort((comptable.loc[unclf, "variance explained"]).to_numpy()))
+        new_varex_lower = stats.scoreatpercentile(sorted_varex[:num_acc_guess], LOW_PERC)
         candart = unclf[comptable.loc[unclf, "d_table_score_scrub"] > num_acc_guess]
         ign_add0 = candart[comptable.loc[candart, "variance explained"] > new_varex_lower]
         ign_add0 = np.setdiff1d(ign_add0, midk)

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -387,7 +387,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
 
         # Find components to ignore
         # Of the remaining components, ignore ones with higher variance even if their
-        # decision tree scores are poor
+        # decision tree scores are poor, instead of rejecting them
         sorted_varex = np.flip(np.sort(comptable.loc[unclf, "variance explained"].to_numpy()))
         new_varex_lower = stats.scoreatpercentile(sorted_varex[:num_acc_guess], LOW_PERC)
         candart = unclf[comptable.loc[unclf, "d_table_score_scrub"] > num_acc_guess]

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -388,7 +388,7 @@ def kundu_selection_v2(comptable, n_echos, n_vols):
         # Find components to ignore
         # Of the remaining components, ignore ones with higher variance even if their
         # decision tree scores are poor
-        sorted_varex = np.flip(np.sort((comptable.loc[unclf, "variance explained"]).to_numpy()))
+        sorted_varex = np.flip(np.sort(comptable.loc[unclf, "variance explained"].to_numpy()))
         new_varex_lower = stats.scoreatpercentile(sorted_varex[:num_acc_guess], LOW_PERC)
         candart = unclf[comptable.loc[unclf, "d_table_score_scrub"] > num_acc_guess]
         ign_add0 = candart[comptable.loc[candart, "variance explained"] > new_varex_lower]

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -9,7 +9,7 @@ def test_getelbow_smoke():
     """A smoke test for the getelbow function."""
     arr = np.random.random(100)
     idx = _utils.getelbow(arr)
-    assert isinstance(idx, np.integer)
+    assert isinstance(idx, np.int32) isinstance(idx, np.int64)
 
     val = _utils.getelbow(arr, return_val=True)
     assert isinstance(val, float)
@@ -29,7 +29,7 @@ def test_getelbow_cons():
     """A smoke test for the getelbow_cons function."""
     arr = np.random.random(100)
     idx = _utils.getelbow_cons(arr)
-    assert isinstance(idx, np.integer)
+    assert isinstance(idx, np.int32) isinstance(idx, np.int64)
 
     val = _utils.getelbow_cons(arr, return_val=True)
     assert isinstance(val, float)

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -9,7 +9,7 @@ def test_getelbow_smoke():
     """A smoke test for the getelbow function."""
     arr = np.random.random(100)
     idx = _utils.getelbow(arr)
-    assert isinstance(idx, np.int32) isinstance(idx, np.int64)
+    assert isinstance(idx, np.int32) or isinstance(idx, np.int64)
 
     val = _utils.getelbow(arr, return_val=True)
     assert isinstance(val, float)
@@ -29,7 +29,7 @@ def test_getelbow_cons():
     """A smoke test for the getelbow_cons function."""
     arr = np.random.random(100)
     idx = _utils.getelbow_cons(arr)
-    assert isinstance(idx, np.int32) isinstance(idx, np.int64)
+    assert isinstance(idx, np.int32) or isinstance(idx, np.int64)
 
     val = _utils.getelbow_cons(arr, return_val=True)
     assert isinstance(val, float)

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -30,7 +30,7 @@ def test_unmask():
         (rs.randint(10, size=(n_data, 3, 3)), int),  # 3D int
     ]
 
-    for (input, dtype) in inputs:
+    for input, dtype in inputs:
         out = utils.unmask(input, mask)
         assert out.shape == (100,) + input.shape[1:]
         assert out.dtype == dtype


### PR DESCRIPTION
Closes #923


Changes proposed in this pull request:

- Fixes bug in the decision tree where variance explained should have been sorted before calculating a percentile for a subset of components.
- The relevant decision tree step used code I011.
- With this change, the variance threshold will be higher and a few more components may end up as `accepted` rather than `ignored` This won't affect the denoised time series since either classification is retained in the denoised time series.

- Also changed an `np.int` to `np.integer` in `_utils.py` that was causing tests to fail in CI, but not locally.
