### PR TITLE
Fix dependabot's uv action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ exclude = [
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "25.1.1a1"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "tedana/_version.py"


### PR DESCRIPTION
Closes #1265. Cursor did all the work here. Locally testing using a script it wrote fails when the proposed change hasn't been made, but passes when it has.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add fallback package version to pyproject.toml.
