### PR TITLE
Add `--ctab` parameter to `ica_reclassify`

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -353,7 +353,8 @@ def test_integration_reclassify_no_manual(skip_integration):
     args = ["ica_reclassify", reclassify_raw_registry(), "--out-dir", out_dir]
 
     result = subprocess.run(args, capture_output=True)
-    assert result.returncode == 0
+    assert b"ValueError: No updated classifications provided" in result.stderr
+    assert result.returncode != 0
 
 
 def test_integration_reclassify_quiet_csv(skip_integration):

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -335,13 +335,17 @@ def test_integration_three_echo_external_regressors_motion_task_models(skip_inte
     check_integration_outputs(fn, out_dir)
 
 
-def test_integration_reclassify_insufficient_args(skip_integration):
+def test_integration_reclassify_no_manual(skip_integration):
+    """Run reclassification workflow without providing any manual accept/reject arguments.
+
+    This should result in the component table being used for classification.
+    """
     if skip_integration:
         pytest.skip("Skipping reclassify insufficient args")
 
     guarantee_reclassify_data()
 
-    test_data_path, osf_id = data_for_testing_info("three-echo")
+    test_data_path, _ = data_for_testing_info("three-echo")
     out_dir = os.path.abspath(
         os.path.join(test_data_path, "../../outputs/reclassify/insufficient")
     )
@@ -349,8 +353,7 @@ def test_integration_reclassify_insufficient_args(skip_integration):
     args = ["ica_reclassify", reclassify_raw_registry(), "--out-dir", out_dir]
 
     result = subprocess.run(args, capture_output=True)
-    assert b"ValueError: Must manually accept or reject" in result.stderr
-    assert result.returncode != 0
+    assert result.returncode == 0
 
 
 def test_integration_reclassify_quiet_csv(skip_integration):

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -351,12 +351,10 @@ def ica_reclassify_workflow(
     # Check that there is no overlap in accepted/rejected components
     if (not accept) and (not reject) and (not ctab):
         raise ValueError(
-            "No updated classifications provided. Please use --ctab, --manacc, and/or --manref."
+            "No updated classifications provided. Please use --ctab, --manacc, and/or --manrej."
         )
 
-    acc = set(accept)
-    rej = set(reject)
-    in_both = acc.intersection(rej)
+    in_both = set(accept).intersection(reject)
     if len(in_both):
         raise ValueError(f"The following components were both accepted and rejected: {in_both}")
 


### PR DESCRIPTION
Closes #1182.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a `--ctab` parameter to `ica_reclassify` that accepts a component table.
- If `--manacc`, `--manrej`, and `--ctab` are not provided, then raise an error (was being raised if `--manacc` and `--manrej` weren't provided).
