### PR TITLE
Returns CircleCI config to before version matrics to fix codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             make unittest
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py3.<< parameters.PYTHON >>
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.unittest.py3.<< parameters.PYTHON >>
             fi
       - save_cache:
           key: conda-py3.<< parameters.PYTHON >>-v3-{{ checksum "pyproject.toml" }}
@@ -112,7 +112,7 @@ jobs:
             make three-echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three-echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -143,7 +143,7 @@ jobs:
             make four-echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four-echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -174,7 +174,7 @@ jobs:
             make five-echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five-echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -205,7 +205,7 @@ jobs:
             make reclassify
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.reclassify
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.reclassify
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -236,7 +236,7 @@ jobs:
             make t2smap
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.t2smap
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.t2smap
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -261,6 +261,7 @@ jobs:
             source activate py3.9_env  # depends on makeenv38
             apt-get update
             apt-get install -yqq curl gnupg
+            ls -la /tmp/src/coverage/
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
       - run:
           name: Merge coverage files
           command: |
-            source activate py3.9_env  # depends on makeenv38
+            source activate py3.9_env
             apt-get update
             apt-get install -yqq curl gnupg
             ls -la /tmp/src/coverage/
@@ -271,7 +271,7 @@ jobs:
       - codecov/upload
 
 workflows:
-  upload-to-codecov:
+  test-jobs:
     jobs:
       - py_env:
           name: py_env-3.<< matrix.PYTHON >>
@@ -287,11 +287,10 @@ workflows:
             parameters:
               PYTHON: ["8", "9", "10", "11", "12", "13"]
           requires:
-            - py_env-3.<< matrix.PYTHON >>
+            - py_env-3.<< parameters.PYTHON >>
           post-steps:
             - codecov/upload
       - t2smap:
-          name: t2smap
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -300,7 +299,6 @@ workflows:
           post-steps:
             - codecov/upload
       - reclassify:
-          name: reclassify
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -309,7 +307,6 @@ workflows:
           post-steps:
             - codecov/upload
       - three_echo:
-          name: three_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -318,7 +315,6 @@ workflows:
           post-steps:
             - codecov/upload
       - four_echo:
-          name: four_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -327,7 +323,6 @@ workflows:
           post-steps:
             - codecov/upload
       - five_echo:
-          name: five_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -335,16 +330,19 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
+
+  merge-coverage:
+    jobs:
       - merge_coverage:
           requires:
-            - unittest_38
-            - unittest_39
-            - unittest_310
-            - unittest_311
-            - unittest_312
-            - unittest_313
-            - three_echo
-            - four_echo
-            - five_echo
-            - t2smap
-            - reclassify
+            - test-jobs/unittest_38
+            - test-jobs/unittest_39
+            - test-jobs/unittest_310
+            - test-jobs/unittest_311
+            - test-jobs/unittest_312
+            - test-jobs/unittest_313
+            - test-jobs/t2smap
+            - test-jobs/reclassify
+            - test-jobs/three_echo
+            - test-jobs/four_echo
+            - test-jobs/five_echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,322 +4,417 @@
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@5.3.0
+  codecov: codecov/codecov@5.2.1
 jobs:
-  py_env:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
+  makeenv_38:
     docker:
       - image: continuumio/miniconda3
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - src/tedana
-      - restore_cache: # ensure this step occurs *before* installing dependencies
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
-      - run: # will overwrite pySPFM installation each time
-          name: Generate environment
-          command: |
-            if [[ -e /opt/conda/envs/py3.<< parameters.PYTHON >>_env ]]; then
-                echo "Restoring environment from cache"
-                source activate py3.<< parameters.PYTHON >>_env
-            else
-                conda create -n py3.<< parameters.PYTHON >>_env python=3.<< parameters.PYTHON >> -yq
-                source activate py3.<< parameters.PYTHON >>_env
-                pip install -e .[tests,doc]
-            fi
-      - save_cache: # environment cache tied to requirements
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
-          paths:
-            - "/opt/conda/envs/py3.<< parameters.PYTHON >>_env"
-
-  unittest:
-    parameters:
-      PYTHON:
-        type: string
     working_directory: /tmp/src/tedana
-    docker:
-      - image: continuumio/miniconda3
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Generate environment
           command: |
-            apt-get update
-            apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
-            pip install -e .[all]
+            if [ ! -d /opt/conda/envs/tedana_py38 ]; then
+              conda create -yq -n tedana_py38 python=3.8
+              source activate tedana_py38
+              pip install -e .[tests]
+            fi
+      - save_cache:
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py38
+
+  unittest_38:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Running unit tests
           command: |
-            source activate py3.<< parameters.PYTHON >>_env
+            apt-get update
+            apt-get install -y make
+            source activate tedana_py38  # depends on makeenv_38
             make unittest
-            mkdir -p /tmp/src/coverage/unittest_3<< parameters.PYTHON >>
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/unittest_3<< parameters.PYTHON >>/.coverage
-            fi
-      - save_cache:
-          key: conda-py3.<< parameters.PYTHON >>-v3-{{ checksum "pyproject.toml" }}
-          paths:
-            - /opt/conda/envs/py3.<< parameters.PYTHON >>_env
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py38
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.py38
 
-  style_check:
-    working_directory: /tmp/src/tedana
+  unittest_39:
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}
+          key: conda-py39-v3-{{ checksum "pyproject.toml" }}
       - run:
-          name: Linting
+          name: Generate environment
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate py3.9_env
+            if [ ! -d /opt/conda/envs/tedana_py39 ]; then
+              conda create -yq -n tedana_py39 python=3.9
+              source activate tedana_py39
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py39
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py39
+      - save_cache:
+          key: conda-py39-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py39
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py39
+
+  unittest_310:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py310-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Generate environment
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/tedana_py310 ]; then
+              conda create -yq -n tedana_py310 python=3.10
+              source activate tedana_py310
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py310
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py310
+      - save_cache:
+          key: conda-py310-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py310
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py310
+
+  unittest_311:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py311-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Generate environment
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/tedana_py311 ]; then
+              conda create -yq -n tedana_py311 python=3.11
+              source activate tedana_py311
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py311
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py311
+      - save_cache:
+          key: conda-py311-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py311
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py311
+
+  unittest_312:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py312-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Generate environment
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/tedana_py312 ]; then
+              conda create -yq -n tedana_py312 python=3.12
+              source activate tedana_py312
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py312
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py312
+      - save_cache:
+          key: conda-py312-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py312
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py312
+
+  unittest_313:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py313-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Generate environment
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            if [ ! -d /opt/conda/envs/tedana_py313 ]; then
+              conda create -yq -n tedana_py313 python=3.13
+              source activate tedana_py313
+              pip install .[tests]
+            fi
+      - run:
+          name: Running unit tests
+          command: |
+            source activate tedana_py313
+            make unittest
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py313
+      - save_cache:
+          key: conda-py313-v3-{{ checksum "pyproject.toml" }}
+          paths:
+            - /opt/conda/envs/tedana_py313
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src/coverage/.coverage.py313
+
+  style_check:
+    docker:
+      - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
+    steps:
+      - checkout
+      - restore_cache:
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Style check
+          command: |
+            apt-get update
+            apt-get install -yqq make
+            source activate tedana_py38  # depends on makeenv38
             make lint
 
   three-echo:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
+            source activate tedana_py38  # depends on makeenv_38
             make three-echo
-            mkdir -p /tmp/src/coverage/three-echo
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/three-echo/.coverage
-            fi
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three-echo
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.three-echo
 
   four-echo:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
+            source activate tedana_py38  # depends on makeenv_38
             make four-echo
-            mkdir -p /tmp/src/coverage/four-echo
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/four-echo/.coverage
-            fi
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four-echo
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.four-echo
 
   five-echo:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
+            source activate tedana_py38  # depends on makeenv_38
             make five-echo
-            mkdir -p /tmp/src/coverage/five-echo
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/five-echo/.coverage
-            fi
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five-echo
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.five-echo
 
   reclassify:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
+            source activate tedana_py38  # depends on makeenv_38
             make reclassify
-            mkdir -p /tmp/src/coverage/reclassify
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/reclassify/.coverage
-            fi
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.reclassify
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.reclassify
 
   t2smap:
-    parameters:
-      PYTHON:
-        type: string
-    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
+    working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.<< parameters.PYTHON >>" }}
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl gnupg
-            source activate py3.<< parameters.PYTHON >>_env
+            source activate tedana_py38  # depends on makeenv_38
             make t2smap
-            mkdir -p /tmp/src/coverage/t2smap
-            if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/t2smap/.coverage
-            fi
+            mkdir /tmp/src/coverage
+            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.t2smap
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
       - persist_to_workspace:
           root: /tmp
           paths:
-            - src/coverage
+            - src/coverage/.coverage.t2smap
 
-  test-and-upload-python:
+  merge_coverage:
+    working_directory: /tmp/src/tedana
     docker:
       - image: continuumio/miniconda3
     steps:
+      - attach_workspace:
+          at: /tmp
       - checkout
-      - run: pip install -e .[all]
-      - run: pytest --cov .
+      - restore_cache:
+          key: conda-py38-v3-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Merge coverage files
+          command: |
+            apt-get update
+            apt-get install -yqq curl gnupg
+            source activate tedana_py38  # depends on makeenv38
+            cd /tmp/src/coverage/
+            coverage combine
+            coverage xml
+            mv coverage.xml /tmp/src/tedana/
+      - store_artifacts:
+          path: /tmp/src/coverage
       - codecov/upload
 
 workflows:
   upload-to-codecov:
     jobs:
-      - py_env:
-          name: py_env-3.<< matrix.PYTHON >>
-          matrix:
-            parameters:
-              PYTHON: ["8", "9", "10", "11", "12", "13"]
+      - makeenv_38
+      - unittest_38:
+          requires:
+            - makeenv_38
       - style_check:
           requires:
-            - py_env-3.9
-      - unittest:
-          name: unittest_3<< matrix.PYTHON >>
-          matrix:
-            parameters:
-              PYTHON: ["8", "9", "10", "11", "12", "13"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - t2smap:
-          name: t2smap
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - reclassify:
-          name: reclassify
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
+            - makeenv_38
       - three-echo:
-          name: three-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
           requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
+            - makeenv_38
       - four-echo:
-          name: four-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
           requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
+            - makeenv_38
       - five-echo:
-          name: five-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
           requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - test-and-upload-python:
+            - makeenv_38
+      - reclassify:
+          requires:
+            - makeenv_38
+      - t2smap:
+          requires:
+            - makeenv_38
+      - unittest_39
+      - unittest_310
+      - unittest_311
+      - unittest_312
+      - unittest_313
+      - merge_coverage:
           requires:
             - unittest_38
             - unittest_39
@@ -327,8 +422,8 @@ workflows:
             - unittest_311
             - unittest_312
             - unittest_313
-            - t2smap
-            - reclassify
             - three-echo
             - four-echo
             - five-echo
+            - reclassify
+            - t2smap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,80 +271,79 @@ jobs:
       - codecov/upload
 
 workflows:
-  upload-to-codecov:
-    jobs:
-      - py_env:
-          name: py_env-3.<< matrix.PYTHON >>
-          matrix:
-            parameters:
-              PYTHON: ["8", "9", "10", "11", "12", "13"]
-      - style_check:
-          requires:
-            - py_env-3.9
-      - unittest:
-          name: unittest_3<< matrix.PYTHON >>
-          matrix:
-            parameters:
-              PYTHON: ["8", "9", "10", "11", "12", "13"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - t2smap:
-          name: t2smap
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - reclassify:
-          name: reclassify
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - three-echo:
-          name: three-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - four-echo:
-          name: four-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - five-echo:
-          name: five-echo
-          matrix:
-            parameters:
-              PYTHON: ["9"]
-          requires:
-            - py_env-3.<< matrix.PYTHON >>
-          post-steps:
-            - codecov/upload
-      - merge_coverage:
-          requires:
-            - unittest_38
-            - unittest_39
-            - unittest_310
-            - unittest_311
-            - unittest_312
-            - unittest_313
-            - three-echo
-            - four-echo
-            - five-echo
-            - t2smap
-            - reclassify
+  jobs:
+    - py_env:
+        name: py_env-3.<< matrix.PYTHON >>
+        matrix:
+          parameters:
+            PYTHON: ["8", "9", "10", "11", "12", "13"]
+    - style_check:
+        requires:
+          - py_env-3.9
+    - unittest:
+        name: unittest_3<< matrix.PYTHON >>
+        matrix:
+          parameters:
+            PYTHON: ["8", "9", "10", "11", "12", "13"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - t2smap:
+        name: t2smap
+        matrix:
+          parameters:
+            PYTHON: ["9"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - reclassify:
+        name: reclassify
+        matrix:
+          parameters:
+            PYTHON: ["9"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - three-echo:
+        name: three-echo
+        matrix:
+          parameters:
+            PYTHON: ["9"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - four-echo:
+        name: four-echo
+        matrix:
+          parameters:
+            PYTHON: ["9"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - five-echo:
+        name: five-echo
+        matrix:
+          parameters:
+            PYTHON: ["9"]
+        requires:
+          - py_env-3.<< matrix.PYTHON >>
+        post-steps:
+          - codecov/upload
+    - merge_coverage:
+        requires:
+          - unittest_38
+          - unittest_39
+          - unittest_310
+          - unittest_311
+          - unittest_312
+          - unittest_313
+          - three-echo
+          - four-echo
+          - five-echo
+          - t2smap
+          - reclassify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,4 +319,16 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
-      - test-and-upload-python
+      - test-and-upload-python:
+          requires:
+            - unittest_38
+            - unittest_39
+            - unittest_310
+            - unittest_311
+            - unittest_312
+            - unittest_313
+            - t2smap
+            - reclassify
+            - three-echo
+            - four-echo
+            - five-echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,8 +275,6 @@ workflows:
           matrix:
             parameters:
               PYTHON: ["8", "9", "10", "11", "12", "13"]
-          post-steps:
-            - codecov/upload
       - style_check:
           requires:
             - py_env-3.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,28 @@ jobs:
           paths:
             - src/coverage
 
+  merge_coverage:
+    working_directory: /tmp/src/tedana
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}
+      - run:
+          name: Merge coverage files
+          command: |
+            apt-get update
+            apt-get install -yqq curl gnupg
+            source activate tedana_py38  # depends on makeenv38
+            cd /tmp/src/coverage/
+            coverage combine
+            coverage xml
+            mv coverage.xml /tmp/src/tedana/
+      - store_artifacts:
+          path: /tmp/src/coverage
+      - codecov/upload
+
 workflows:
   upload-to-codecov:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             pip install -e .[all]
       - run:
@@ -107,7 +107,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make three-echo
             mkdir -p /tmp/src/coverage
@@ -138,7 +138,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make four-echo
             mkdir -p /tmp/src/coverage
@@ -169,7 +169,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make five-echo
             mkdir -p /tmp/src/coverage
@@ -200,7 +200,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make reclassify
             mkdir -p /tmp/src/coverage
@@ -231,7 +231,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
+            apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make t2smap
             mkdir -p /tmp/src/coverage
@@ -278,8 +278,6 @@ workflows:
       - style_check:
           requires:
             - py_env-3.9
-          post-steps:
-            - codecov/upload
       - unittest:
           name: unittest_3<< matrix.PYTHON >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ workflows:
             parameters:
               PYTHON: ["8", "9", "10", "11", "12", "13"]
           requires:
-            - py_env-3.<< parameters.PYTHON >>
+            - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
       - t2smap:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,8 +340,3 @@ workflows:
             - unittest_311
             - unittest_312
             - unittest_313
-            - three-echo
-            - four-echo
-            - five-echo
-            - reclassify
-            - t2smap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,8 @@ jobs:
     docker:
       - image: continuumio/miniconda3
     steps:
+      - attach_workspace:
+          at: /tmp
       - checkout
       - restore_cache:
           key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}
@@ -258,7 +260,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq curl gnupg
-            source activate py_env-3.8  # depends on makeenv38
+            source activate py3.8_env  # depends on makeenv38
             cd /tmp/src/coverage/
             coverage combine
             coverage xml
@@ -266,6 +268,7 @@ jobs:
       - store_artifacts:
           path: /tmp/src/coverage
       - codecov/upload
+
 
 workflows:
   upload-to-codecov:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
             source activate py3.9_env
             make lint
 
-  three_echo:
+  three-echo:
     parameters:
       PYTHON:
         type: string
@@ -109,10 +109,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make three_echo
-            mkdir -p /tmp/src/coverage/three_echo
+            make three-echo
+            mkdir -p /tmp/src/coverage/three-echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/three_echo/.coverage
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/three-echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -121,7 +121,7 @@ jobs:
           paths:
             - src/coverage
 
-  four_echo:
+  four-echo:
     parameters:
       PYTHON:
         type: string
@@ -140,10 +140,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make four_echo
-            mkdir -p /tmp/src/coverage/four_echo
+            make four-echo
+            mkdir -p /tmp/src/coverage/four-echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/four_echo/.coverage
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/four-echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -152,7 +152,7 @@ jobs:
           paths:
             - src/coverage
 
-  five_echo:
+  five-echo:
     parameters:
       PYTHON:
         type: string
@@ -171,10 +171,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make five_echo
-            mkdir -p /tmp/src/coverage/five_echo
+            make five-echo
+            mkdir -p /tmp/src/coverage/five-echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/five_echo/.coverage
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/five-echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -325,8 +325,8 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
-      - three_echo:
-          name: three_echo
+      - three-echo:
+          name: three-echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -334,8 +334,8 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
-      - four_echo:
-          name: four_echo
+      - four-echo:
+          name: four-echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -343,8 +343,8 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
-      - five_echo:
-          name: five_echo
+      - five-echo:
+          name: five-echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -362,6 +362,6 @@ workflows:
             - unittest_313
             - t2smap
             - reclassify
-            - three_echo
-            - four_echo
-            - five_echo
+            - three-echo
+            - four-echo
+            - five-echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,11 +333,13 @@ workflows:
           post-steps:
             - codecov/upload
       - merge_coverage:
-          matrix:
-            parameters:
-              PYTHON: ["8", "9", "10", "11", "12", "13"]
           requires:
-            - unittest_3<< matrix.PYTHON >>
+            - unittest_38
+            - unittest_39
+            - unittest_310
+            - unittest_311
+            - unittest_312
+            - unittest_313
             - three-echo
             - four-echo
             - five-echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq curl gnupg
-            source activate tedana_py38  # depends on makeenv38
+            source activate py_env-3.8  # depends on makeenv38
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
             source activate py3.9_env
             make lint
 
-  three-echo:
+  three_echo:
     parameters:
       PYTHON:
         type: string
@@ -109,10 +109,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make three-echo
+            make three_echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three_echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -121,7 +121,7 @@ jobs:
           paths:
             - src/coverage
 
-  four-echo:
+  four_echo:
     parameters:
       PYTHON:
         type: string
@@ -140,10 +140,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make four-echo
+            make four_echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four_echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -152,7 +152,7 @@ jobs:
           paths:
             - src/coverage
 
-  five-echo:
+  five_echo:
     parameters:
       PYTHON:
         type: string
@@ -171,10 +171,10 @@ jobs:
             apt-get install -yqq make
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
-            make five-echo
+            make five_echo
             mkdir -p /tmp/src/coverage
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five-echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five_echo
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -271,79 +271,80 @@ jobs:
       - codecov/upload
 
 workflows:
-  jobs:
-    - py_env:
-        name: py_env-3.<< matrix.PYTHON >>
-        matrix:
-          parameters:
-            PYTHON: ["8", "9", "10", "11", "12", "13"]
-    - style_check:
-        requires:
-          - py_env-3.9
-    - unittest:
-        name: unittest_3<< matrix.PYTHON >>
-        matrix:
-          parameters:
-            PYTHON: ["8", "9", "10", "11", "12", "13"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - t2smap:
-        name: t2smap
-        matrix:
-          parameters:
-            PYTHON: ["9"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - reclassify:
-        name: reclassify
-        matrix:
-          parameters:
-            PYTHON: ["9"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - three-echo:
-        name: three-echo
-        matrix:
-          parameters:
-            PYTHON: ["9"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - four-echo:
-        name: four-echo
-        matrix:
-          parameters:
-            PYTHON: ["9"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - five-echo:
-        name: five-echo
-        matrix:
-          parameters:
-            PYTHON: ["9"]
-        requires:
-          - py_env-3.<< matrix.PYTHON >>
-        post-steps:
-          - codecov/upload
-    - merge_coverage:
-        requires:
-          - unittest_38
-          - unittest_39
-          - unittest_310
-          - unittest_311
-          - unittest_312
-          - unittest_313
-          - three-echo
-          - four-echo
-          - five-echo
-          - t2smap
-          - reclassify
+  upload-to-codecov:
+    jobs:
+      - py_env:
+          name: py_env-3.<< matrix.PYTHON >>
+          matrix:
+            parameters:
+              PYTHON: ["8", "9", "10", "11", "12", "13"]
+      - style_check:
+          requires:
+            - py_env-3.9
+      - unittest:
+          name: unittest_3<< matrix.PYTHON >>
+          matrix:
+            parameters:
+              PYTHON: ["8", "9", "10", "11", "12", "13"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - t2smap:
+          name: t2smap
+          matrix:
+            parameters:
+              PYTHON: ["9"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - reclassify:
+          name: reclassify
+          matrix:
+            parameters:
+              PYTHON: ["9"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - three_echo:
+          name: three_echo
+          matrix:
+            parameters:
+              PYTHON: ["9"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - four_echo:
+          name: four_echo
+          matrix:
+            parameters:
+              PYTHON: ["9"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - five_echo:
+          name: five_echo
+          matrix:
+            parameters:
+              PYTHON: ["9"]
+          requires:
+            - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
+      - merge_coverage:
+          requires:
+            - unittest_38
+            - unittest_39
+            - unittest_310
+            - unittest_311
+            - unittest_312
+            - unittest_313
+            - three_echo
+            - four_echo
+            - five_echo
+            - t2smap
+            - reclassify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
           post-steps:
             - codecov/upload
       - t2smap:
-          name: t2smap_job
+          name: t2smap
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -300,7 +300,7 @@ workflows:
           post-steps:
             - codecov/upload
       - reclassify:
-          name: reclassify_job
+          name: reclassify
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -309,7 +309,7 @@ workflows:
           post-steps:
             - codecov/upload
       - three_echo:
-          name: three_echo_job
+          name: three_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -318,7 +318,7 @@ workflows:
           post-steps:
             - codecov/upload
       - four_echo:
-          name: four_echo_job
+          name: four_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -327,7 +327,7 @@ workflows:
           post-steps:
             - codecov/upload
       - five_echo:
-          name: five_echo_job
+          name: five_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -343,8 +343,8 @@ workflows:
             - unittest_311
             - unittest_312
             - unittest_313
-            - three_echo_job
-            - four_echo_job
-            - five_echo_job
-            - t2smap_job
-            - reclassify_job
+            - three_echo
+            - four_echo
+            - five_echo
+            - t2smap
+            - reclassify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,9 @@ jobs:
           command: |
             source activate py3.<< parameters.PYTHON >>_env
             make unittest
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/unittest_3<< parameters.PYTHON >>
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.unittest.py3.<< parameters.PYTHON >>
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/unittest_3<< parameters.PYTHON >>/.coverage
             fi
       - save_cache:
           key: conda-py3.<< parameters.PYTHON >>-v3-{{ checksum "pyproject.toml" }}
@@ -110,9 +110,9 @@ jobs:
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make three_echo
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/three_echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three_echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/three_echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -141,9 +141,9 @@ jobs:
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make four_echo
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/four_echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four_echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/four_echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -172,9 +172,9 @@ jobs:
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make five_echo
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/five_echo
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five_echo
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/five_echo/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -203,9 +203,9 @@ jobs:
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make reclassify
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/reclassify
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.reclassify
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/reclassify/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -234,9 +234,9 @@ jobs:
             apt-get install -yqq curl gnupg
             source activate py3.<< parameters.PYTHON >>_env
             make t2smap
-            mkdir -p /tmp/src/coverage
+            mkdir -p /tmp/src/coverage/t2smap
             if [ -f /tmp/src/tedana/.coverage ]; then
-              cp /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.t2smap
+              cp /tmp/src/tedana/.coverage /tmp/src/coverage/t2smap/.coverage
             fi
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs
@@ -261,9 +261,26 @@ jobs:
             source activate py3.9_env
             apt-get update
             apt-get install -yqq curl gnupg
+
+            # List all coverage directories
             ls -la /tmp/src/coverage/
+
+            # Create a combined coverage file
             cd /tmp/src/coverage/
-            coverage combine
+
+            # Create a combined .coveragerc file to handle paths
+            echo "[paths]" > .coveragerc
+            echo "source =" >> .coveragerc
+            echo "    /tmp/src/tedana" >> .coveragerc
+
+            # Combine all coverage files from subdirectories
+            echo "Finding coverage files in subdirectories..."
+            find . -name ".coverage" -type f | xargs ls -la
+
+            # Combine using absolute paths to avoid issues
+            find . -name ".coverage" -type f -print0 | xargs -0 -I{} coverage combine --append "{}"
+
+            # Generate the XML report
             coverage xml
             mv coverage.xml /tmp/src/tedana/
       - store_artifacts:
@@ -271,7 +288,7 @@ jobs:
       - codecov/upload
 
 workflows:
-  test-jobs:
+  coverage:
     jobs:
       - py_env:
           name: py_env-3.<< matrix.PYTHON >>
@@ -291,6 +308,7 @@ workflows:
           post-steps:
             - codecov/upload
       - t2smap:
+          name: t2smap
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -299,6 +317,7 @@ workflows:
           post-steps:
             - codecov/upload
       - reclassify:
+          name: reclassify
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -307,6 +326,7 @@ workflows:
           post-steps:
             - codecov/upload
       - three_echo:
+          name: three_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -315,6 +335,7 @@ workflows:
           post-steps:
             - codecov/upload
       - four_echo:
+          name: four_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -323,6 +344,7 @@ workflows:
           post-steps:
             - codecov/upload
       - five_echo:
+          name: five_echo
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -330,19 +352,16 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
-
-  merge-coverage:
-    jobs:
       - merge_coverage:
           requires:
-            - test-jobs/unittest_38
-            - test-jobs/unittest_39
-            - test-jobs/unittest_310
-            - test-jobs/unittest_311
-            - test-jobs/unittest_312
-            - test-jobs/unittest_313
-            - test-jobs/t2smap
-            - test-jobs/reclassify
-            - test-jobs/three_echo
-            - test-jobs/four_echo
-            - test-jobs/five_echo
+            - unittest_38
+            - unittest_39
+            - unittest_310
+            - unittest_311
+            - unittest_312
+            - unittest_313
+            - t2smap
+            - reclassify
+            - three_echo
+            - four_echo
+            - five_echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,3 +332,14 @@ workflows:
             - py_env-3.<< matrix.PYTHON >>
           post-steps:
             - codecov/upload
+      - merge_coverage:
+          matrix:
+            parameters:
+              PYTHON: ["8", "9", "10", "11", "12", "13"]
+          requires:
+            - unittest_3<< matrix.PYTHON >>
+            - three-echo
+            - four-echo
+            - five-echo
+            - reclassify
+            - t2smap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
       - run:
           name: Merge coverage files
           command: |
-            source activate py3.8_env  # depends on makeenv38
+            source activate py3.9_env  # depends on makeenv38
             apt-get update
             apt-get install -yqq curl gnupg
             cd /tmp/src/coverage/
@@ -268,7 +268,6 @@ jobs:
       - store_artifacts:
           path: /tmp/src/coverage
       - codecov/upload
-
 
 workflows:
   upload-to-codecov:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
           post-steps:
             - codecov/upload
       - t2smap:
-          name: t2smap
+          name: t2smap_job
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -300,7 +300,7 @@ workflows:
           post-steps:
             - codecov/upload
       - reclassify:
-          name: reclassify
+          name: reclassify_job
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -309,7 +309,7 @@ workflows:
           post-steps:
             - codecov/upload
       - three_echo:
-          name: three_echo
+          name: three_echo_job
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -318,7 +318,7 @@ workflows:
           post-steps:
             - codecov/upload
       - four_echo:
-          name: four_echo
+          name: four_echo_job
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -327,7 +327,7 @@ workflows:
           post-steps:
             - codecov/upload
       - five_echo:
-          name: five_echo
+          name: five_echo_job
           matrix:
             parameters:
               PYTHON: ["9"]
@@ -343,8 +343,8 @@ workflows:
             - unittest_311
             - unittest_312
             - unittest_313
-            - three_echo
-            - four_echo
-            - five_echo
-            - t2smap
-            - reclassify
+            - three_echo_job
+            - four_echo_job
+            - five_echo_job
+            - t2smap_job
+            - reclassify_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,3 +343,8 @@ workflows:
             - unittest_311
             - unittest_312
             - unittest_313
+            - three-echo
+            - four-echo
+            - five-echo
+            - t2smap
+            - reclassify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,28 +245,6 @@ jobs:
           paths:
             - src/coverage
 
-  merge_coverage:
-    working_directory: /tmp/src/tedana
-    docker:
-      - image: continuumio/miniconda3
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}
-      - run:
-          name: Merge coverage files
-          command: |
-            apt-get update
-            apt-get install -yqq curl gnupg
-            source activate tedana_py38  # depends on makeenv38
-            cd /tmp/src/coverage/
-            coverage combine
-            coverage xml
-            mv coverage.xml /tmp/src/tedana/
-      - store_artifacts:
-          path: /tmp/src/coverage
-      - codecov/upload
-
 workflows:
   upload-to-codecov:
     jobs:
@@ -275,9 +253,13 @@ workflows:
           matrix:
             parameters:
               PYTHON: ["8", "9", "10", "11", "12", "13"]
+          post-steps:
+            - codecov/upload
       - style_check:
           requires:
             - py_env-3.9
+          post-steps:
+            - codecov/upload
       - unittest:
           name: unittest_3<< matrix.PYTHON >>
           matrix:
@@ -285,6 +267,8 @@ workflows:
               PYTHON: ["8", "9", "10", "11", "12", "13"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
       - t2smap:
           name: t2smap
           matrix:
@@ -292,6 +276,8 @@ workflows:
               PYTHON: ["9"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
       - reclassify:
           name: reclassify
           matrix:
@@ -299,6 +285,8 @@ workflows:
               PYTHON: ["9"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
       - three-echo:
           name: three-echo
           matrix:
@@ -306,6 +294,8 @@ workflows:
               PYTHON: ["9"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
       - four-echo:
           name: four-echo
           matrix:
@@ -313,6 +303,8 @@ workflows:
               PYTHON: ["9"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload
       - five-echo:
           name: five-echo
           matrix:
@@ -320,3 +312,5 @@ workflows:
               PYTHON: ["9"]
           requires:
             - py_env-3.<< matrix.PYTHON >>
+          post-steps:
+            - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,15 +250,17 @@ jobs:
     docker:
       - image: continuumio/miniconda3
     steps:
+      - attach_workspace:
+          at: /tmp
       - checkout
       - restore_cache:
           key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}
       - run:
           name: Merge coverage files
           command: |
+            source activate py3.8_env  # depends on makeenv38
             apt-get update
             apt-get install -yqq curl gnupg
-            source activate py3.8_env  # depends on makeenv38
             cd /tmp/src/coverage/
             coverage combine
             coverage xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,6 @@ jobs:
     docker:
       - image: continuumio/miniconda3
     steps:
-      - attach_workspace:
-          at: /tmp
       - checkout
       - restore_cache:
           key: v1-{{ checksum "pyproject.toml" }}-{{ "3.9" }}


### PR DESCRIPTION
Closes #1192.

Me and @eurunuela tried to do a lot of things to get codecov working againa fter #1190 changed `.circleci/config.yml` to use version matrices. After nothing worked we decided to go back to the config from before #1190 that did work. We can then separately try to figure out how to switch back to version matrics without (again) breaking codecov interactions.

Changes proposed in this pull request:

- Replaced `.circleci/config.yml` with the version that existed before #1190