### PR TITLE
Download decision trees from figshare

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -518,36 +518,35 @@ def download_json(tree: str, out_dir: str) -> str:
     save_path : str
         The filepath of the downloaded decision tree.
     """
-    base_url = 'https://api.figshare.com/v2'
+    base_url = "https://api.figshare.com/v2"
     item_id = 25251433
 
-    fname = tree + ".json" if not tree.endswith(".json") else tree 
+    fname = tree + ".json" if not tree.endswith(".json") else tree
     save_path = op.join(out_dir, fname)
 
     if op.isfile(save_path):
         return save_path
 
     try:
-        r = requests.get(f'{base_url}/articles/{item_id}')
+        r = requests.get(f"{base_url}/articles/{item_id}")
         r.raise_for_status()
         metadata = r.json()
 
-        file_info = next((f for f in metadata["files"] if f["name"] == fname), None)
-        
+        file_info = next((f for f in metadata["files"] if f["name"] == fname.lower()), None)
+
         if not file_info:
-            LGR.info(f"Tree {tree} not found on figshare.")
             return
 
-        download_r = requests.get(file_info['download_url'])
+        download_r = requests.get(file_info["download_url"])
         download_r.raise_for_status()
 
-        with open(save_path, 'wb') as f:
+        with open(save_path, "wb") as f:
             f.write(download_r.content)
         LGR.info(f"Tree {tree} downloaded from figshare to {save_path}")
         return save_path
 
     except requests.RequestException as e:
-        LGR.error(e)
+        LGR.error(f"Cannot connect to figshare: {e}")
  
 
 

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -16,6 +16,7 @@ from typing import List
 import nibabel as nib
 import numpy as np
 import pandas as pd
+import requests
 from nilearn._utils import check_niimg
 from nilearn.image import new_img_like
 
@@ -500,6 +501,54 @@ def load_json(path: str) -> dict:
         except json.decoder.JSONDecodeError:
             raise ValueError(f"File {path} is not a valid JSON.")
     return data
+
+
+def download_json(tree: str, out_dir: str) -> str:
+    """Download a json file from figshare unless the file already exists.
+
+    Parameters
+    ----------
+    tree : str
+        The name of the tree to download
+    out_dir : str
+        The directory where the json file will be saved
+
+    Returns
+    -------
+    save_path : str
+        The filepath of the downloaded decision tree.
+    """
+    base_url = 'https://api.figshare.com/v2'
+    item_id = 25251433
+
+    fname = tree + ".json" if not tree.endswith(".json") else tree 
+    save_path = op.join(out_dir, fname)
+
+    if op.isfile(save_path):
+        return save_path
+
+    try:
+        r = requests.get(f'{base_url}/articles/{item_id}')
+        r.raise_for_status()
+        metadata = r.json()
+
+        file_info = next((f for f in metadata["files"] if f["name"] == fname), None)
+        
+        if not file_info:
+            LGR.info(f"Tree {tree} not found on figshare.")
+            return
+
+        download_r = requests.get(file_info['download_url'])
+        download_r.raise_for_status()
+
+        with open(save_path, 'wb') as f:
+            f.write(download_r.content)
+        LGR.info(f"Tree {tree} downloaded from figshare to {save_path}")
+        return save_path
+
+    except requests.RequestException as e:
+        LGR.error(e)
+ 
 
 
 def add_decomp_prefix(comp_num, prefix, max_value):

--- a/tedana/selection/component_selector.py
+++ b/tedana/selection/component_selector.py
@@ -72,15 +72,14 @@ def load_config(tree: str, out_dir: str = ".") -> Dict:
         fname = tree
     else:
         fname = download_json(tree, out_dir)
-        
+
     try:
         dectree = load_json(fname)
-    except:
+    except Exception:
         raise ValueError(
             f"Cannot find tree {tree}. Please check your path or use a "
             f"default tree ({DEFAULT_TREES}) or one from figshare."
         )
-
 
     return validate_tree(dectree)
 

--- a/tedana/tests/test_io.py
+++ b/tedana/tests/test_io.py
@@ -332,10 +332,10 @@ def test_download_json_file_not_found(mock_isfile, mock_requests_get):
     mock_response.json.return_value = {"files": [{"name": "tree.json", "download_url": "url.com"}]}
     mock_requests_get.return_value = mock_response
 
-    with mock.patch("tedana.io.LGR") as mock_lgr:
-        result = me.download_json("non_existent_tree", "some_dir")
-        assert result is None
-        mock_lgr.info.assert_called_with("Tree non_existent_tree not found on figshare.")
+    result = me.download_json("non_existent_tree", "some_dir")
+
+    assert result is None
+    mock_response.raise_for_status.assert_called_once()
 
 
 @mock.patch("tedana.io.requests.get")

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -609,7 +609,7 @@ def tedana_workflow(
         data = [data]
 
     LGR.info("Initializing and validating component selection tree")
-    selector = ComponentSelector(tree)
+    selector = ComponentSelector(tree, out_dir)
 
     LGR.info(f"Loading input data: {[f for f in data]}")
     data_cat, ref_img = io.load_data(data, n_echos=n_echos)
@@ -884,7 +884,7 @@ def tedana_workflow(
                 # regular expressions immediately after initialization,
                 # store and copy this key
                 tmp_external_regressor_config = selector.tree["external_regressor_config"]
-                selector = ComponentSelector(tree)
+                selector = ComponentSelector(tree, out_dir)
                 selector.tree["external_regressor_config"] = tmp_external_regressor_config
 
             RepLGR.disabled = True  # Disable the report to avoid duplicate text


### PR DESCRIPTION
Closes #1205.

Changes proposed:

- `download_json` function that downloads decision trees from figshare to `out_dir` if not in `DEFAULT_TREES` or saved locally.
- Some relevant tests

Please note that some users on protected networks may encounter SSL issues when connecting to figshare’s API.