### PR TITLE
Add verbose option to ica_reclassify to obtain denoised echo images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@4.0.1
+  codecov: codecov/codecov@1.0.5
 jobs:
   makeenv_38:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.5
+  codecov: codecov/codecov@4.0.1
 jobs:
   makeenv_38:
     docker:

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -143,9 +143,9 @@ class OutputGenerator:
             del old_registry["root"]
             for k, v in old_registry.items():
                 if isinstance(v, list):
-                    self.registry[k] = [op.join(rel_root, vv) for vv in v]
+                    self.registry[k] = [op.normpath(op.join(rel_root, vv)) for vv in v]
                 else:
-                    self.registry[k] = op.join(rel_root, v)
+                    self.registry[k] = op.normpath(op.join(rel_root, v))
 
         if not op.isdir(self.out_dir):
             LGR.info(f"Generating output directory: {self.out_dir}")

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -203,7 +203,7 @@ class OutputGenerator:
         names : list[str]
             The list of filenames being input as multi-echo volumes.
         """
-        self.registry["input img"] = [name for name in names]
+        self.registry["input img"] = [op.relpath(name, start=self.out_dir) for name in names]
 
     def get_name(self, description, **kwargs):
         """Generate a file full path to simplify file output.

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -203,7 +203,7 @@ class OutputGenerator:
         names : list[str]
             The list of filenames being input as multi-echo volumes.
         """
-        self.registry["input img"] = [op.relpath(name, start=self.out_dir) for name in names]
+        self.registry["input img"] = [name for name in names]
 
     def get_name(self, description, **kwargs):
         """Generate a file full path to simplify file output.
@@ -414,7 +414,10 @@ class InputHarvester:
             Description of the file to get the path for.
         """
         if description in self._registry.keys():
-            return op.join(self._base_dir, self._registry[description])
+            if isinstance(self._registry[description], list):
+                return [op.join(self._base_dir, f) for f in self._registry[description]]
+            else:
+                return op.join(self._base_dir, self._registry[description])
         else:
             return None
 
@@ -429,7 +432,10 @@ class InputHarvester:
         """
         for ftype, loader in InputHarvester.loaders.items():
             if ftype in description:
-                return loader(self.get_file_path(description))
+                if isinstance(self.get_file_path(description), list):
+                    return [loader(f) for f in self.get_file_path(description)]
+                else:
+                    return loader(self.get_file_path(description))
 
     @property
     def registry(self):

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -192,6 +192,7 @@ def test_integration_four_echo(skip_integration):
         reject=[4, 5, 6],
         out_dir=out_dir_manual,
         mir=True,
+        verbose=True,
     )
 
     # compare the generated output files

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -401,6 +401,7 @@ def ica_reclassify_workflow(
         used_gs = False
 
     if verbose:
+        LGR.debug("Loading input 4D data")
         data_cat = ioh.get_file_contents("input img")
         # Extract the data from the nibabel objects
         data_cat, _ = io.load_data(data_cat, n_echos=len(data_cat))
@@ -515,6 +516,7 @@ def ica_reclassify_workflow(
         io_generator.overwrite = False
 
     if verbose:
+        LGR.debug("Writing out verbose data")
         io.writeresults_echoes(data_cat, mixing, mask_denoise, component_table, io_generator)
 
     # Write out BIDS-compatible description file

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -404,7 +404,6 @@ def ica_reclassify_workflow(
         data_cat = ioh.get_file_contents("input img")
         # Extract the data from the nibabel objects
         data_cat, _ = io.load_data(data_cat, n_echos=len(data_cat))
-        breakpoint()
 
     io_generator = io.OutputGenerator(
         data_optcom,

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -180,6 +180,7 @@ def _main(argv=None):
         no_reports=args.no_reports,
         png_cmap=args.png_cmap,
         overwrite=args.overwrite,
+        verbose=args.verbose,
         debug=args.debug,
         quiet=args.quiet,
         reclassify_command=reclassify_command,


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1178.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds verbose option to `ica_reclassify`
- Changes the way input files are registered from relative paths to absolute paths
- Adds `verbose = True` to the four echo integration test
