### PR TITLE
Fix dynamic reports with bokeh 3.4.0 problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
-    "bokeh",
+    "bokeh>=1.0.0,<=3.4.0",
     "mapca>=0.0.4,<=0.0.5",
     "matplotlib",
     "nibabel>=2.5.1,<=5.2.1",

--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -170,7 +170,7 @@ def _create_kr_plt(comptable_cds, kappa_elbow=None, rho_elbow=None):
     )
     diagonal = models.Slope(gradient=1, y_intercept=0, line_color="#D3D3D3")
     fig.add_layout(diagonal)
-    fig.circle(
+    fig.scatter(
         "kappa",
         "rho",
         size="size",
@@ -287,7 +287,7 @@ def _create_sorted_plt(
         y=comptable_cds.data[y_var].sort_values(ascending=False).values,
         color="black",
     )
-    fig.circle(x_var, y_var, source=comptable_cds, size=5, color="color", alpha=0.7)
+    fig.scatter(x_var, y_var, source=comptable_cds, size=5, color="color", alpha=0.7)
     fig.xaxis.axis_label = x_label
     fig.yaxis.axis_label = y_label
     fig.x_range = models.Range1d(-1, n_comps + 1)
@@ -347,7 +347,9 @@ def _create_varexp_pie_plt(comptable_cds):
     fig.grid.visible = False
     fig.toolbar.logo = None
 
-    circle = models.Circle(x=0, y=1, size=150, fill_color="white", line_color="white")
+    circle = models.Scatter(
+        x=0, y=1, size=150, marker="circle", fill_color="white", line_color="white"
+    )
     fig.add_glyph(circle)
 
     return fig

--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -162,10 +162,15 @@ def _create_kr_plt(comptable_cds, kappa_elbow=None, rho_elbow=None):
             ("Tags", "@classtag"),
         ]
     )
+
     fig = plotting.figure(
         width=400,
         height=400,
-        tools=["tap,wheel_zoom,reset,pan,crosshair,save", kr_hovertool],
+        tools=[
+            "wheel_zoom,reset,pan,crosshair,save",
+            models.TapTool(mode="replace"),
+            kr_hovertool,
+        ],
         title="Kappa / Rho Plot",
     )
     diagonal = models.Slope(gradient=1, y_intercept=0, line_color="#D3D3D3")
@@ -279,7 +284,7 @@ def _create_sorted_plt(
     fig = plotting.figure(
         width=400,
         height=400,
-        tools=["tap,wheel_zoom,reset,pan,crosshair,save", hovertool],
+        tools=["wheel_zoom,reset,pan,crosshair,save", models.TapTool(mode="replace"), hovertool],
         title=title,
     )
     fig.line(
@@ -319,18 +324,22 @@ def _create_sorted_plt(
 
 
 def _create_varexp_pie_plt(comptable_cds):
+
+    pie_hovertool = models.HoverTool(
+        tooltips=[
+            ("Component ID", "@component"),
+            ("Kappa", "@kappa{0.00}"),
+            ("Rho", "@rho{0.00}"),
+            ("Var. Expl.", "@varexp{0.00}%"),
+            ("Tags", "@classtag"),
+        ]
+    )
+
     fig = plotting.figure(
         width=400,
         height=400,
         title="Variance Explained View",
-        tools=["hover,tap,save"],
-        tooltips=[
-            ("Component ID", " @component"),
-            ("Kappa", "@kappa{0.00}"),
-            ("Rho", "@rho{0.00}"),
-            ("Var. Exp.", "@varexp{0.00}%"),
-            ("Tags", "@classtag"),
-        ],
+        tools=[pie_hovertool, models.TapTool(mode="replace"), "save"],
     )
     fig.wedge(
         x=0,


### PR DESCRIPTION
Closes #1063

I've now had 3 people ask about crashes related to this issue I'd like to figure out a nice solution to this problem.

Changes proposed in this pull request:

- Listed version numbers for bokeh in `pyproject.toml`
- Changed a few references from `circle` to `scatter` in `dynamic_figures.py`
- Since the tapping default was changed from `replace` to `xor` in `bokeh v3.4.0` it was possible to select more than one component at a time and that broke other functionality. This directly defines `models.TapTool(mode="replace")` instead of just listing `tap` with the default setting.

~~This no longer crashes, and the static report looks fine, but there is one annoying bug relating to the dynamic interactions. I'm not sure if this is due to the above changes or due to other changes in bokeh 3.4.0. The generated report looks fine, but if you click on one component and then another, then, instead of presenting the most recent one, both are highlighted and you have to unclick each component before highlighting a new one. I could use help from someone who has played with bokeh a bit more than I have (@eurunuela @javiergcas).~~
