### PR TITLE
Fix style issues

### DIFF
--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -43,22 +43,23 @@ def selectcomps2use(selector, decide_comps):
             "selector.component_table needs a 'classification' column to run selectcomp2suse"
         )
 
-    if (type(decide_comps) == str) or (type(decide_comps) == int):
+    if isinstance(decide_comps, (str, int)):
         decide_comps = [decide_comps]
-    if (type(decide_comps) == list) and (decide_comps[0] == "all"):
+
+    if isinstance(decide_comps, list) and (decide_comps[0] == "all"):
         # All components with any string in the classification field
         # are set to True
         comps2use = list(range(selector.component_table.shape[0]))
 
-    elif (type(decide_comps) == list) and all(isinstance(elem, str) for elem in decide_comps):
+    elif isinstance(decide_comps, list) and all(isinstance(elem, str) for elem in decide_comps):
         comps2use = []
         for didx in range(len(decide_comps)):
             newcomps2use = selector.component_table.index[
                 selector.component_table["classification"] == decide_comps[didx]
             ].tolist()
             comps2use = list(set(comps2use + newcomps2use))
-    elif (type(decide_comps) == list) and all(type(elem) == int for elem in decide_comps):
-        # decide_comps is already a string of indices
+    elif isinstance(decide_comps, list) and all(isinstance(elem, int) for elem in decide_comps):
+        # decide_comps is already a list of indices
         if len(selector.component_table) <= max(decide_comps):
             raise ValueError(
                 "decide_comps for selectcomps2use is selecting for a component with index"

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -35,7 +35,7 @@ def _get_parser():
 
     from tedana import __version__
 
-    verstr = "ica_reclassify v{}".format(__version__)
+    verstr = f"ica_reclassify v{__version__}"
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Argument parser follow template provided by RalphyZ
@@ -212,10 +212,10 @@ def _parse_manual_list(manual_list):
     elif op.exists(op.expanduser(str(manual_list[0]).strip(" "))):
         # filename was given
         manual_nums = fname_to_component_list(op.expanduser(str(manual_list[0]).strip(" ")))
-    elif type(manual_list[0]) == str:
+    elif isinstance(manual_list[0], str):
         # arbitrary string was given, length of list is 1
         manual_nums = str_to_component_list(manual_list[0])
-    elif type(manual_list[0]) == int:
+    elif isinstance(manual_list[0], int):
         # Is a single integer and should remain a list with a single integer
         manual_nums = manual_list
     else:
@@ -345,7 +345,7 @@ def ica_reclassify_workflow(
     logname = op.join(out_dir, (basename + start_time + "." + extension))
     utils.setup_loggers(logname=logname, repname=repname, quiet=quiet, debug=debug)
 
-    LGR.info("Using output directory: {}".format(out_dir))
+    LGR.info(f"Using output directory: {out_dir}")
 
     ioh = io.InputHarvester(registry)
     comptable = ioh.get_file_contents("ICA metrics tsv")


### PR DESCRIPTION
Closes None.

Changes proposed:
- Change cases of `type(x) == y` to `isinstance(x, y)`, which should fix the failing lint jobs.
- Change a couple of cases of `.format` strings to f-strings. We should do this across the whole package, but I've only done it for `ica_reclassify.py`.