### PR TITLE
logging MAPCA subsampling

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -103,11 +103,11 @@ def tedpca(
         to select
         Default is 'aic'.
     kdaw : :obj:`float`, optional
-        Dimensionality augmentation weight for Kappa calculations. Must be a
-        non-negative float, or -1 (a special value). Default is 10.
+        Dimensionality augmentation weight for Kappa calculations when `algorithm` is
+        'kundu'. Must be a non-negative float, or -1 (a special value). Default is 10.
     rdaw : :obj:`float`, optional
-        Dimensionality augmentation weight for Rho calculations. Must be a
-        non-negative float, or -1 (a special value). Default is 1.
+        Dimensionality augmentation weight for Rho calculations when `algorithm` is
+        'kundu'. Must be a non-negative float, or -1 (a special value). Default is 1.
     verbose : :obj:`bool`, optional
         Whether to output files from fitmodels_direct or not. Default: False
     low_mem : :obj:`bool`, optional
@@ -309,6 +309,22 @@ def tedpca(
                 "explained_variance_total": varex_95_varexp,
             },
         }
+        if "subsampling_" in dir(ma_pca):
+            # Since older version of MAPCA did not log these values
+            # Check before trying to access the values. This will be
+            # unnecessary and removal once logging these values gets
+            # a new version number in MAPCA and tedana updates its
+            # minimum MAPCA version
+            mapca_results["MAPCA_subsampling"] = {
+                "calculated_IID_subsample_depth": ma_pca.subsampling_[
+                    "calculated_IID_subsample_depth"
+                ],
+                "calculated_IID_subsample_mean": ma_pca.subsampling_[
+                    "calculated_IID_subsample_mean"
+                ],
+                "effective_num_IID_samples": ma_pca.subsampling_["effective_num_IID_samples"],
+                "total_num_samples": ma_pca.subsampling_["total_num_samples"],
+            }
 
         # Save dictionary
         io_generator.save_file(mapca_results, "PCA cross component metrics json")


### PR DESCRIPTION
Once https://github.com/ME-ICA/mapca/pull/57 is merged into MAPCA, it will be possible for tedana to log the estimated subsampling value and several related parameters.

Changes proposed in this pull request:

- Logs several values related to the IID subsampling estiamte that are related to `desc-PCACrossComponent_metrics.json`
- A few PCA-related documentation changes that were noticed when writing this PR

I decided to add a conditional statement to only log these new values if they exist. The alternative is, once the above PR is merged into MAPCA, we release a new version of MAPCA and then update the minimum MAPCA version allowed with tedana. I'd rather just merge for now and then we can delete the conditional in the same PR where the minimum version of MAPCA is increased.
