### PR TITLE
Use nearest-neighbors interpolation in `plot_component`

### DIFF
--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -235,6 +235,7 @@ def plot_component(
         colorbar=False,
         draw_cross=False,
         annotate=False,
+        resampling_interpolation="nearest",
     )
     display.annotate(size=30)
     example_ax = list(display.axes.values())[0]
@@ -601,6 +602,7 @@ def plot_t2star_and_s0(
         vmax=t2s_p98,
         annotate=False,
         output_file=os.path.join(io_generator.out_dir, "figures", t2star_plot),
+        resampling_interpolation="nearest",
     )
 
     s0_plot = f"{io_generator.prefix}s0_brain.svg"
@@ -615,6 +617,7 @@ def plot_t2star_and_s0(
         vmax=s0_p98,
         annotate=False,
         output_file=os.path.join(io_generator.out_dir, "figures", s0_plot),
+        resampling_interpolation="nearest",
     )
 
 
@@ -701,6 +704,7 @@ def plot_rmse(
         vmax=rmse_p98,
         annotate=False,
         output_file=rmse_brain_plot,
+        resampling_interpolation="nearest",
     )
 
 

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -602,7 +602,6 @@ def plot_t2star_and_s0(
         vmax=t2s_p98,
         annotate=False,
         output_file=os.path.join(io_generator.out_dir, "figures", t2star_plot),
-        resampling_interpolation="nearest",
     )
 
     s0_plot = f"{io_generator.prefix}s0_brain.svg"
@@ -617,7 +616,6 @@ def plot_t2star_and_s0(
         vmax=s0_p98,
         annotate=False,
         output_file=os.path.join(io_generator.out_dir, "figures", s0_plot),
-        resampling_interpolation="nearest",
     )
 
 
@@ -704,7 +702,6 @@ def plot_rmse(
         vmax=rmse_p98,
         annotate=False,
         output_file=rmse_brain_plot,
-        resampling_interpolation="nearest",
     )
 
 


### PR DESCRIPTION
Closes #1095.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Switch from the default 'continuous' resampling approach to 'nearest' in `plot_component`'s `plot_stat_map` call. This should stop non-diagonal images from being resampled to have low, non-zero values outside of the brain.
