### PR TITLE
Fix check of dummy scans against external regressors

### DIFF
--- a/tedana/metrics/external.py
+++ b/tedana/metrics/external.py
@@ -220,7 +220,7 @@ def validate_extern_regress(
                     )
 
     if len(external_regressors.index) != n_vols:
-        if len(external_regressors.index) == n_vols + dummy_scans:
+        if len(external_regressors.index) == (n_vols + dummy_scans):
             LGR.warning(
                 "External regressors have the same number of timepoints as the fMRI data, "
                 "but dummy scans are included in the fMRI data. "

--- a/tedana/tests/test_external_metrics.py
+++ b/tedana/tests/test_external_metrics.py
@@ -257,7 +257,7 @@ def test_validate_extern_regress_succeeds(caplog):
     external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
-        n_vols=n_vols,
+        n_vols=n_vols - 5,
         dummy_scans=5,
     )
     assert "External regressors have the same number of timepoints" in caplog.text
@@ -268,7 +268,7 @@ def test_validate_extern_regress_succeeds(caplog):
     external.validate_extern_regress(
         external_regressors=external_regressors,
         external_regressor_config=external_regressor_config,
-        n_vols=n_vols + 5,
+        n_vols=n_vols,
         dummy_scans=5,
     )
     assert "External regressors have the same number of timepoints" not in caplog.text


### PR DESCRIPTION
Closes #1272. The old behavior assumes that dummy scans have _not_ been removed from the fMRI data by the time the external regressors are validated, but that happens when the data are loaded.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Instead of checking that the number of rows in the external regressors is equal to (1) the number of volumes in the fMRI scan or (2) the number of volumes in the fMRI scan _minus_ the number of dummy scans, check (1) but change (2) to be the fMRI volume count _plus_ the dummy scan count.

