### PR TITLE
Adding python313

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,40 @@ jobs:
           paths:
             - src/coverage/.coverage.py312
 
+  unittest_313:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py313-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Generate environment
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/tedana_py313 ]; then
+              conda create -yq -n tedana_py313 python=3.13
+              source activate tedana_py313
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py313
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py313
+      - save_cache:
+          key: conda-py313-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py313
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py313
+
   style_check:
     docker:
       - image: continuumio/miniconda3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = {file = "LICENSE"}
 requires-python = ">=3.8"


### PR DESCRIPTION
Python 3.13 has been out long enough that I decided to see if tedana runs on it & it ran fine & all tests passed. 

Changes proposed in this pull request:

- Adds python 3.13 to pyproject.toml as a version that can be used with tedana.
- Add python 3.13 to the circleci unit tests (if I correctly made those edits)

