### PR TITLE
Back-fill, then forward-fill, NaNs in external regressors

### DIFF
--- a/tedana/metrics/external.py
+++ b/tedana/metrics/external.py
@@ -156,6 +156,20 @@ def validate_extern_regress(
             f"external regressor model: {sorted(extra_names)}"
         )
 
+    nan_columns = []
+    for column in external_regressor_names:
+        if external_regressors[column].isna().values.any():
+            nan_columns.append(column)
+
+    if nan_columns:
+        LGR.warning(
+            f"External regressors include columns with NaN values: {sorted(nan_columns)}. "
+            "These will be backfilled with the nearest non-NaN value."
+        )
+        external_regressors = external_regressors.bfill(axis=0)
+        # Also ffill just in case there are NaNs at the end of the time series
+        external_regressors = external_regressors.ffill(axis=0)
+
     # If a model includes specifications for partial regressors, expand them
     for config_idx in range(len(external_regressor_config)):
         if "partial_models" in external_regressor_config[config_idx].keys():


### PR DESCRIPTION
Closes #1152.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Warn if the external regressors have NaNs.
- Back-fill (and forward-fill) cells with NaNs in the external regressors DataFrame.
