### PR TITLE
Cleaning up installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,35 +2,47 @@
 Installation
 ############
 
-You'll need to set up a working development environment to use ``tedana``.
-To set up a local environment, you will need Python >=3.8 and the following
-packages will need to be installed:
-
-- nilearn
-- nibabel
-- numpy
-- scikit-learn
-- scipy
-- mapca
-
-After installing relevant dependencies, you can then install ``tedana`` with:
+You'll need to install ``tedana`` in your python environment.
+If you already have a python environment and you want to add tedana, type:
 
 .. code-block:: bash
 
   pip install tedana
 
-In addition to the Python package, installing ``tedana`` will add the ``tedana``
-and ``t2smap`` workflow CLIs to your path.
-You can confirm that ``tedana`` has successfully installed by launching a Python instance and running:
-
-.. code-block:: python
-
-  import tedana
-
-You can check that it is available through the command line interface (CLI) with:
+You can use a program like `conda`_ to create an environment for ``tedana`` with:
 
 .. code-block:: bash
 
-  tedana --help
+  conda create -n tedenv python=3.12 pip
+  conda activate tedenv
+  pip install tedana
+
+The above will create a python environment for tedana called ``tedenv``,
+and you can enter that environment with ``conda activate tedenv``.
+
+With either of the above methods, `pip` will install python and all its dependencies.
+tedana's `dependencies are listed here`_.
+
+
+Once ``tedana`` is installed, there are two ways to run it.
+You can run ``tedana``, ``ica_reclassify``, and ``t2smap`` from the command line interface (CLI).
+You can see the options for any of these commands using ``--help`` (i.e. ``tedana --help``).
+
+You can also import these commands to run within python using:
+
+.. code-block:: python
+
+  from tedana.workflows import ica_reclassify_workflow, t2smap_workflow, tedana_workflow
+
+API instructions for running these `commands in python are here`_.
 
 If no error occurs, ``tedana`` has correctly installed in your environment!
+
+If you are having trouble solving errors,
+`here are places the tedana community monitors`_ to offer support.
+
+
+.. _commands in python are here: https://tedana.readthedocs.io/en/stable/api.html#module-tedana.workflows
+.. _conda: https://www.anaconda.com/download
+.. _dependencies are listed here: https://github.com/ME-ICA/tedana/blob/main/pyproject.toml
+.. _here are places the tedana community monitors: https://tedana.readthedocs.io/en/stable/support.html


### PR DESCRIPTION
Closes #1111

Changes proposed in this pull request:

- Removed an outdated an unnecessary list of python dependencies from our installation instructions. (Unnecessary since a dependencies are automatically installed by `pip`)
- Added a link to `pyproject.toml` so that users can see the list of dependencies and we don't need to keep a parallel copy updated as part of our installation instructions
- Cleaned up the instructions to use less jargon to better explain the remaining jargon
- Added instructions for how to important workflows to run tedana within python (in addition to instructions for running from the command line)
- Added a link to our support page if a user is having problems.

@rcwelsh Does this address our concerns? Any suggestions for making this more clear for end-users who might not be strong programmers?
