### PR TITLE
Add Rica integration for interactive ICA component visualization

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -630,6 +630,85 @@ These plots show the voxel-wise global signal weights and the global signal time
   :height: 400px
 
 
+.. _rica-reports:
+
+***********************************
+Rica Interactive Reports (Optional)
+***********************************
+
+In addition to the standard HTML report, ``tedana`` can generate files for
+`Rica <https://github.com/ME-ICA/rica>`_, an interactive web-based visualization
+tool for exploring ICA components. Rica provides a more detailed and interactive
+way to inspect individual components, including 3D brain visualization using NiiVue.
+
+Generating Rica Reports
+-----------------------
+
+To generate Rica report files, use the ``--rica-report`` flag:
+
+.. code-block:: bash
+
+    tedana -d echo1.nii.gz echo2.nii.gz echo3.nii.gz \
+           -e 14.5 29.0 43.5 \
+           --out-dir output \
+           --rica-report
+
+This will:
+
+1. Download Rica from the `ME-ICA/rica GitHub releases <https://github.com/ME-ICA/rica/releases>`_
+   (cached locally for future use)
+2. Copy Rica files to ``output/rica/``
+3. Generate a launcher script ``open_rica_report.py`` in the output directory
+
+Opening Rica
+------------
+
+After running ``tedana`` with ``--rica-report``, open the Rica visualization:
+
+.. code-block:: bash
+
+    cd output
+    python open_rica_report.py
+
+This will:
+
+- Start a local HTTP server
+- Automatically open Rica in your default web browser
+- Load the tedana output files for visualization
+
+Press ``Ctrl+C`` in the terminal to stop the server when you're done.
+
+Rica Output Files
+-----------------
+
+When ``--rica-report`` is used, the following files are added to the output directory:
+
+==================================  ===========================================================
+File                                Description
+==================================  ===========================================================
+``open_rica_report.py``             Cross-platform launcher script to start Rica
+``rica/index.html``                 Rica web application (single-file bundle)
+``rica/rica_server.py``             HTTP server with CORS support for serving files
+``rica/favicon.ico``                Rica favicon
+==================================  ===========================================================
+
+Platform Support
+----------------
+
+Rica reports work on all major platforms:
+
+- **Linux**: Cache stored in ``~/.cache/tedana/rica``
+- **macOS**: Cache stored in ``~/Library/Caches/tedana/rica``
+- **Windows**: Cache stored in ``%LOCALAPPDATA%/tedana/rica``
+
+The launcher script automatically finds an available port if the default (8000) is busy.
+
+.. note::
+
+    Rica reports require an internet connection for the initial download.
+    Once cached, Rica can be used offline.
+
+
 **************************
 Citable workflow summaries
 **************************

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -709,6 +709,136 @@ The launcher script automatically finds an available port if the default (8000) 
     Once cached, Rica can be used offline.
 
 
+Using a Local Rica Bundle (Advanced)
+------------------------------------
+
+For advanced users and developers who need to use a custom Rica build or work offline,
+you can point tedana to a local Rica installation using the ``TEDANA_RICA_PATH``
+environment variable.
+
+The path should point to a directory containing the required Rica files:
+
+- ``index.html`` - The Rica web application
+- ``rica_server.py`` - HTTP server with CORS support
+- ``favicon.ico`` - Rica favicon (optional)
+
+**Setting the environment variable:**
+
+.. code-block:: bash
+
+    # Set for current session
+    export TEDANA_RICA_PATH=/path/to/rica/build
+
+    # Then run tedana as usual
+    tedana -d echo1.nii.gz echo2.nii.gz echo3.nii.gz \
+           -e 14.5 29.0 43.5 \
+           --out-dir output \
+           --rica-report
+
+To make this permanent, add the export line to your shell configuration file
+(e.g., ``~/.bashrc``, ``~/.zshrc``, or ``~/.bash_profile``).
+
+.. note::
+
+    If ``TEDANA_RICA_PATH`` is not set, tedana will automatically download Rica
+    from GitHub and cache it locally.
+
+**For Rica developers:**
+
+If you are developing Rica and have a local build, you can point tedana to your
+build output directory:
+
+.. code-block:: bash
+
+    # Build Rica locally
+    cd ~/GitHub/rica
+    npm run build
+
+    # Set the environment variable to use the local build
+    export TEDANA_RICA_PATH=~/GitHub/rica/build
+
+    # Run tedana with Rica report
+    tedana -d data/*.nii.gz -e 14.5 29.0 43.5 --out-dir output --rica-report
+
+
+Troubleshooting Rica
+--------------------
+
+**Rica download fails:**
+
+If Rica fails to download from GitHub, you may see an error like:
+
+.. code-block:: text
+
+    Failed to download Rica: <urlopen error ...>
+
+Possible solutions:
+
+1. **Check your internet connection** - Ensure you can access GitHub.
+
+2. **Use a local Rica bundle** - Download Rica manually and set ``TEDANA_RICA_PATH``:
+
+   .. code-block:: bash
+
+       # Download Rica release manually
+       wget https://github.com/ME-ICA/rica/releases/latest/download/index.html
+       wget https://github.com/ME-ICA/rica/releases/latest/download/rica_server.py
+       wget https://github.com/ME-ICA/rica/releases/latest/download/favicon.ico
+
+       # Place files in a directory and set the environment variable
+       mkdir ~/rica-bundle
+       mv index.html rica_server.py favicon.ico ~/rica-bundle/
+       export TEDANA_RICA_PATH=~/rica-bundle
+       tedana ... --rica-report
+
+3. **Run without Rica** - Remove the ``--rica-report`` flag. The standard HTML
+   report will still be generated.
+
+**Clearing the Rica cache:**
+
+If Rica files become corrupted or you want to force a fresh download:
+
+.. code-block:: bash
+
+    # Linux
+    rm -rf ~/.cache/tedana/rica
+
+    # macOS
+    rm -rf ~/Library/Caches/tedana/rica
+
+    # Windows (PowerShell)
+    Remove-Item -Recurse -Force "$env:LOCALAPPDATA\tedana\rica"
+
+The next time you run tedana with ``--rica-report``, Rica will be re-downloaded.
+
+**Port conflicts:**
+
+When opening Rica, if port 8000 is already in use, the launcher script
+automatically tries the next available port (8001, 8002, etc.). If you see:
+
+.. code-block:: text
+
+    Error: Could not find free port starting from 8000
+
+This means ports 8000-8009 are all in use. You can specify a different starting port:
+
+.. code-block:: bash
+
+    python open_rica_report.py --port 9000
+
+**Browser does not open automatically:**
+
+If the browser doesn't open, you can:
+
+1. Open the URL manually (displayed in the terminal output)
+2. Use the ``--no-open`` flag and open the URL yourself:
+
+   .. code-block:: bash
+
+       python open_rica_report.py --no-open
+       # Then open http://localhost:8000/rica/index.html in your browser
+
+
 **************************
 Citable workflow summaries
 **************************

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -839,6 +839,11 @@ If the browser doesn't open, you can:
        python open_rica_report.py --no-open
        # Then open http://localhost:8000/rica/index.html in your browser
 
+**Browser shows old version of Rica after update:**
+
+See the `Rica troubleshooting guide <https://me-ica.github.io/rica/troubleshooting/#browser-shows-old-version-after-update>`_
+for solutions to browser caching issues.
+
 
 **************************
 Citable workflow summaries

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -689,7 +689,6 @@ File                                Description
 ``open_rica_report.py``             Cross-platform launcher script to start Rica
 ``rica/index.html``                 Rica web application (single-file bundle)
 ``rica/rica_server.py``             HTTP server with CORS support for serving files
-``rica/favicon.ico``                Rica favicon
 ==================================  ===========================================================
 
 Platform Support
@@ -720,7 +719,6 @@ The path should point to a directory containing the required Rica files:
 
 - ``index.html`` - The Rica web application
 - ``rica_server.py`` - HTTP server with CORS support
-- ``favicon.ico`` - Rica favicon (optional)
 
 **Setting the environment variable:**
 
@@ -783,11 +781,10 @@ Possible solutions:
        # Download Rica release manually
        wget https://github.com/ME-ICA/rica/releases/latest/download/index.html
        wget https://github.com/ME-ICA/rica/releases/latest/download/rica_server.py
-       wget https://github.com/ME-ICA/rica/releases/latest/download/favicon.ico
 
        # Place files in a directory and set the environment variable
        mkdir ~/rica-bundle
-       mv index.html rica_server.py favicon.ico ~/rica-bundle/
+       mv index.html rica_server.py ~/rica-bundle/
        export TEDANA_RICA_PATH=~/rica-bundle
        tedana ... --rica-report
 

--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -170,7 +170,174 @@
     padding: 2em !important;
     border-radius: 5px;
   }
+
+  /* Rica button styles */
+  .rica-button-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+  }
+
+  .rica-button {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border: none;
+    border-radius: 8px;
+    color: white;
+    padding: 12px 20px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+    transition: transform 0.2s, box-shadow 0.2s;
+    float: none;
+    height: auto;
+  }
+
+  .rica-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.5);
+    opacity: 1;
+  }
+
+  .rica-button:active {
+    transform: translateY(0);
+    float: none;
+    margin-top: 0;
+  }
+
+  /* Rica modal styles */
+  .rica-modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 2000;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .rica-modal {
+    background: white;
+    border-radius: 12px;
+    padding: 30px;
+    max-width: 500px;
+    width: 90%;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+    position: relative;
+  }
+
+  .rica-modal h2 {
+    margin: 0 0 15px 0;
+    color: #333;
+    font-size: 24px;
+  }
+
+  .rica-modal p {
+    color: #555;
+    line-height: 1.6;
+    margin-bottom: 15px;
+  }
+
+  .rica-modal code {
+    background: #f4f4f4;
+    padding: 10px 15px;
+    border-radius: 6px;
+    display: block;
+    font-family: 'Courier New', monospace;
+    font-size: 14px;
+    color: #333;
+    margin: 15px 0;
+  }
+
+  .rica-modal-close {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #999;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    float: none;
+  }
+
+  .rica-modal-close:hover {
+    color: #333;
+    opacity: 1;
+  }
+
+  .rica-modal-buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 20px;
+  }
+
+  .rica-modal-btn {
+    flex: 1;
+    padding: 12px 20px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.2s;
+    float: none;
+    height: auto;
+  }
+
+  .rica-modal-btn-primary {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+  }
+
+  .rica-modal-btn-secondary {
+    background: #f0f0f0;
+    color: #333;
+    border: 1px solid #ddd;
+  }
 </style>
+
+<!-- Rica Button -->
+<div class="rica-button-container">
+  <button type="button" class="rica-button" onclick="openRicaModal()">
+    🔍 Open in Rica
+  </button>
+</div>
+
+<!-- Rica Modal -->
+<div class="rica-modal-overlay" id="ricaModal">
+  <div class="rica-modal">
+    <button type="button" class="rica-modal-close" onclick="closeRicaModal()">×</button>
+    <h2>Open in Rica</h2>
+    <p>
+      <strong>Rica</strong> is an interactive web-based tool for exploring ICA components
+      with 3D brain visualization.
+    </p>
+    <p>
+      To view these results in Rica locally, run this command in your output directory:
+    </p>
+    <code>python open_rica_report.py</code>
+    <p style="font-size: 13px; color: #777;">
+      This will download Rica (if needed), start a local server, and open your browser.
+    </p>
+    <div class="rica-modal-buttons">
+      <button type="button" class="rica-modal-btn rica-modal-btn-secondary" onclick="closeRicaModal()">
+        Close
+      </button>
+      <button type="button" class="rica-modal-btn rica-modal-btn-primary" onclick="openRicaWebsite()">
+        Learn more about Rica →
+      </button>
+    </div>
+  </div>
+</div>
 <div class="content">
   <h1>ICA components</h1>
   {{ content }}
@@ -356,6 +523,33 @@
     // Update the image source
     document.getElementById("imgCarpetPlot").src = carpetPlot;
   }
+
+  // Rica modal functions
+  function openRicaModal() {
+    document.getElementById("ricaModal").style.display = "flex";
+  }
+
+  function closeRicaModal() {
+    document.getElementById("ricaModal").style.display = "none";
+  }
+
+  function openRicaWebsite() {
+    window.open("https://github.com/ME-ICA/rica", "_blank");
+  }
+
+  // Close modal when clicking outside
+  document.getElementById("ricaModal").addEventListener("click", function(event) {
+    if (event.target === this) {
+      closeRicaModal();
+    }
+  });
+
+  // Close modal with Escape key
+  document.addEventListener("keydown", function(event) {
+    if (event.key === "Escape") {
+      closeRicaModal();
+    }
+  });
 </script>
 
 {{ javascript }}

--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -319,7 +319,8 @@
     <h2>Open in Rica</h2>
     <p>
       <strong>Rica</strong> is an interactive web-based tool for exploring ICA components
-      with 3D brain visualization.
+      with 3D brain visualization and
+      can be used to manually change component classifications.
     </p>
     <p>
       To view these results in Rica locally, run this command in your output directory:

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -505,9 +505,14 @@ def setup_rica(output_dir, force_download=False):
 
     # Check if we need to update the output directory
     source_version = get_cached_rica_version(source_dir)
-    output_version = output_version_file.read_text().strip() if output_version_file.exists() else None
+    output_version = None
+    if output_version_file.exists():
+        output_version = output_version_file.read_text().strip()
 
-    if not force_download and output_version and output_version == source_version and validate_rica_path(rica_dir):
+    is_up_to_date = (
+        output_version and output_version == source_version and validate_rica_path(rica_dir)
+    )
+    if not force_download and is_up_to_date:
         print(f"[Rica] Using {output_version} from {rica_dir}")
         return rica_dir
 

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -531,12 +531,19 @@ def setup_rica(output_dir, force_download=False):
 
 
 class RicaHandler(http.server.SimpleHTTPRequestHandler):
-    """HTTP handler with CORS support and file listing endpoint."""
+    """HTTP handler with CORS support, cache control, and file listing endpoint."""
 
     def end_headers(self):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        # Add cache-control headers for Rica core files to prevent browser caching
+        # This ensures updated Rica versions are always served fresh
+        path = unquote(self.path) if hasattr(self, 'path') else ""
+        if "/rica/" in path and (path.endswith(".html") or path.endswith(".py")):
+            self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
         super().end_headers()
 
     def do_OPTIONS(self):

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -18,6 +18,7 @@ import stat
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
 
 LGR = logging.getLogger("GENERAL")
 
@@ -61,7 +62,7 @@ def get_rica_cache_dir() -> Path:
     return rica_cache
 
 
-def get_latest_rica_version() -> tuple[str, dict]:
+def get_latest_rica_version() -> Tuple[str, Dict]:
     """Fetch the latest Rica version information from GitHub.
 
     Returns
@@ -116,7 +117,7 @@ def download_rica_file(url: str, dest_path: Path) -> None:
         dest_path.write_bytes(response.read())
 
 
-def get_cached_rica_version(cache_dir: Path) -> str | None:
+def get_cached_rica_version(cache_dir: Path) -> Optional[str]:
     """Get the version of Rica currently cached.
 
     Parameters
@@ -222,7 +223,7 @@ def download_rica(force: bool = False) -> Path:
     return cache_dir
 
 
-def generate_rica_launcher_script(out_dir: str | Path, port: int = 8000) -> Path:
+def generate_rica_launcher_script(out_dir: Union[str, Path], port: int = 8000) -> Path:
     """Generate the Rica launcher script for a tedana output directory.
 
     This creates a Python script that, when executed, starts a local server
@@ -434,7 +435,7 @@ if __name__ == "__main__":
     return script_path
 
 
-def setup_rica_report(out_dir: str | Path) -> Path | None:
+def setup_rica_report(out_dir: Union[str, Path]) -> Optional[Path]:
     """Set up Rica report files in a tedana output directory.
 
     This function:
@@ -485,7 +486,7 @@ def setup_rica_report(out_dir: str | Path) -> Path | None:
         return None
 
 
-def get_rica_version() -> str | None:
+def get_rica_version() -> Optional[str]:
     """Get the version of Rica that is cached.
 
     Returns

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -30,7 +30,7 @@ RICA_GITHUB_API = (
 )
 
 # Files to download from Rica releases
-RICA_FILES = ["index.html", "rica_server.py", "favicon.ico"]
+RICA_FILES = ["index.html", "rica_server.py"]
 
 # Environment variable for local Rica path
 RICA_PATH_ENV_VAR = "TEDANA_RICA_PATH"

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -539,7 +539,7 @@ class RicaHandler(http.server.SimpleHTTPRequestHandler):
         cwd = Path.cwd()
         for f in cwd.rglob("*"):
             if f.is_file() and any(p in f.name for p in RICA_FILE_PATTERNS):
-                files.append(str(f.relative_to(cwd)).replace("\\\\", "/"))
+                files.append(f.relative_to(cwd).as_posix())
         response_data = {"files": sorted(files), "path": str(cwd), "count": len(files)}
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -670,7 +670,7 @@ def setup_rica_report(out_dir: Union[str, Path]) -> Path:
     # Generate launcher script (all Rica setup happens when user runs the script)
     launcher_path = generate_rica_launcher_script(out_dir)
 
-    LGR.info(f"Rica launcher created. Run 'python {launcher_path.name}' to visualize results.")
+    LGR.info(f"Rica launcher created. Run 'python {launcher_path}' to visualize results.")
 
     return launcher_path
 

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -401,7 +401,7 @@ class RicaHandler(http.server.SimpleHTTPRequestHandler):
         for f in cwd.rglob("*"):
             if f.is_file():
                 if any(pattern in f.name for pattern in RICA_FILE_PATTERNS):
-                    rel_path = str(f.relative_to(cwd)).replace("\\\\", "/")
+                    rel_path = str(f.relative_to(cwd)).replace("\\", "/")
                     files.append(rel_path)
 
         response_data = {

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import platform
-import shutil
 import stat
 import urllib.error
 import urllib.request
@@ -364,7 +363,9 @@ from urllib.parse import unquote
 # Rica configuration
 RICA_REPO_OWNER = "ME-ICA"
 RICA_REPO_NAME = "rica"
-RICA_GITHUB_API = f"https://api.github.com/repos/{RICA_REPO_OWNER}/{RICA_REPO_NAME}/releases/latest"
+RICA_GITHUB_API = (
+    f"https://api.github.com/repos/{RICA_REPO_OWNER}/{RICA_REPO_NAME}/releases/latest"
+)
 RICA_FILES = ["index.html", "rica_server.py"]
 RICA_PATH_ENV_VAR = "TEDANA_RICA_PATH"
 
@@ -430,7 +431,10 @@ def download_rica(force=False):
     try:
         req = urllib.request.Request(
             RICA_GITHUB_API,
-            headers={"Accept": "application/vnd.github.v3+json", "User-Agent": "tedana-rica-launcher"}
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "tedana-rica-launcher",
+            },
         )
         with urllib.request.urlopen(req, timeout=30) as response:
             release_info = json.loads(response.read().decode("utf-8"))

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -1,0 +1,497 @@
+"""Rica integration module for tedana.
+
+This module provides functionality to:
+1. Download and cache Rica (ICA component visualization tool) from GitHub releases
+2. Generate Rica report files in tedana output directories
+3. Create cross-platform launcher scripts to open Rica reports
+
+Rica is an interactive web-based visualization tool for exploring ICA components
+from tedana analysis. For more information, see: https://github.com/ME-ICA/rica
+"""
+
+import json
+import logging
+import os
+import platform
+import shutil
+import stat
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+LGR = logging.getLogger("GENERAL")
+
+# Rica GitHub repository information
+RICA_REPO_OWNER = "ME-ICA"
+RICA_REPO_NAME = "rica"
+RICA_GITHUB_API = (
+    f"https://api.github.com/repos/{RICA_REPO_OWNER}/{RICA_REPO_NAME}/releases/latest"
+)
+
+# Files to download from Rica releases
+RICA_FILES = ["index.html", "rica_server.py", "favicon.ico"]
+
+
+def get_rica_cache_dir() -> Path:
+    """Get the platform-specific cache directory for Rica files.
+
+    Returns
+    -------
+    Path
+        Path to Rica cache directory.
+        - Linux: ~/.cache/tedana/rica
+        - macOS: ~/Library/Caches/tedana/rica
+        - Windows: %LOCALAPPDATA%/tedana/rica
+    """
+    system = platform.system()
+
+    if system == "Linux":
+        base_cache = Path.home() / ".cache"
+    elif system == "Darwin":  # macOS
+        base_cache = Path.home() / "Library" / "Caches"
+    elif system == "Windows":
+        base_cache = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        # Fallback for other systems
+        base_cache = Path.home() / ".cache"
+
+    rica_cache = base_cache / "tedana" / "rica"
+    rica_cache.mkdir(parents=True, exist_ok=True)
+
+    return rica_cache
+
+
+def get_latest_rica_version() -> tuple[str, dict]:
+    """Fetch the latest Rica version information from GitHub.
+
+    Returns
+    -------
+    version : str
+        The version tag (e.g., "v2.0.0").
+    assets : dict
+        Dictionary mapping filename to download URL.
+
+    Raises
+    ------
+    urllib.error.URLError
+        If unable to connect to GitHub API.
+    ValueError
+        If the release has no assets.
+    """
+    req = urllib.request.Request(
+        RICA_GITHUB_API,
+        headers={"Accept": "application/vnd.github.v3+json", "User-Agent": "tedana"},
+    )
+
+    with urllib.request.urlopen(req, timeout=30) as response:
+        release_info = json.loads(response.read().decode("utf-8"))
+
+    version = release_info["tag_name"]
+    assets = {}
+
+    for asset in release_info.get("assets", []):
+        name = asset["name"]
+        if name in RICA_FILES:
+            assets[name] = asset["browser_download_url"]
+
+    if not assets:
+        raise ValueError(f"No Rica assets found in release {version}")
+
+    return version, assets
+
+
+def download_rica_file(url: str, dest_path: Path) -> None:
+    """Download a single file from a URL.
+
+    Parameters
+    ----------
+    url : str
+        URL to download from.
+    dest_path : Path
+        Destination file path.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "tedana"})
+
+    with urllib.request.urlopen(req, timeout=60) as response:
+        dest_path.write_bytes(response.read())
+
+
+def get_cached_rica_version(cache_dir: Path) -> str | None:
+    """Get the version of Rica currently cached.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Path to Rica cache directory.
+
+    Returns
+    -------
+    str or None
+        Version string if version file exists, None otherwise.
+    """
+    version_file = cache_dir / "VERSION"
+    if version_file.exists():
+        return version_file.read_text().strip()
+    return None
+
+
+def is_rica_cached(cache_dir: Path) -> bool:
+    """Check if Rica files are cached and complete.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Path to Rica cache directory.
+
+    Returns
+    -------
+    bool
+        True if all required files exist in cache.
+    """
+    for filename in RICA_FILES:
+        if not (cache_dir / filename).exists():
+            return False
+    return True
+
+
+def download_rica(force: bool = False) -> Path:
+    """Download Rica files from GitHub releases.
+
+    Downloads the latest Rica release to the platform-specific cache directory.
+    If Rica is already cached and up-to-date, skips the download unless force=True.
+
+    Parameters
+    ----------
+    force : bool, optional
+        Force re-download even if Rica is cached. Default: False.
+
+    Returns
+    -------
+    Path
+        Path to Rica cache directory containing the downloaded files.
+
+    Raises
+    ------
+    RuntimeError
+        If download fails after retries.
+    """
+    cache_dir = get_rica_cache_dir()
+    cached_version = get_cached_rica_version(cache_dir)
+
+    # Check if we need to download
+    if not force and is_rica_cached(cache_dir) and cached_version:
+        LGR.debug(f"Rica {cached_version} already cached at {cache_dir}")
+        return cache_dir
+
+    LGR.info("Downloading Rica from GitHub...")
+
+    try:
+        latest_version, assets = get_latest_rica_version()
+    except (urllib.error.URLError, ValueError) as e:
+        if is_rica_cached(cache_dir):
+            LGR.warning(
+                f"Could not check for Rica updates: {e}. Using cached version {cached_version}."
+            )
+            return cache_dir
+        raise RuntimeError(f"Failed to download Rica: {e}") from e
+
+    # Skip if already have latest version
+    if not force and cached_version == latest_version and is_rica_cached(cache_dir):
+        LGR.debug(f"Rica {latest_version} is already cached")
+        return cache_dir
+
+    LGR.info(f"Downloading Rica {latest_version}...")
+
+    # Download each file
+    for filename in RICA_FILES:
+        if filename not in assets:
+            LGR.warning(f"Rica asset {filename} not found in release")
+            continue
+
+        dest_path = cache_dir / filename
+        try:
+            download_rica_file(assets[filename], dest_path)
+            LGR.debug(f"Downloaded {filename}")
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Failed to download {filename}: {e}") from e
+
+    # Write version file
+    (cache_dir / "VERSION").write_text(latest_version)
+
+    LGR.info(f"Rica {latest_version} downloaded to {cache_dir}")
+    return cache_dir
+
+
+def generate_rica_launcher_script(out_dir: str | Path, port: int = 8000) -> Path:
+    """Generate the Rica launcher script for a tedana output directory.
+
+    This creates a Python script that, when executed, starts a local server
+    and opens Rica in the user's browser to visualize the tedana output.
+
+    Parameters
+    ----------
+    out_dir : str or Path
+        The tedana output directory.
+    port : int, optional
+        Default port for the local server. Default: 8000.
+
+    Returns
+    -------
+    Path
+        Path to the generated launcher script.
+    """
+    out_dir = Path(out_dir)
+    script_path = out_dir / "open_rica_report.py"
+
+    # Cross-platform launcher script
+    script_content = (
+        '''#!/usr/bin/env python3
+"""
+Rica Report Launcher - Opens tedana output in Rica visualization
+
+Usage:
+    python open_rica_report.py [--port PORT] [--no-open]
+
+This script starts a local server and opens Rica in your default browser
+to visualize the ICA component analysis from this tedana output directory.
+
+Press Ctrl+C to stop the server when done.
+"""
+
+import argparse
+import http.server
+import json
+import mimetypes
+import sys
+import webbrowser
+from pathlib import Path
+from urllib.parse import unquote
+
+# File patterns that Rica needs
+RICA_FILE_PATTERNS = [
+    "_metrics.tsv",
+    "_mixing.tsv",
+    "stat-z_components.nii.gz",
+    "_mask.nii",
+    "report.txt",
+    "comp_",
+    ".svg",
+    "tedana_",
+]
+
+# Ensure proper MIME types
+mimetypes.add_type("application/gzip", ".gz")
+mimetypes.add_type("text/tab-separated-values", ".tsv")
+
+
+class RicaHandler(http.server.SimpleHTTPRequestHandler):
+    """HTTP handler with CORS support and file listing endpoint."""
+
+    def end_headers(self):
+        """Add CORS headers to all responses."""
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests."""
+        self.send_response(200)
+        self.end_headers()
+
+    def do_GET(self):
+        """Handle GET requests with special endpoint for file listing."""
+        path = unquote(self.path)
+
+        if path == "/api/files":
+            self.send_file_list()
+        else:
+            super().do_GET()
+
+    def send_file_list(self):
+        """Return JSON list of Rica-relevant files in current directory."""
+        files = []
+        cwd = Path.cwd()
+
+        for f in cwd.rglob("*"):
+            if f.is_file():
+                if any(pattern in f.name for pattern in RICA_FILE_PATTERNS):
+                    rel_path = str(f.relative_to(cwd)).replace("\\\\", "/")
+                    files.append(rel_path)
+
+        response_data = {
+            "files": sorted(files),
+            "path": str(cwd),
+            "count": len(files),
+        }
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(response_data, indent=2).encode("utf-8"))
+
+    def log_message(self, format, *args):
+        """Custom log format - suppress noisy output."""
+        try:
+            msg = str(args[0]) if args else ""
+            if "/api/files" in msg:
+                print("[Rica] File list requested")
+            elif "GET" in msg and len(args) > 1:
+                status = str(args[1])
+                if not status.startswith("2"):
+                    print(f"[Rica] {msg} - {status}")
+        except Exception:
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Open Rica report to visualize tedana ICA components"
+    )
+    parser.add_argument(
+        "--port", type=int, default='''
+        + str(port)
+        + """, help="Port to serve on"
+    )
+    parser.add_argument(
+        "--no-open", action="store_true", help="Don't auto-open browser"
+    )
+    args = parser.parse_args()
+
+    # Change to script directory (tedana output folder)
+    script_dir = Path(__file__).parent.resolve()
+
+    # Check for Rica files
+    rica_index = script_dir / "rica" / "index.html"
+    if not rica_index.exists():
+        print(f"Error: Rica not found at {rica_index}")
+        print("Rica files may not have been downloaded during tedana execution.")
+        print("Try re-running tedana with --rica-report flag.")
+        sys.exit(1)
+
+    # Change to output directory
+    import os
+    os.chdir(script_dir)
+
+    # Find a free port if default is busy
+    port = args.port
+    import socket
+    for attempt in range(10):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(("", port))
+            sock.close()
+            break
+        except OSError:
+            port += 1
+    else:
+        print(f"Error: Could not find free port starting from {args.port}")
+        sys.exit(1)
+
+    # Start server
+    try:
+        with http.server.HTTPServer(("", port), RicaHandler) as httpd:
+            url = f"http://localhost:{port}/rica/index.html"
+            print()
+            print("=" * 60)
+            print("Rica - ICA Component Visualization")
+            print("=" * 60)
+            print()
+            print(f"Server running at: http://localhost:{port}")
+            print(f"Rica interface:    {url}")
+            print(f"Serving files from: {script_dir}")
+            print()
+            print("Press Ctrl+C to stop the server")
+            print()
+
+            if not args.no_open:
+                webbrowser.open(url)
+
+            httpd.serve_forever()
+
+    except KeyboardInterrupt:
+        print("\\nServer stopped.")
+        sys.exit(0)
+    except OSError as e:
+        if "Address already in use" in str(e):
+            print(f"Error: Port {port} is already in use.")
+            print(f"Try: python open_rica_report.py --port {port + 1}")
+        else:
+            raise
+
+
+if __name__ == "__main__":
+    main()
+"""
+    )
+
+    script_path.write_text(script_content)
+
+    # Make script executable on Unix systems
+    if platform.system() != "Windows":
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    return script_path
+
+
+def setup_rica_report(out_dir: str | Path) -> Path | None:
+    """Set up Rica report files in a tedana output directory.
+
+    This function:
+    1. Downloads Rica if not already cached
+    2. Copies Rica files to the output directory
+    3. Generates the launcher script
+
+    Parameters
+    ----------
+    out_dir : str or Path
+        The tedana output directory.
+
+    Returns
+    -------
+    Path or None
+        Path to the launcher script if successful, None if Rica setup failed.
+    """
+    out_dir = Path(out_dir)
+
+    try:
+        # Download Rica if needed
+        cache_dir = download_rica()
+
+        # Create rica subdirectory in output
+        rica_dir = out_dir / "rica"
+        rica_dir.mkdir(exist_ok=True)
+
+        # Copy Rica files to output
+        for filename in RICA_FILES:
+            src = cache_dir / filename
+            dst = rica_dir / filename
+            if src.exists():
+                shutil.copy2(src, dst)
+                LGR.debug(f"Copied {filename} to {rica_dir}")
+            else:
+                LGR.warning(f"Rica file {filename} not found in cache")
+
+        # Generate launcher script
+        launcher_path = generate_rica_launcher_script(out_dir)
+
+        LGR.info(f"Rica report setup complete. Run '{launcher_path.name}' to visualize results.")
+
+        return launcher_path
+
+    except Exception as e:
+        LGR.warning(f"Failed to set up Rica report: {e}")
+        LGR.warning("You can still view the standard HTML report.")
+        return None
+
+
+def get_rica_version() -> str | None:
+    """Get the version of Rica that is cached.
+
+    Returns
+    -------
+    str or None
+        Version string if Rica is cached, None otherwise.
+    """
+    cache_dir = get_rica_cache_dir()
+    return get_cached_rica_version(cache_dir)

--- a/tedana/tests/data/cornell_three_echo_outputs.txt
+++ b/tedana/tests/data/cornell_three_echo_outputs.txt
@@ -110,3 +110,4 @@ figures/t2star_histogram.svg
 references.bib
 report.txt
 tedana_report.html
+open_rica_report.py

--- a/tedana/tests/data/cornell_three_echo_preset_mixing_outputs.txt
+++ b/tedana/tests/data/cornell_three_echo_preset_mixing_outputs.txt
@@ -103,3 +103,4 @@ figures/t2star_histogram.svg
 references.bib
 report.txt
 tedana_report.html
+open_rica_report.py

--- a/tedana/tests/data/cornell_three_echo_verbose_outputs.txt
+++ b/tedana/tests/data/cornell_three_echo_verbose_outputs.txt
@@ -144,3 +144,4 @@ figures/t2star_histogram.svg
 references.bib
 report.txt
 tedana_report.html
+open_rica_report.py

--- a/tedana/tests/data/fiu_four_echo_outputs.txt
+++ b/tedana/tests/data/fiu_four_echo_outputs.txt
@@ -61,6 +61,7 @@ sub-01_echo-4_desc-ICA_components.nii.gz
 sub-01_echo-4_desc-Rejected_bold.nii.gz
 sub-01_report.txt
 sub-01_tedana_report.html
+open_rica_report.py
 figures
 figures/sub-01_adaptive_mask.svg
 figures/sub-01_carpet_optcom.svg

--- a/tedana/tests/data/nih_five_echo_outputs_verbose.txt
+++ b/tedana/tests/data/nih_five_echo_outputs_verbose.txt
@@ -87,6 +87,7 @@ sub-01_stat-covariance_desc-t2star+s0_statmap.nii.gz
 sub-01_stat-variance_desc-s0_statmap.nii.gz
 sub-01_stat-variance_desc-t2star_statmap.nii.gz
 sub-01_tedana_report.html
+open_rica_report.py
 figures
 figures/sub-01_adaptive_mask.svg
 figures/sub-01_carpet_optcom.svg

--- a/tedana/tests/data/reclassify_debug_out.txt
+++ b/tedana/tests/data/reclassify_debug_out.txt
@@ -1,5 +1,6 @@
 figures
 ica_reclassify_call.sh
+open_rica_report.py
 sub-testymctestface_references.bib
 sub-testymctestface_report.txt
 sub-testymctestface_betas_OC.nii.gz

--- a/tedana/tests/data/reclassify_no_bold.txt
+++ b/tedana/tests/data/reclassify_no_bold.txt
@@ -11,5 +11,6 @@ desc-tedana_metrics.json
 desc-tedana_metrics.tsv
 desc-tedana_registry.json
 figures
+open_rica_report.py
 references.bib
 report.txt

--- a/tedana/tests/data/reclassify_quiet_out.txt
+++ b/tedana/tests/data/reclassify_quiet_out.txt
@@ -14,6 +14,7 @@ desc-tedana_metrics.tsv
 desc-tedana_registry.json
 figures
 ica_reclassify_call.sh
+open_rica_report.py
 references.bib
 report.txt
 tedana_report.html

--- a/tedana/tests/data/reclassify_run_twice.txt
+++ b/tedana/tests/data/reclassify_run_twice.txt
@@ -13,6 +13,7 @@ desc-tedana_metrics.json
 desc-tedana_metrics.tsv
 desc-tedana_registry.json
 figures
+open_rica_report.py
 references.bib
 report.txt
 report_old.txt

--- a/tedana/tests/test_rica.py
+++ b/tedana/tests/test_rica.py
@@ -1,0 +1,206 @@
+"""Tests for tedana.rica module."""
+
+import platform
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+from tedana import rica
+
+
+class TestGetRicaCacheDir:
+    """Tests for get_rica_cache_dir function."""
+
+    def test_returns_path_object(self):
+        """Test that function returns a Path object."""
+        result = rica.get_rica_cache_dir()
+        assert isinstance(result, Path)
+
+    def test_creates_directory(self, tmp_path):
+        """Test that the cache directory is created if it doesn't exist."""
+        with patch.object(Path, "home", return_value=tmp_path):
+            cache_dir = rica.get_rica_cache_dir()
+            assert cache_dir.exists()
+            assert cache_dir.is_dir()
+
+    def test_platform_specific_paths(self, tmp_path):
+        """Test platform-specific cache directory paths."""
+        with patch.object(Path, "home", return_value=tmp_path):
+            with patch("platform.system", return_value="Linux"):
+                cache_dir = rica.get_rica_cache_dir()
+                assert ".cache" in str(cache_dir)
+
+            with patch("platform.system", return_value="Darwin"):
+                cache_dir = rica.get_rica_cache_dir()
+                assert "Library" in str(cache_dir) or "Caches" in str(cache_dir)
+
+
+class TestGenerateRicaLauncherScript:
+    """Tests for generate_rica_launcher_script function."""
+
+    def test_creates_launcher_script(self, tmp_path):
+        """Test that launcher script is created in output directory."""
+        launcher_path = rica.generate_rica_launcher_script(tmp_path)
+
+        assert launcher_path.exists()
+        assert launcher_path.name == "open_rica_report.py"
+        assert launcher_path.parent == tmp_path
+
+    def test_launcher_script_is_executable_on_unix(self, tmp_path):
+        """Test that launcher script is executable on Unix systems."""
+        launcher_path = rica.generate_rica_launcher_script(tmp_path)
+
+        if platform.system() != "Windows":
+            # Check that user execute bit is set
+            mode = launcher_path.stat().st_mode
+            assert mode & stat.S_IXUSR
+
+    def test_launcher_script_contains_required_elements(self, tmp_path):
+        """Test that launcher script contains essential code."""
+        launcher_path = rica.generate_rica_launcher_script(tmp_path)
+        content = launcher_path.read_text()
+
+        # Check for essential elements
+        assert "#!/usr/bin/env python3" in content
+        assert "RicaHandler" in content
+        assert "http.server" in content
+        assert "webbrowser" in content
+        assert "def main():" in content
+        assert "RICA_FILE_PATTERNS" in content
+
+    def test_custom_port(self, tmp_path):
+        """Test that custom port is included in the script."""
+        custom_port = 9999
+        launcher_path = rica.generate_rica_launcher_script(tmp_path, port=custom_port)
+        content = launcher_path.read_text()
+
+        assert str(custom_port) in content
+
+
+class TestIsCachedFunctions:
+    """Tests for cache checking functions."""
+
+    def test_get_cached_rica_version_no_file(self, tmp_path):
+        """Test that None is returned when VERSION file doesn't exist."""
+        result = rica.get_cached_rica_version(tmp_path)
+        assert result is None
+
+    def test_get_cached_rica_version_with_file(self, tmp_path):
+        """Test that version is returned when VERSION file exists."""
+        version_file = tmp_path / "VERSION"
+        version_file.write_text("v2.0.0\n")
+
+        result = rica.get_cached_rica_version(tmp_path)
+        assert result == "v2.0.0"
+
+    def test_is_rica_cached_false_when_files_missing(self, tmp_path):
+        """Test that is_rica_cached returns False when files are missing."""
+        result = rica.is_rica_cached(tmp_path)
+        assert result is False
+
+    def test_is_rica_cached_true_when_all_files_present(self, tmp_path):
+        """Test that is_rica_cached returns True when all files exist."""
+        for filename in rica.RICA_FILES:
+            (tmp_path / filename).write_text("dummy content")
+
+        result = rica.is_rica_cached(tmp_path)
+        assert result is True
+
+    def test_is_rica_cached_false_when_partial_files(self, tmp_path):
+        """Test that is_rica_cached returns False when some files are missing."""
+        # Only create one file
+        (tmp_path / rica.RICA_FILES[0]).write_text("dummy content")
+
+        result = rica.is_rica_cached(tmp_path)
+        assert result is False
+
+
+class TestSetupRicaReport:
+    """Tests for setup_rica_report function."""
+
+    def test_creates_rica_directory(self, tmp_path):
+        """Test that rica subdirectory is created."""
+        # Create mock cached files
+        mock_cache_dir = tmp_path / "cache"
+        mock_cache_dir.mkdir()
+        for filename in rica.RICA_FILES:
+            (mock_cache_dir / filename).write_text("dummy content")
+        (mock_cache_dir / "VERSION").write_text("v2.0.0")
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch.object(rica, "download_rica", return_value=mock_cache_dir):
+            rica.setup_rica_report(output_dir)
+
+        rica_dir = output_dir / "rica"
+        assert rica_dir.exists()
+        assert rica_dir.is_dir()
+
+    def test_copies_rica_files(self, tmp_path):
+        """Test that Rica files are copied to output directory."""
+        # Create mock cached files
+        mock_cache_dir = tmp_path / "cache"
+        mock_cache_dir.mkdir()
+        for filename in rica.RICA_FILES:
+            (mock_cache_dir / filename).write_text(f"content of {filename}")
+        (mock_cache_dir / "VERSION").write_text("v2.0.0")
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch.object(rica, "download_rica", return_value=mock_cache_dir):
+            rica.setup_rica_report(output_dir)
+
+        rica_dir = output_dir / "rica"
+        for filename in rica.RICA_FILES:
+            assert (rica_dir / filename).exists()
+            assert (rica_dir / filename).read_text() == f"content of {filename}"
+
+    def test_creates_launcher_script(self, tmp_path):
+        """Test that launcher script is created in output directory."""
+        # Create mock cached files
+        mock_cache_dir = tmp_path / "cache"
+        mock_cache_dir.mkdir()
+        for filename in rica.RICA_FILES:
+            (mock_cache_dir / filename).write_text("dummy content")
+        (mock_cache_dir / "VERSION").write_text("v2.0.0")
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch.object(rica, "download_rica", return_value=mock_cache_dir):
+            launcher_path = rica.setup_rica_report(output_dir)
+
+        assert launcher_path is not None
+        assert launcher_path.exists()
+        assert launcher_path.name == "open_rica_report.py"
+        assert launcher_path.parent == output_dir
+
+    def test_returns_none_on_failure(self, tmp_path):
+        """Test that None is returned when setup fails."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch.object(rica, "download_rica", side_effect=RuntimeError("Download failed")):
+            result = rica.setup_rica_report(output_dir)
+
+        assert result is None
+
+
+class TestGetRicaVersion:
+    """Tests for get_rica_version function."""
+
+    def test_returns_cached_version(self, tmp_path):
+        """Test that cached version is returned."""
+        # Create VERSION file in cache dir
+        with patch.object(rica, "get_rica_cache_dir", return_value=tmp_path):
+            (tmp_path / "VERSION").write_text("v2.0.0")
+            result = rica.get_rica_version()
+            assert result == "v2.0.0"
+
+    def test_returns_none_when_not_cached(self, tmp_path):
+        """Test that None is returned when not cached."""
+        with patch.object(rica, "get_rica_cache_dir", return_value=tmp_path):
+            result = rica.get_rica_version()
+            assert result is None

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 import tedana.gscontrol as gsc
-from tedana import __version__, io, reporting, selection, utils
+from tedana import __version__, io, reporting, rica, selection, utils
 from tedana.bibtex import get_description_references
 from tedana.io import ALLOWED_COMPONENT_DELIMITERS
 from tedana.workflows.parser_utils import parse_manual_list_int, parse_manual_list_str
@@ -155,6 +155,18 @@ def _get_parser():
         default=False,
     )
     optional.add_argument(
+        "--rica-report",
+        dest="rica_report",
+        action="store_true",
+        help=(
+            "Generate Rica interactive report files. Rica is a web-based "
+            "visualization tool for exploring ICA components. When enabled, "
+            "a launcher script 'open_rica_report.py' will be created in the "
+            "output directory."
+        ),
+        default=False,
+    )
+    optional.add_argument(
         "--png-cmap", dest="png_cmap", type=str, help="Colormap for figures", default="coolwarm"
     )
     optional.add_argument(
@@ -216,6 +228,7 @@ def _main(argv=None):
         tedort=args.tedort,
         gscontrol=args.gscontrol,
         no_reports=args.no_reports,
+        rica_report=args.rica_report,
         png_cmap=args.png_cmap,
         overwrite=args.overwrite,
         verbose=args.verbose,
@@ -239,6 +252,7 @@ def ica_reclassify_workflow(
     tedort=False,
     gscontrol=None,
     no_reports=False,
+    rica_report=False,
     png_cmap="coolwarm",
     verbose=False,
     overwrite=False,
@@ -278,6 +292,9 @@ def ica_reclassify_workflow(
     no_reports : obj:'bool', optional
         Do not generate .html reports and .png plots. Default is false such
         that reports are generated.
+    rica_report : obj:'bool', optional
+        Generate Rica interactive report files. Rica is a web-based visualization
+        tool for exploring ICA components. Default is False.
     png_cmap : obj:'str', optional
         Name of a matplotlib colormap to be used when generating figures.
         Cannot be used with --no-png. Default is 'coolwarm'.
@@ -603,6 +620,14 @@ def ica_reclassify_workflow(
         reporting.generate_report(io_generator, cluster_labels=None, similarity_t_sne=None)
 
     io_generator.save_self()
+
+    # Generate Rica report if requested
+    if rica_report:
+        LGR.info("Setting up Rica interactive report")
+        rica_launcher = rica.setup_rica_report(io_generator.out_dir)
+        if rica_launcher:
+            LGR.info(f"Rica report ready. Run 'python {rica_launcher.name}' to visualize results.")
+
     LGR.info("Workflow completed")
 
     # Add newsletter info to the log

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -155,18 +155,6 @@ def _get_parser():
         default=False,
     )
     optional.add_argument(
-        "--rica-report",
-        dest="rica_report",
-        action="store_true",
-        help=(
-            "Generate Rica interactive report files. Rica is a web-based "
-            "visualization tool for exploring ICA components. When enabled, "
-            "a launcher script 'open_rica_report.py' will be created in the "
-            "output directory."
-        ),
-        default=False,
-    )
-    optional.add_argument(
         "--png-cmap", dest="png_cmap", type=str, help="Colormap for figures", default="coolwarm"
     )
     optional.add_argument(
@@ -228,7 +216,6 @@ def _main(argv=None):
         tedort=args.tedort,
         gscontrol=args.gscontrol,
         no_reports=args.no_reports,
-        rica_report=args.rica_report,
         png_cmap=args.png_cmap,
         overwrite=args.overwrite,
         verbose=args.verbose,
@@ -252,7 +239,6 @@ def ica_reclassify_workflow(
     tedort=False,
     gscontrol=None,
     no_reports=False,
-    rica_report=False,
     png_cmap="coolwarm",
     verbose=False,
     overwrite=False,
@@ -292,9 +278,6 @@ def ica_reclassify_workflow(
     no_reports : obj:'bool', optional
         Do not generate .html reports and .png plots. Default is false such
         that reports are generated.
-    rica_report : obj:'bool', optional
-        Generate Rica interactive report files. Rica is a web-based visualization
-        tool for exploring ICA components. Default is False.
     png_cmap : obj:'str', optional
         Name of a matplotlib colormap to be used when generating figures.
         Cannot be used with --no-png. Default is 'coolwarm'.
@@ -621,12 +604,8 @@ def ica_reclassify_workflow(
 
     io_generator.save_self()
 
-    # Generate Rica report if requested
-    if rica_report:
-        LGR.info("Setting up Rica interactive report")
-        rica_launcher = rica.setup_rica_report(io_generator.out_dir)
-        if rica_launcher:
-            LGR.info(f"Rica report ready. Run 'python {rica_launcher.name}' to visualize results.")
+    # Generate Rica launcher script
+    rica.setup_rica_report(io_generator.out_dir)
 
     LGR.info("Workflow completed")
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -309,19 +309,6 @@ def _get_parser():
         default=False,
     )
     optional.add_argument(
-        "--rica-report",
-        dest="rica_report",
-        action="store_true",
-        help=(
-            "Generate Rica interactive report files. Rica is a web-based "
-            "visualization tool for exploring ICA components. When enabled, "
-            "tedana will download Rica (if not cached) and generate a launcher "
-            "script 'open_rica_report.py' in the output directory. Run this "
-            "script to visualize your results in Rica."
-        ),
-        default=False,
-    )
-    optional.add_argument(
         "--png-cmap", dest="png_cmap", type=str, help="Colormap for figures", default="coolwarm"
     )
     optional.add_argument(
@@ -441,7 +428,6 @@ def tedana_workflow(
     tedort=False,
     gscontrol=None,
     no_reports=False,
-    rica_report=False,
     png_cmap="coolwarm",
     verbose=False,
     low_mem=False,
@@ -555,11 +541,6 @@ def tedana_workflow(
     no_reports : obj:'bool', optional
         Do not generate .html reports and .png plots. Default is false such
         that reports are generated.
-    rica_report : obj:'bool', optional
-        Generate Rica interactive report files. Rica is a web-based visualization
-        tool for exploring ICA components. When enabled, tedana will download Rica
-        (if not cached) and create a launcher script in the output directory.
-        Default is False.
     png_cmap : obj:'str', optional
         Name of a matplotlib colormap to be used when generating figures.
         Cannot be used with --no-png. Default is 'coolwarm'.
@@ -1269,12 +1250,8 @@ def tedana_workflow(
         LGR.info("Generating dynamic report")
         reporting.generate_report(io_generator, cluster_labels, similarity_t_sne)
 
-    # Generate Rica report if requested
-    if rica_report:
-        LGR.info("Setting up Rica interactive report")
-        rica_launcher = rica.setup_rica_report(out_dir)
-        if rica_launcher:
-            LGR.info(f"Rica report ready. Run 'python {rica_launcher.name}' to visualize results.")
+    # Generate Rica launcher script
+    rica.setup_rica_report(out_dir)
 
     LGR.info("Workflow completed")
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -24,6 +24,7 @@ from tedana import (
     io,
     metrics,
     reporting,
+    rica,
     selection,
     utils,
 )
@@ -308,6 +309,19 @@ def _get_parser():
         default=False,
     )
     optional.add_argument(
+        "--rica-report",
+        dest="rica_report",
+        action="store_true",
+        help=(
+            "Generate Rica interactive report files. Rica is a web-based "
+            "visualization tool for exploring ICA components. When enabled, "
+            "tedana will download Rica (if not cached) and generate a launcher "
+            "script 'open_rica_report.py' in the output directory. Run this "
+            "script to visualize your results in Rica."
+        ),
+        default=False,
+    )
+    optional.add_argument(
         "--png-cmap", dest="png_cmap", type=str, help="Colormap for figures", default="coolwarm"
     )
     optional.add_argument(
@@ -427,6 +441,7 @@ def tedana_workflow(
     tedort=False,
     gscontrol=None,
     no_reports=False,
+    rica_report=False,
     png_cmap="coolwarm",
     verbose=False,
     low_mem=False,
@@ -540,6 +555,11 @@ def tedana_workflow(
     no_reports : obj:'bool', optional
         Do not generate .html reports and .png plots. Default is false such
         that reports are generated.
+    rica_report : obj:'bool', optional
+        Generate Rica interactive report files. Rica is a web-based visualization
+        tool for exploring ICA components. When enabled, tedana will download Rica
+        (if not cached) and create a launcher script in the output directory.
+        Default is False.
     png_cmap : obj:'str', optional
         Name of a matplotlib colormap to be used when generating figures.
         Cannot be used with --no-png. Default is 'coolwarm'.
@@ -1248,6 +1268,13 @@ def tedana_workflow(
 
         LGR.info("Generating dynamic report")
         reporting.generate_report(io_generator, cluster_labels, similarity_t_sne)
+
+    # Generate Rica report if requested
+    if rica_report:
+        LGR.info("Setting up Rica interactive report")
+        rica_launcher = rica.setup_rica_report(out_dir)
+        if rica_launcher:
+            LGR.info(f"Rica report ready. Run 'python {rica_launcher.name}' to visualize results.")
 
     LGR.info("Workflow completed")
 


### PR DESCRIPTION
## Summary

Adds Rica integration for interactive ICA component visualization. Every tedana run now creates a launcher script that handles Rica setup on demand.

## Key Changes

- **No CLI flag needed**: tedana always generates `open_rica_report.py` in the output directory
- **On-demand download**: Rica is downloaded when user runs the launcher script, not during tedana execution
- **Faster tedana runs**: No network calls during analysis
- **Self-contained launcher**: The launcher script includes all download/setup logic
- **Rica button in HTML report**: "Open in Rica" button with popup instructions

## How It Works

1. Run tedana as usual (no special flag needed)
2. Find `open_rica_report.py` in your output directory (full path is logged at end of run)
3. Run `python open_rica_report.py`
4. The script downloads Rica (if not cached), starts a local server, and opens your browser

Alternatively, open the HTML report and click the "Open in Rica" button in the top-right corner for instructions.

## Features

- Automatic Rica download from GitHub releases
- Platform-specific caching (Linux: ~/.cache, macOS: ~/Library/Caches, Windows: %LOCALAPPDATA%)
- Cross-platform path handling using `pathlib.as_posix()` for reliable Windows/Mac/Linux support
- `TEDANA_RICA_PATH` environment variable for developers to use local Rica builds
- `--force-download` flag to launcher for manual updates
- Cross-platform launcher script with built-in HTTP server and CORS support
- Graceful fallback if download fails (uses cached version if available)
- "Open in Rica" button in HTML report with modal popup

## Usage

```bash
# Run tedana
tedana -d data/*.nii.gz -e 14.5 29.0 43.5 --out-dir output

# View results in Rica (full path shown in tedana output)
python output/open_rica_report.py

# Or with ica_reclassify
ica_reclassify -c report.txt --out-dir output
python output/open_rica_report.py
```

## Test Plan

- [x] Unit tests for rica.py module (91% coverage)
- [x] Integration tests include open_rica_report.py in expected outputs
- [x] Works with both tedana and ica_reclassify workflows
- [x] Cross-platform path handling verified (Windows backslash fix)

## Files Changed

- `tedana/rica.py` - Simplified to generate self-contained launcher script
- `tedana/workflows/tedana.py` - Always calls setup_rica_report()
- `tedana/workflows/ica_reclassify.py` - Always calls setup_rica_report()
- `tedana/tests/test_rica.py` - Updated tests for new behavior
- `docs/outputs.rst` - Updated documentation
- `tedana/reporting/data/html/report_body_template.html` - Added Rica button with popup

Closes #1283.
