### PR TITLE
Properly flip ICA mixing matrix time series

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -354,7 +354,7 @@ def tedpca(
         "d_table_score",
     ]
     # Even if user inputted, don't fit external_regressors to PCA components
-    component_table, _ = metrics.collect.generate_metrics(
+    component_table, comp_ts = metrics.collect.generate_metrics(
         data_cat=data_cat,
         data_optcom=data_optcom,
         mixing=comp_ts,

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -667,7 +667,9 @@ def get_metadata(component_table: pd.DataFrame) -> Dict:
             "Description": (
                 "Optimal sign determined based on skew direction of component parameter estimates "
                 "across the brain. In cases where components were left-skewed (-1), the component "
-                "time series and map weights are flipped prior to metric calculation."
+                "time series and map weights are flipped prior to metric calculation. "
+                "This sign applies to the original mixing matrix and map weights. "
+                "The outputs produced by tedana are already flipped."
             ),
             "Levels": {
                 1: "Component is not flipped prior to metric calculation.",

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -35,7 +35,7 @@ def generate_metrics(
     external_regressors: Union[pd.DataFrame, None] = None,
     external_regressor_config: Union[List[Dict], None] = None,
     metrics: Union[List[str], None] = None,
-) -> Tuple[pd.DataFrame, Dict]:
+) -> Tuple[pd.DataFrame, npt.NDArray]:
     """Fit TE-dependence and -independence models to components.
 
     Parameters
@@ -76,9 +76,11 @@ def generate_metrics(
     component_table : (C x X) :obj:`pandas.DataFrame`
         Component metric table. One row for each component, with a column for each metric.
         The index is the component number.
-    external_regressor_config : :obj:`dict`
-        Info describing the external regressors and method used for fitting and statistical tests
-        (or None if none were inputed)
+    mixing : (T x C) array_like
+        Mixing matrix for converting input data to component space,
+        where `C` is components and `T` is the same as in `data_cat`
+        The signs of a component time series are flipped so that the components spatial map
+        has more positive voxel weights
     """
     # Load metric dependency tree from json file
     dependency_config = op.join(utils.get_resource_path(), "config", "metrics.json")
@@ -460,7 +462,7 @@ def generate_metrics(
     other_columns = [col for col in component_table.columns if col not in preferred_order]
     component_table = component_table[first_columns + other_columns]
 
-    return component_table, external_regressor_config
+    return component_table, mixing
 
 
 def get_metadata(component_table: pd.DataFrame) -> Dict:
@@ -665,7 +667,7 @@ def get_metadata(component_table: pd.DataFrame) -> Dict:
             "Description": (
                 "Optimal sign determined based on skew direction of component parameter estimates "
                 "across the brain. In cases where components were left-skewed (-1), the component "
-                "time series is flipped prior to metric calculation."
+                "time series and map weights are flipped prior to metric calculation."
             ),
             "Levels": {
                 1: "Component is not flipped prior to metric calculation.",

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -340,7 +340,6 @@ def comp_figures(ts, mask, component_table, mixing, io_generator, png_cmap):
     io_generator : :obj:`tedana.io.OutputGenerator`
         Output Generator object to use for this workflow
     """
-
     # regenerate the beta images
     component_maps_arr = stats.get_coeffs(ts, mixing, mask)
     component_maps_arr = component_maps_arr.reshape(

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -340,8 +340,6 @@ def comp_figures(ts, mask, component_table, mixing, io_generator, png_cmap):
     io_generator : :obj:`tedana.io.OutputGenerator`
         Output Generator object to use for this workflow
     """
-    # Flip signs of mixing matrix as needed
-    mixing = mixing * component_table["optimal sign"].values
 
     # regenerate the beta images
     component_maps_arr = stats.get_coeffs(ts, mixing, mask)

--- a/tedana/tests/data/nih_five_echo_outputs_verbose.txt
+++ b/tedana/tests/data/nih_five_echo_outputs_verbose.txt
@@ -121,6 +121,9 @@ figures/sub-01_comp_028.png
 figures/sub-01_comp_029.png
 figures/sub-01_comp_030.png
 figures/sub-01_comp_031.png
+figures/sub-01_comp_032.png
+figures/sub-01_comp_033.png
+figures/sub-01_comp_034.png
 figures/sub-01_rmse_brain.svg
 figures/sub-01_rmse_timeseries.svg
 figures/sub-01_s0_brain.svg

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -8,6 +8,7 @@ import pytest
 
 from tedana import io, utils
 from tedana.metrics import collect, dependence, external
+from tedana.metrics._utils import flip_components
 from tedana.tests.test_external_metrics import (
     sample_external_regressor_config,
     sample_external_regressors,
@@ -74,7 +75,7 @@ def test_smoke_generate_metrics(testdata1):
         external_regressors, external_regressor_config, n_vols
     )
 
-    component_table, _ = collect.generate_metrics(
+    component_table, new_mixing = collect.generate_metrics(
         data_cat=testdata1["data_cat"],
         data_optcom=testdata1["data_optcom"],
         mixing=testdata1["mixing"],
@@ -87,6 +88,12 @@ def test_smoke_generate_metrics(testdata1):
         metrics=metrics,
     )
     assert isinstance(component_table, pd.DataFrame)
+    # new_mixing should have flipped signs compared to mixing.
+    # multiplying by "optimal sign" will flip the signs back so it should match
+    assert (
+        np.round(flip_components(new_mixing, signs=component_table["optimal sign"].to_numpy()), 4)
+        == np.round(testdata1["mixing"], 4)
+    ).all()
 
 
 def test_generate_metrics_fails(testdata1):

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -841,7 +841,7 @@ def tedana_workflow(
             extra_metrics = ["variance explained", "normalized variance explained", "kappa", "rho"]
             necessary_metrics = sorted(list(set(necessary_metrics + extra_metrics)))
 
-            component_table, _ = metrics.collect.generate_metrics(
+            component_table, mixing = metrics.collect.generate_metrics(
                 data_cat=data_cat,
                 data_optcom=data_optcom,
                 mixing=mixing,
@@ -905,7 +905,7 @@ def tedana_workflow(
         extra_metrics = ["variance explained", "normalized variance explained", "kappa", "rho"]
         necessary_metrics = sorted(list(set(necessary_metrics + extra_metrics)))
 
-        component_table, _ = metrics.collect.generate_metrics(
+        component_table, mixing = metrics.collect.generate_metrics(
             data_cat=data_cat,
             data_optcom=data_optcom,
             mixing=mixing,

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -668,11 +668,15 @@ def tedana_workflow(
     if mixing_file is not None and op.isfile(mixing_file):
         mixing_file = op.abspath(mixing_file)
         # Allow users to re-run on same folder
-        mixing_name = io_generator.get_name("ICA mixing tsv")
-        if op.basename(mixing_file) != op.basename(mixing_name):
-            shutil.copyfile(mixing_file, op.join(io_generator.out_dir, op.basename(mixing_file)))
+        mixing_name_output = io_generator.get_name("ICA mixing tsv")
+        mixing_file_new_path = op.join(io_generator.out_dir, op.basename(mixing_file))
+        if op.basename(mixing_file) != op.basename(mixing_name_output) and not op.isfile(
+            mixing_file_new_path
+        ):
+            shutil.copyfile(mixing_file, mixing_file_new_path)
         else:
             # Add "user_provided" to the mixing file's name if it's identical to the new file name
+            # or if there's already a file in the output directory with the same name
             shutil.copyfile(
                 mixing_file,
                 op.join(io_generator.out_dir, f"user_provided_{op.basename(mixing_file)}"),

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -670,7 +670,6 @@ def tedana_workflow(
         # Allow users to re-run on same folder
         mixing_name = io_generator.get_name("ICA mixing tsv")
         if mixing_file != mixing_name:
-            shutil.copyfile(mixing_file, mixing_name)
             shutil.copyfile(mixing_file, op.join(io_generator.out_dir, op.basename(mixing_file)))
     elif mixing_file is not None:
         raise OSError("Argument '--mix' must be an existing file.")
@@ -896,7 +895,6 @@ def tedana_workflow(
         io_generator.overwrite = overwrite  # Re-enable original overwrite behavior
     else:
         LGR.info("Using supplied mixing matrix from ICA")
-        mixing_file = io_generator.get_name("ICA mixing tsv")
         mixing = pd.read_table(mixing_file).values
 
         # selector = ComponentSelector(tree)
@@ -926,17 +924,10 @@ def tedana_workflow(
             n_independent_echos=n_independent_echos,
         )
 
-    # TODO The ICA mixing matrix should be written out after it is created
-    #     It is currently being written after component selection is done
-    #     and rewritten if an existing mixing matrix is given as an input
     comp_names = component_table["Component"].values
     mixing_df = pd.DataFrame(data=mixing, columns=comp_names)
-    if not op.exists(io_generator.get_name("ICA mixing tsv")):
-        io_generator.save_file(mixing_df, "ICA mixing tsv")
-    else:  # Make sure the relative path to the supplied mixing matrix is saved in the registry
-        io_generator.registry["ICA mixing tsv"] = op.basename(
-            io_generator.get_name("ICA mixing tsv")
-        )
+    io_generator.save_file(mixing_df, "ICA mixing tsv")
+
     betas_oc = utils.unmask(computefeats2(data_optcom, mixing, mask_denoise), mask_denoise)
     io_generator.save_file(betas_oc, "z-scored ICA components img")
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -669,8 +669,14 @@ def tedana_workflow(
         mixing_file = op.abspath(mixing_file)
         # Allow users to re-run on same folder
         mixing_name = io_generator.get_name("ICA mixing tsv")
-        if mixing_file != mixing_name:
+        if op.basename(mixing_file) != op.basename(mixing_name):
             shutil.copyfile(mixing_file, op.join(io_generator.out_dir, op.basename(mixing_file)))
+        else:
+            # Add "user_provided" to the mixing file's name if it's identical to the new file name
+            shutil.copyfile(
+                mixing_file,
+                op.join(io_generator.out_dir, f"user_provided_{op.basename(mixing_file)}"),
+            )
     elif mixing_file is not None:
         raise OSError("Argument '--mix' must be an existing file.")
 


### PR DESCRIPTION
Closes #1206 and reverts the changes in #748.
Closes #981 (Update: I realized it was really easy to also address this issue within this PR)

The signs of PCA & ICA components are flipped so that there are more positive vs negative values in the component weight maps. The maps were saved with the flipped values, but the time series in the mixing matrices were not. On a second look, after opening the issue, I realized that we actually were correctly flipping the mixing matrix in `collect.py` but `generate_metrics` was not returning the updated mixing matrix to be used elsewhere & saved.

I am labelling this a `breaking change` because the time series in the mixing matrix files might change, but it should not meaningfully alter results.

Changes proposed in this pull request:

- `collect.py/generate_metrics` now returns the mixing matrix with columns appropriately flipped by "Optimal Sign"
- I realized that `collect.py/generate_metrics` was returning `external_regressor_config` but it was not being altered within the function and the variable was never being updated by functions that called `generate_metrics` so I removed this returned value
- Text describing "optimal sign" in the component matrix was already correct, but I tweaked the language slightly
- Updated the test for `generate_metrics` to confirm the sign of the mixing matrix is being flipped
- Updated `static_figures.py` so that it does not reflip the sign of the mixing matrix.
- In `tedana.py`, if there was a user-provided mixing matrix, it was copied to the original and new file names and not otherwise changed. Now, just the originally named file is copied and the mixing matrix with potentially flipped values is always saved.
  - I also noticed a bug in this copying that it was supposed to compare the provided mixing matrix name to the name that would be output to tedana and only copy if they were different, but the `if` clause included the full paths so they would always be different. In practice, this worked fine because the two files were always identical, but it would no longer work when time series are flipped. I fixed this & now add "user_provided_" to the file name before copying it to the directory. This was already tested in `test_integration_three_echo`
- `test_integration_five_echo` was failing because this is now outputting 3 additional components, so I added the file names for those additional components. This is a real breaking change, but I think it's happening because this is the test using robustICA with only 4 iterations, which will be noisy. Flipping some time series for the PCA mixing matrix was enough to alter the number of stable components. robustICA with only 4 iterations is good for a test of the code, but doesn't results in robustly stable results.
