### PR TITLE
Add dash versions of underscore params

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -129,7 +129,7 @@ independant and identically distributed (IID),
 and signal leakage from in-slice and multi-slice accelleration may violate this assumption.
 
 We have one option that is generally useful and is also a partial solution.
-``--ica_method robustica`` will run `robustica`_.
+``--ica-method robustica`` will run `robustica`_.
 This is a method that, for a given number of PCA components,
 will repeatedly run ICA and identify components that are stable across iterations.
 While running ICA multiple times will slow processing, as a general benefit,
@@ -152,7 +152,7 @@ but is still sensitive to the intial number of PCA components.
 For example, for a single dataset 60 PCA components might result in 46 stable ICA components,
 while 55 PCA components might results in 43 stable ICA components.
 We are still testing how these interact to give better recommendations for even more stable results.
-While the TEDANA developers expect that ``--ica_method robustica`` may become
+While the TEDANA developers expect that ``--ica-method robustica`` may become
 the default configuration in future TEDANA versions,
 it is first being released to the public as a non-default option
 in hope of gaining insight into its behaviour

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -198,6 +198,7 @@ def _get_parser():
         default=None,
     )
     optional.add_argument(
+        "--ica-method",
         "--ica_method",
         dest="ica_method",
         help=(
@@ -226,6 +227,7 @@ def _get_parser():
         default=DEFAULT_SEED,
     )
     optional.add_argument(
+        "--n-robust-runs",
         "--n_robust_runs",
         dest="n_robust_runs",
         metavar="[5-500]",


### PR DESCRIPTION
Closes none. This makes the formatting of params consistent.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add dash versions of `--ica-method` and `--n-robust-runs`. I didn't remove the underscore versions, but we should in the next major release.

