### PR TITLE
add pandas version check >= 1.5.2 and mod behavior

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -79,6 +79,11 @@
             "orcid": "0000-0002-2553-3327"
         },
         {
+            "name": "Molfese, Peter",
+            "affiliation": "National Institutes of Mental Health, CMN",
+            "orcid": "0000-0002-3045-9408"
+        },
+        {
             "name": "Salo, Taylor",
             "affiliation": "Florida International University",
             "orcid": "0000-0001-9813-3167"

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -266,12 +266,14 @@ class OutputGenerator:
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
         if versiontuple(pd.__version__) >= versiontuple("1.5.2"):
-        	data.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
+            data.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
         else:
-        	data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
+            data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
+
 
 def versiontuple(v):
-	return tuple(map(int, (v.split("."))))
+    return tuple(map(int, (v.split("."))))
+
 
 def get_fields(name):
     """Identify all fields in an unformatted string.

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -265,8 +265,13 @@ class OutputGenerator:
         data_type = type(data)
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
-        data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
+        if versiontuple(pd.__version__) >= versiontuple("1.5.2"):
+        	data.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
+        else:
+        	data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
 
+def versiontuple(v):
+	return tuple(map(int, (v.split("."))))
 
 def get_fields(name):
     """Identify all fields in an unformatted string.


### PR DESCRIPTION
Closes #935 by adding 

Ultimately needed a way to check pandas version, if it's above 1.5 then the parameters for to_csv are different. Did two things:

1. Added a version check function 
```
def versiontuple(v):
	return tuple(map(int, (v.split("."))))
```

2. Added conditional to `save_tsv`
```
if versiontuple(pd.__version__) >= versiontuple("1.5.2"):
        data.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
else:
        data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
```

Someone should probably write more tests for this. However I did run on my system and confirm that it runs now successfully on pandas 2.0.0 (and 1.5.2). 