### PR TITLE
Add Dependabot config and switch Release Drafter to Changelog config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    labels: ["maintenance", "ignore-for-release"]
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: pip
+    directory: "/"
+    labels: ["maintenance", "ignore-for-release"]
+    schedule:
+      interval: weekly

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,0 @@
-template: |
-  ## Release Notes
-
-
-  ## Changes
-
-  $CHANGES

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🛠 Breaking Changes
+      labels:
+        - breaking-change
+    - title: 🎉 Exciting New Features
+      labels:
+        - enhancement
+    - title: 👎 Deprecations
+      labels:
+        - deprecation
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a dependabot config to automatically open PRs updating to new versions of dependencies. This will help us keep up to date _and_ flag any incompatible versions.
- Switch from release drafter to a changelog config. We can use PR labels to organize our release notes.
