### PR TITLE
Include intercept in `get_coeffs` calls

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -658,7 +658,7 @@ def writeresults(ts, mask, comptable, mmix, io_generator):
     acc = comptable[comptable.classification == "accepted"].index.values
     write_split_ts(ts, mmix, mask, comptable, io_generator)
 
-    ts_pes = get_coeffs(ts, mmix, mask)
+    ts_pes = get_coeffs(ts, mmix, mask, add_const=True)
     fout = io_generator.save_file(ts_pes, "ICA components img")
     LGR.info(f"Writing full ICA coefficient feature set: {fout}")
 
@@ -829,7 +829,7 @@ def split_ts(data, mmix, mask, comptable):
     """
     acc = comptable[comptable.classification == "accepted"].index.values
 
-    cbetas = get_coeffs(data - data.mean(axis=-1, keepdims=True), mmix, mask)
+    cbetas = get_coeffs(data, mmix, mask, add_const=True)
     betas = cbetas[mask]
     if len(acc) != 0:
         hikts = utils.unmask(betas[:, acc].dot(mmix.T[acc, :]), mask)

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -50,20 +50,16 @@ def calculate_betas(data, mixing):
     betas : (M x [E] x C) array_like
         Unstandardized parameter estimates
     """
-    if len(data.shape) == 2:
-        data_optcom = data
-        assert data_optcom.shape[1] == mixing.shape[0]
-        # mean-center optimally-combined data
-        data_optcom_dm = data_optcom - data_optcom.mean(axis=-1, keepdims=True)
-        # betas are the result of a normal OLS fit of the mixing matrix
-        # against the mean-center data
-        betas = get_coeffs(data_optcom_dm, mixing)
-        return betas
-    else:
+    if data.ndim == 2:  # data are optimally combined
+        assert data.shape[1] == mixing.shape[0]
+        # betas are the result of a normal OLS fit of the mixing matrix (including an intercept)
+        betas = get_coeffs(data, mixing, add_const=True)
+    else:  # data are echo-wise
         betas = np.zeros([data.shape[0], data.shape[1], mixing.shape[1]])
-        for n_echo in range(data.shape[1]):
-            betas[:, n_echo, :] = get_coeffs(data[:, n_echo, :], mixing)
-        return betas
+        for i_echo in range(data.shape[1]):
+            betas[:, i_echo, :] = get_coeffs(data[:, i_echo, :], mixing, add_const=True)
+
+    return betas
 
 
 def calculate_psc(data_optcom, optcom_betas):

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -335,7 +335,7 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
     mmix = mmix * comptable["optimal sign"].values
 
     # regenerate the beta images
-    component_maps_arr = stats.get_coeffs(ts, mmix, mask)
+    component_maps_arr = stats.get_coeffs(ts, mmix, mask, add_const=True)
     component_maps_arr = component_maps_arr.reshape(
         io_generator.reference_img.shape[:3] + component_maps_arr.shape[1:],
     )


### PR DESCRIPTION
Closes none. I was just thinking that we should include an intercept term when calculating echo-wise betas.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-
