### PR TITLE
Add option to overwrite file (and write out extra files with "verbose") in T2smap workflow

### DIFF
--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -152,6 +152,21 @@ def _get_parser():
     optional.add_argument(
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False
     )
+    optional.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Generate intermediate and additional files.",
+        default=False,
+    )
+    optional.add_argument(
+        "--overwrite",
+        "-f",
+        dest="overwrite",
+        action="store_true",
+        help="Force overwriting of files.",
+        default=False,
+    )
     parser._action_groups.append(optional)
     return parser
 
@@ -168,7 +183,9 @@ def t2smap_workflow(
     fitmode="all",
     combmode="t2s",
     debug=False,
+    verbose=False,
     quiet=False,
+    overwrite=False,
     t2smap_command=None,
 ):
     """
@@ -205,6 +222,11 @@ def t2smap_workflow(
         Combination scheme for TEs: 't2s' (Posse 1999, default), 'paid' (Poser).
     t2smap_command : :obj:`str`, optional
         The command used to run t2smap. Default is None.
+    verbose : :obj:`bool`, optional
+        Generate intermediate and additional files. Default is False.
+    overwrite : :obj:`bool`, optional
+        If True, force overwriting of files. Default is False.
+
 
     Other Parameters
     ----------------
@@ -284,6 +306,8 @@ def t2smap_workflow(
         prefix=prefix,
         config="auto",
         make_figures=False,
+        overwrite=overwrite,
+        verbose=verbose,
     )
     n_echos = data_cat.shape[1]
     LGR.debug(f"Resulting data shape: {data_cat.shape}")

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -361,7 +361,7 @@ def _get_parser():
     optional.add_argument(
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False
     )
-    parser.add_argument(
+    optional.add_argument(
         "--overwrite",
         "-f",
         dest="overwrite",


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes [I don't know if there was an issue open for this].

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- T2smap workflow currently does not allow to overwrite files - but stops with runtime error if a file would be overwritten, asking to use the non-existing `--overwrite` argument. This PR solves that issue.
- I saw that in the tedana workflow parser, "overwrite" was added to the parser itself rather than to the "optional" parser group, so just quickly changed that, if desirable.
