### PR TITLE
add warning for when tedana calculates mask

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -254,7 +254,7 @@ def test_integration_three_echo(skip_integration):
     check_integration_outputs(fn, out_dir)
 
 
-def test_integration_three_echo_external_regressors_single_model(skip_integration):
+def test_integration_three_echo_external_regressors_single_model(skip_integration, caplog):
     """Integration test of tedana workflow with extern regress and F stat."""
 
     if skip_integration:
@@ -298,6 +298,8 @@ def test_integration_three_echo_external_regressors_single_model(skip_integratio
     # compare the generated output files
     fn = resource_filename("tedana", "tests/data/cornell_three_echo_outputs.txt")
     check_integration_outputs(fn, out_dir)
+
+    assert "It is strongly recommended to provide an external mask," in caplog.text
 
 
 def test_integration_three_echo_external_regressors_motion_task_models(skip_integration):

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -106,7 +106,7 @@ def _get_parser():
             "space as `data`. If an explicit mask is not "
             "provided, then Nilearn's compute_epi_mask "
             "function will be used to derive a mask "
-            "from the first echo's data."
+            "from the first echo's data. "
             "Providing a mask is recommended."
         ),
         default=None,
@@ -443,7 +443,7 @@ def tedana_workflow(
         then Nilearn's compute_epi_mask function will be used to derive a mask
         from the first echo's data.
         Since most pipelines use better masking tools,
-        providing a mask, rather than using compute_epi_mask is recommended.
+        providing a mask, rather than using compute_epi_mask, is recommended.
     convention : {'bids', 'orig'}, optional
         Filenaming convention. bids uses the latest BIDS derivatives version (1.5.0).
         Default is 'bids'.

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -107,6 +107,7 @@ def _get_parser():
             "provided, then Nilearn's compute_epi_mask "
             "function will be used to derive a mask "
             "from the first echo's data."
+            "Providing a mask is recommended."
         ),
         default=None,
     )
@@ -441,6 +442,8 @@ def tedana_workflow(
         spatially aligned with `data`. If an explicit mask is not provided,
         then Nilearn's compute_epi_mask function will be used to derive a mask
         from the first echo's data.
+        Since most pipelines use better masking tools,
+        providing a mask, rather than using compute_epi_mask is recommended.
     convention : {'bids', 'orig'}, optional
         Filenaming convention. bids uses the latest BIDS derivatives version (1.5.0).
         Default is 'bids'.
@@ -688,7 +691,7 @@ def tedana_workflow(
         RepLGR.info("A user-defined mask was applied to the data.")
         mask = utils.reshape_niimg(mask).astype(int)
     elif t2smap and not mask:
-        LGR.info("Using user-defined T2* map to generate mask")
+        LGR.info("Assuming user=defined T2* map is masked and using it to generate mask")
         t2s_limited_sec = utils.reshape_niimg(t2smap)
         t2s_limited = utils.sec2millisec(t2s_limited_sec)
         t2s_full = t2s_limited.copy()
@@ -701,7 +704,12 @@ def tedana_workflow(
         mask = utils.reshape_niimg(mask).astype(int)
         mask[t2s_limited == 0] = 0  # reduce mask based on T2* map
     else:
-        LGR.info("Computing EPI mask from first echo")
+        LGR.warning(
+            "Computing EPI mask from first echo using nilearn's compute_epi_mask function. "
+            "Most external pipelines include more reliable masking functions. "
+            "It is strongly recommended to provide an external mask, "
+            "and to visually confirm that mask accurately conforms to data boundaries."
+        )
         first_echo_img = io.new_nii_like(io_generator.reference_img, data_cat[:, 0, :])
         mask = compute_epi_mask(first_echo_img).get_fdata()
         mask = utils.reshape_niimg(mask).astype(int)


### PR DESCRIPTION
Closes #1176.

We regularly receive user feedback that the masks calculated within tedana using `nilearns`'s `compute_epi_mask` sometimes removes too many potentially good voxels. Our documented recommendation is that users should provide their own masks.

It's useful to keep existing functionality so that tedana can run without a user-provided mask and we don't break backwards compatibility, but we should make the above message more explicit.

Changes proposed in this pull request:

- Added text recommending users provide their own mask to the CLI and API descriptions for `mask`
- Changed an `LGR.info` to an `LGR.warning` with a more detailed message when an external mask is not provided
- Clarified an `LGR.info` message to state that, when a T2* map and no mask is provided, tedana assumes the T2* map is masked and uses the non-zero values of the map for the mask
- Added a test to make sure the warning appears.

FWIW, in making this PR, I noticed that our integration tests don't include providing a `mask` option besides `None` to `tedana` and don't include providing a T2* map. That's not essential to add now, & is something that should be addressed whenever we get around to doing #920
