### PR TITLE
update codecov to 5.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.5
+  codecov: codecov/codecov@5.3.0
 jobs:
   makeenv_38:
     docker:


### PR DESCRIPTION
This relates to #1192. Not sure if it closes it yet.

Changes proposed in this pull request:

- updates codecov to v5.3.0 in `.circleci/config.yml`

Once this is merged into `main`, we should update the version in another active PR to see if it properly triggers codecov.
