### PR TITLE
MNT: Uncap dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
-    "bokeh<2.3.0",
+    "bokeh",
     "mapca>=0.0.3",
     "matplotlib",
     "nibabel>=2.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "scikit-learn>=0.21",
     "scipy>=1.2.0",
     "threadpoolctl",
-    "jinja2==3.0.1",
 ]
 dynamic = ["version"]
 

--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -162,8 +162,8 @@ def _create_kr_plt(comptable_cds, kappa_elbow=None, rho_elbow=None):
         ]
     )
     fig = plotting.figure(
-        plot_width=400,
-        plot_height=400,
+        width=400,
+        height=400,
         tools=["tap,wheel_zoom,reset,pan,crosshair,save", kr_hovertool],
         title="Kappa / Rho Plot",
     )
@@ -276,8 +276,8 @@ def _create_sorted_plt(
         ]
     )
     fig = plotting.figure(
-        plot_width=400,
-        plot_height=400,
+        width=400,
+        height=400,
         tools=["tap,wheel_zoom,reset,pan,crosshair,save", hovertool],
         title=title,
     )
@@ -319,8 +319,8 @@ def _create_sorted_plt(
 
 def _create_varexp_pie_plt(comptable_cds):
     fig = plotting.figure(
-        plot_width=400,
-        plot_height=400,
+        width=400,
+        height=400,
         title="Variance Explained View",
         tools=["hover,tap,save"],
         tooltips=[


### PR DESCRIPTION
I looked at #869 and #766 and I think I roughly understand the problems they were trying to fix. I think the jinja2 one was a short-lived incompatibility that just removing it should fix. The other one appeared to affect the reports. Running `make three-echo` in an environment with the latest bokeh produced one complaint that resolved to https://github.com/bokeh/bokeh/issues/12543, and otherwise just worked.

![image](https://github.com/ME-ICA/tedana/assets/83442/e5baf1b2-5d48-43a0-80b9-094c6bb2bb48)

Closes #976.