### PR TITLE
minimum nilearn to 0.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "mapca>=0.0.4,<=0.0.5",
     "matplotlib",
     "nibabel>=2.5.1,<=5.2.1",
-    "nilearn>=0.7,<=0.10.4",
+    "nilearn>=0.10.3,<=0.10.4",
     "numpy>=1.16,<=1.26.4",
     "pandas>=2.0,<=2.2.2",
     "pybtex",


### PR DESCRIPTION
@pmolfese notified me of a crash when he ran tedana with nilearn v0.10.2:

```
File ".../python3.11/site-packages/nilearn/plotting/img_plotting.py", line 77, in _get_colorbar_and_data_ranges
    raise ValueError('this function does not accept a "vmin" '
ValueError: this function does not accept a "vmin" argument, as it uses a symmetrical range defined via the vmax argument. To threshold the plotted map, use the "threshold" argument
```

In `static_figures.py` we are calling `nilearn.plotting.plot_stat_map` with the `vmin` option. Going through the nilearn releases, this was only added in v0.10.3  ( https://github.com/nilearn/nilearn/pull/3993 ). I really don't like setting our minimum nilearn version to something that was only released in January 2024. I'd welcome to code changes that address this issue and retain slightly older compatibility, but I'm not sure if there's a way to get the images we want to include in the reports using older versions.

Given this will cause crashes, it would be nice to get a solution merged before releasing our v24.0.1.

Changes proposed in this pull request:

- Raises the minimum nilearn version to 0.10.3
