### PR TITLE
Fixing unflipped PCA component weights

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -367,6 +367,13 @@ def tedpca(
         metrics=required_metrics,
     )
 
+    # Flip signs for voxel_comp_weights to match comp_ts mixing matrix
+    # that were flipped in collect.generate_metrics
+    optimal_sign = np.matlib.repmat(
+        component_table["optimal sign"].to_numpy(), voxel_comp_weights.shape[0], 1
+    )
+    voxel_comp_weights = voxel_comp_weights * optimal_sign
+
     # varex_norm from PCA overrides varex_norm from dependence_metrics,
     # but we retain the original
     component_table["estimated normalized variance explained"] = component_table[

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -369,10 +369,8 @@ def tedpca(
 
     # Flip signs for voxel_comp_weights to match comp_ts mixing matrix
     # that were flipped in collect.generate_metrics
-    optimal_sign = np.matlib.repmat(
-        component_table["optimal sign"].to_numpy(), voxel_comp_weights.shape[0], 1
-    )
-    voxel_comp_weights = voxel_comp_weights * optimal_sign
+    optimal_sign = component_table["optimal sign"].to_numpy()
+    voxel_comp_weights = voxel_comp_weights * optimal_sign[None, :]
 
     # varex_norm from PCA overrides varex_norm from dependence_metrics,
     # but we retain the original


### PR DESCRIPTION
Closes # 1233.

I noticed that ICA components where different after #1212 was merged. @tsalo noticed the bug was that, in `decomposition.tedpca` we flipped the component mixing matrix time series in `collect.generate_metrics` but, `voxel_comp_weights` was not flipped. This slipped past because we were focused on this change for ICA and, for ICA and PCA, the weight map is calculated saved to a file within `collect.generate_metrics` & we didn't notice that a the weight map separately calculated in `decomposition.tedpca` was the one that was returned & used.

Changes proposed in this pull request:

- The "optimal sign" values (1 or -1) calculated in `collect.generate_metrics` is used to flip the signs for components in `voxel_comp_weights`

**Note 1** Please take a look to confirm nothing else needs flipping. I'm fairly sure it's only `voxel_comp_weights` but more eyes on this is good.

**Note 2** If we agree this is both a bug and this PR fully fixes it, I'd like to release version 25.0.1 ASAP. Please comment on this.
