### PR TITLE
Only mean centering PCA components

### DIFF
--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -161,7 +161,7 @@ def r_ica(data, n_components, fixed_seed, n_robust_runs, max_it):
             robust_ica = RobustICA(
                 n_components=n_components,
                 robust_runs=n_robust_runs,
-                whiten="arbitrary-variance",
+                whiten="unit-variance",
                 max_iter=max_it,
                 random_state=fixed_seed,
                 robust_dimreduce=False,
@@ -320,6 +320,7 @@ def f_ica(data, n_components, fixed_seed, maxit, maxrestart):
             n_components=n_components,
             algorithm="parallel",
             fun="logcosh",
+            whiten="unit-variance",
             max_iter=maxit,
             random_state=fixed_seed,
         )

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -370,6 +370,15 @@ def _get_parser():
     )
 
     optional.add_argument(
+        "--mean_center_only",
+        "--mean-center-only",
+        dest="mean_center_only",
+        action="store_false",
+        help="Only mean center fMRI time series before PCA and ICA. Do not scale by stdev.",
+        default=False,
+    )
+
+    optional.add_argument(
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False
     )
     optional.add_argument(
@@ -431,6 +440,7 @@ def tedana_workflow(
     t2smap=None,
     mixing_file=None,
     tedana_command=None,
+    mean_center_only=False,
 ):
     """Run the "canonical" TE-Dependent ANAlysis workflow.
 
@@ -549,6 +559,9 @@ def tedana_workflow(
     mixing_file : :obj:`str` or None, optional
         File containing mixing matrix, to be used when re-running the workflow.
         If not provided, ME-PCA and ME-ICA are done. Default is None.
+    mean_center_only  : :obj:`bool`, optional
+        Only center the mean time series to 0 instead of also scaling the variance
+        Default: False
     quiet : :obj:`bool`, optional
         If True, suppresses logging/printing of messages. Default is False.
     overwrite : :obj:`bool`, optional
@@ -840,6 +853,7 @@ def tedana_workflow(
             kdaw=10.0,
             rdaw=1.0,
             low_mem=low_mem,
+            mean_center_only=mean_center_only,
         )
         if verbose:
             io_generator.save_file(utils.unmask(data_reduced, mask_clf), "whitened img")


### PR DESCRIPTION
In playing around with ICA convergence failures @marms7 and I realized that not variance scaling the data pre & post PCA seems to remove almost all convergence failures and (n=1) might even give better final ICA components for denoising. This is a work in progress and we're still testing, but I wanted to share here in case others have thoughts.

Changes proposed in this pull request:

- Added a `--mean_center_only` option that removes variance scaling and zscoring of data
  - I don't love this because, if we decide this will eventually be the default, we'll need to change the input option, but it's enough for me (and others to start testing now)
- Switched RobustICA to using `unit-variance` for whitening to match the recommended default fastICA setting and to now match what we're doing in our single call to fastICA (@BahmanTahayori & @Lestropie any reason this might be an issue with robustICA?)
