### PR TITLE
Report sort external regressors rows alphabetically in correlation matrix

### DIFF
--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -967,7 +967,7 @@ def plot_heatmap(
         sharex=True,
     )
     sns.heatmap(
-        corr_df,
+        corr_df.sort_index(),
         cmap="seismic",
         center=0,
         vmax=1,


### PR DESCRIPTION
Currently, the correlation matrix orders the regressors in an arbitrary order, which seems to lose the order of the file it was loaded from, here is an example:
<img width="2968" height="5074" alt="image" src="https://github.com/user-attachments/assets/18a0f298-aa1e-46ff-b3d9-5589ec56bc34" />

This is a simple fix that simply sorts the index, but maybe fixing the correlation function to keep the loaded TSV order would make more sense.

