### PR TITLE
Fix NaNs in external regressors, take 2

### DIFF
--- a/tedana/metrics/external.py
+++ b/tedana/metrics/external.py
@@ -57,7 +57,7 @@ def load_validate_external_regressors(
     except FileNotFoundError:
         raise ValueError(f"Cannot load tsv file with external regressors: {external_regressors}")
 
-    external_regressor_config = validate_extern_regress(
+    external_regressors, external_regressor_config = validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,
@@ -237,7 +237,7 @@ def validate_extern_regress(
     if err_msg:
         raise RegressError(err_msg)
 
-    return external_regressor_config
+    return external_regressors, external_regressor_config
 
 
 def fit_regressors(

--- a/tedana/tests/test_external_metrics.py
+++ b/tedana/tests/test_external_metrics.py
@@ -186,7 +186,7 @@ def test_validate_extern_regress_succeeds(caplog):
 
     external_regressors, n_vols = sample_external_regressors()
     external_regressor_config = sample_external_regressor_config()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,
@@ -194,6 +194,7 @@ def test_validate_extern_regress_succeeds(caplog):
     )
 
     # The regex patterns should have been replaced with the full names of the regressors
+    assert external_regressors.notna().all(axis=None)
     assert set(external_regressor_config_expanded[0]["partial_models"]["Motion"]) == set(
         [
             "Mot_X",
@@ -217,7 +218,7 @@ def test_validate_extern_regress_succeeds(caplog):
     # Rerunning with explicit names for the above three categories instead of regex patterns
     # Shouldn't change anything, but making sure it runs
     caplog.clear()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config_expanded,
         n_vols=n_vols,
@@ -330,7 +331,7 @@ def test_validate_extern_regress_fails():
     # when "Mot_Y" is in the config, but removed from external_regressors
     external_regressor_config = sample_external_regressor_config()
     external_regressors, n_vols = sample_external_regressors()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,
@@ -423,7 +424,7 @@ def test_fit_regressors(caplog):
     caplog.set_level(logging.INFO)
     external_regressors, n_vols = sample_external_regressors()
     external_regressor_config = sample_external_regressor_config()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,
@@ -512,7 +513,7 @@ def test_fit_mixing_to_regressors(caplog):
     caplog.set_level(logging.INFO)
     external_regressors, n_vols = sample_external_regressors()
     external_regressor_config = sample_external_regressor_config()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,
@@ -619,7 +620,7 @@ def test_build_fstat_regressor_models(caplog):
     caplog.set_level(logging.INFO)
     external_regressors, n_vols = sample_external_regressors()
     external_regressor_config = sample_external_regressor_config()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,

--- a/tedana/tests/test_external_metrics.py
+++ b/tedana/tests/test_external_metrics.py
@@ -274,6 +274,32 @@ def test_validate_extern_regress_succeeds(caplog):
     assert "External regressors have the same number of timepoints" not in caplog.text
 
 
+# validate_extern_regress_warn_na
+# -----------------------
+def test_validate_extern_regress_warn_na(caplog):
+    """Test validate_extern_regress works as expected."""
+
+    external_regressors, n_vols = sample_external_regressors()
+    # add NA values to regressor before validating
+    for col in external_regressors.columns:
+        if "d1" in col:
+            external_regressors.loc[0, col] = pd.NA
+    external_regressor_config = sample_external_regressor_config()
+
+    caplog.clear()
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
+        external_regressors=external_regressors,
+        external_regressor_config=external_regressor_config,
+        n_vols=n_vols,
+        dummy_scans=0,
+    )
+    assert (
+        "WARNING" in caplog.text
+        and "External regressors include columns with NaN values" in caplog.text
+    )
+    assert not external_regressors.isna().any(axis=None)
+
+
 def test_validate_extern_regress_fails():
     """Test validate_extern_regress fails when expected."""
 

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -71,7 +71,7 @@ def test_smoke_generate_metrics(testdata1):
     external_regressors = external_regressors.drop(labels=range(5, 75), axis=0)
 
     external_regressor_config = sample_external_regressor_config()
-    external_regressor_config_expanded = external.validate_extern_regress(
+    external_regressors, external_regressor_config_expanded = external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
         n_vols=n_vols,


### PR DESCRIPTION
Turns out https://github.com/ME-ICA/tedana/pull/1163 did not fix the issue, because the modified dataframe is never returned to the workflow.

Quick fix, but adding tests would be better. 
