### PR TITLE
Adding python library version numbers

### DIFF
--- a/tedana/reporting/data/html/report_info_table_template.html
+++ b/tedana/reporting/data/html/report_info_table_template.html
@@ -1,7 +1,7 @@
 <div>
   <p>
     <span class="title">Tedana command used:</span>
-    <pre class="language-python">
+  <pre class="language-python">
       <code class="code_block">
         $command
       </code>
@@ -39,6 +39,10 @@
     <tr>
       <td class="title">Tedana version:</td>
       <td>$tedana</td>
+    </tr>
+    <tr>
+      <td class="title">Other library versions:</td>
+      <td>$python_libraries</td>
     </tr>
   </table>
 </div>

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -131,20 +131,19 @@ def _generate_info_table(info_dict):
         info_tpl = Template(info_file.read())
 
     info_dict = info_dict["GeneratedBy"][0]
-    command = info_dict["Command"]
-    version_python = info_dict["Python"]
-    info_dict = info_dict["Node"]
+    node_dict = info_dict["Node"]
 
     info_html = info_tpl.substitute(
-        command=command,
-        system=info_dict["System"],
-        node=info_dict["Name"],
-        release=info_dict["Release"],
-        sysversion=info_dict["Version"],
-        machine=info_dict["Machine"],
-        processor=info_dict["Processor"],
-        python=version_python,
-        tedana=__version__,
+        command=info_dict["Command"],
+        system=node_dict["System"],
+        node=node_dict["Name"],
+        release=node_dict["Release"],
+        sysversion=node_dict["Version"],
+        machine=node_dict["Machine"],
+        processor=node_dict["Processor"],
+        python=info_dict["Python"],
+        python_libraries=info_dict["Python_Libraries"],
+        tedana=info_dict["Version"],
     )
     return info_html
 

--- a/tedana/tests/data/nih_five_echo_outputs_t2smap.txt
+++ b/tedana/tests/data/nih_five_echo_outputs_t2smap.txt
@@ -5,3 +5,4 @@ desc-tedana_registry.json
 desc-optcom_bold.nii.gz
 S0map.nii.gz
 T2starmap.nii.gz
+t2smap_call.sh

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -2,13 +2,24 @@
 import logging
 import os.path as op
 import platform
+import sys
 import warnings
 
 import nibabel as nib
 import numpy as np
+from bokeh import __version__ as bokeh_version
+from mapca import __version__ as mapca_version
+from matplotlib import __version__ as matplotlib_version
+from nibabel import __version__ as nibabel_version
+from nilearn import __version__ as nilearn_version
 from nilearn._utils import check_niimg
+from numpy import __version__ as numpy_version
+from pandas import __version__ as pandas_version
+from scipy import __version__ as scipy_version
 from scipy import ndimage
+from sklearn import __version__ as sklearn_version
 from sklearn.utils import check_array
+from threadpoolctl import __version__ as threadpoolctl_version
 
 LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
@@ -443,15 +454,31 @@ def get_resource_path():
     return op.abspath(op.join(op.dirname(__file__), "resources") + op.sep)
 
 
-def get_system_info():
-    """Return information about the system tedana is being run on.
+def get_system_version_info():
+    """
+    Return information about the system tedana is being run on.
 
     Returns
     -------
     dict
-        Info about system where tedana is run on.
+        Info about system where tedana is run on and
+        and python and python library versioning info for key
+        modules used by tedana.
     """
     system_info = platform.uname()
+
+    python_libraries = {
+        "bokeh": bokeh_version,
+        "matplotlib": matplotlib_version,
+        "mapca": mapca_version,
+        "nibabel": nibabel_version,
+        "nilearn": nilearn_version,
+        "numpy": numpy_version,
+        "pandas": pandas_version,
+        "scikit-learn": sklearn_version,
+        "scipy": scipy_version,
+        "threadpoolctl": threadpoolctl_version,
+    }
 
     return {
         "System": system_info.system,
@@ -460,4 +487,6 @@ def get_system_info():
         "Version": system_info.version,
         "Machine": system_info.machine,
         "Processor": system_info.processor,
+        "Python": sys.version,
+        "Python_Libraries": python_libraries,
     }

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -150,7 +150,11 @@ def _get_parser():
 
 def _main(argv=None):
     """Run the ica_reclassify workflow."""
-    reclassify_command = "ica_reclassify " + " ".join(sys.argv[1:])
+    if argv:
+        # relevant for tests or if CLI called using ica_reclassify_cli._main(args)
+        reclassify_command = "ica_reclassify " + " ".join(argv)
+    else:
+        reclassify_command = "ica_reclassify " + " ".join(sys.argv[1:])
 
     args = _get_parser().parse_args(argv)
 
@@ -362,8 +366,7 @@ def ica_reclassify_workflow(
         reclassify_command = f"ica_reclassify_workflow({variables})"
 
     # Save system info to json
-    info_dict = utils.get_system_info()
-    info_dict["Python"] = sys.version
+    info_dict = utils.get_system_version_info()
     info_dict["Command"] = reclassify_command
 
     LGR.info(f"Using output directory: {out_dir}")
@@ -512,6 +515,7 @@ def ica_reclassify_workflow(
                     "Version": info_dict["Version"],
                 },
                 "Python": info_dict["Python"],
+                "Python_Libraries": info_dict["Python_Libraries"],
                 "Command": info_dict["Command"],
             }
         ],

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import os
 import os.path as op
+import sys
 
 import numpy as np
 from scipy import stats
@@ -155,6 +156,7 @@ def t2smap_workflow(
     combmode="t2s",
     debug=False,
     quiet=False,
+    t2smap_command=None,
 ):
     """
     Estimate T2 and S0, and optimally combine data across TEs.
@@ -186,6 +188,8 @@ def t2smap_workflow(
         Default is 'all'.
     combmode : {'t2s', 'paid'}, optional
         Combination scheme for TEs: 't2s' (Posse 1999, default), 'paid' (Poser).
+    t2smap_command : :obj:`str`, optional
+        The command used to run t2smap. Default is None.
 
     Other Parameters
     ----------------
@@ -231,6 +235,22 @@ def t2smap_workflow(
     utils.setup_loggers(quiet=quiet, debug=debug)
 
     LGR.info(f"Using output directory: {out_dir}")
+
+    # Save command into sh file, if the command-line interface was used
+    if t2smap_command is not None:
+        command_file = open(os.path.join(out_dir, "t2smap_call.sh"), "w")
+        command_file.write(t2smap_command)
+        command_file.close()
+    else:
+        # Get variables passed to function if the tedana command is None
+        variables = ", ".join(f"{name}={value}" for name, value in locals().items())
+        # From variables, remove everything after ", tedana_command"
+        variables = variables.split(", t2smap_command")[0]
+        t2smap_command = f"t2smap_workflow({variables})"
+
+    # Save system info to json
+    info_dict = utils.get_system_version_info()
+    info_dict["Command"] = t2smap_command
 
     # ensure tes are in appropriate format
     tes = [float(te) for te in tes]
@@ -309,16 +329,28 @@ def t2smap_workflow(
         "DatasetType": "derivative",
         "GeneratedBy": [
             {
-                "Name": "tedana",
+                "Name": "t2smap",
                 "Version": __version__,
                 "Description": (
                     "A pipeline estimating T2* from multi-echo fMRI data and "
                     "combining data across echoes."
                 ),
                 "CodeURL": "https://github.com/ME-ICA/tedana",
+                "Node": {
+                    "Name": info_dict["Node"],
+                    "System": info_dict["System"],
+                    "Machine": info_dict["Machine"],
+                    "Processor": info_dict["Processor"],
+                    "Release": info_dict["Release"],
+                    "Version": info_dict["Version"],
+                },
+                "Python": info_dict["Python"],
+                "Python_Libraries": info_dict["Python_Libraries"],
+                "Command": info_dict["Command"],
             }
         ],
     }
+
     io_generator.save_file(derivative_metadata, "data description json")
     io_generator.save_self()
 
@@ -328,12 +360,17 @@ def t2smap_workflow(
 
 def _main(argv=None):
     """Run the t2smap workflow."""
+    if argv:
+        # relevant for tests when CLI called with t2smap_cli._main(args)
+        t2smap_command = "t2smap " + " ".join(argv)
+    else:
+        t2smap_command = "t2smap " + " ".join(sys.argv[1:])
     options = _get_parser().parse_args(argv)
     kwargs = vars(options)
     n_threads = kwargs.pop("n_threads")
     n_threads = None if n_threads == -1 else n_threads
     with threadpool_limits(limits=n_threads, user_api=None):
-        t2smap_workflow(**kwargs)
+        t2smap_workflow(**kwargs, t2smap_command=t2smap_command)
 
 
 if __name__ == "__main__":

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -515,8 +515,7 @@ def tedana_workflow(
     io_generator.register_input(data)
 
     # Save system info to json
-    info_dict = utils.get_system_info()
-    info_dict["Python"] = sys.version
+    info_dict = utils.get_system_version_info()
     info_dict["Command"] = tedana_command
 
     n_samp, n_echos, n_vols = catd.shape
@@ -844,6 +843,7 @@ def tedana_workflow(
                     "Version": info_dict["Version"],
                 },
                 "Python": info_dict["Python"],
+                "Python_Libraries": info_dict["Python_Libraries"],
                 "Command": info_dict["Command"],
             }
         ],
@@ -909,7 +909,11 @@ def tedana_workflow(
 
 def _main(argv=None):
     """Run the tedana workflow."""
-    tedana_command = "tedana " + " ".join(sys.argv[1:])
+    if argv:
+        # relevant for tests when CLI called with tedana_cli._main(args)
+        tedana_command = "tedana " + " ".join(argv)
+    else:
+        tedana_command = "tedana " + " ".join(sys.argv[1:])
     options = _get_parser().parse_args(argv)
     kwargs = vars(options)
     n_threads = kwargs.pop("n_threads")


### PR DESCRIPTION
When we closed #747 I had made a comment that we might also want to log the version numbers of key modules used by tedana. This PR does that (plus identifies & corrects an omission from that PR)

Changes proposed in this pull request:

- `dataset_description.json` includes the version numbers for all libraries specified in `project.toml`
-  `utils.get_system_info` is now `utils.get_system_and_version_info`. The previous line to get the python version was moved from tedana.py and ica_reclassify.py into this function and this function now compiles the version numbers for the other packages
  - I wouldn't mind someone making sure I'm getting all the version numbers in a pythonic and not-too-inefficient way.
- In making the above changes, I noticed the `tedana` and `ica_reclassify` workflows saves the system information, but `t2smap` did not so I added that info to `t2smap`
- I also noticed that the method in the `_main` functions for getting the text of a command line input worked for an actual command line input, but not `tedana_cli` calls, which we were using in the tests. I think I fixed this is a way that won't break anything else.
  - This causes code coverage to drop since the CLI line that created garbled outputs is now skipped. Not sure how to directly call that line.
- Added library version info to `tedana_report.html` via edits to `report_info_table_template.html` and `html_report.py`

For future work (or edits to this PR). The three work flows all have a very similar block of text to specify and write `derivative_metadata` This could be it's own function. Also, `BIDSVersion` is hard-coded in all three. Given 1.5.0 is the only version we support, that's not a big deal, but, if we ever add an updated output option, we might want to make that a variable.

I was reminded to do this via https://github.com/nipreps/fmriprep/issues/3196
