### PR TITLE
Fix interpolation arg in percentile numpy class 

### DIFF
--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -182,13 +182,10 @@ def make_adaptive_mask(data, mask, n_independent_echos=None, threshold=1, method
 
         # get 33rd %ile of `first_echo` and find corresponding index
         # NOTE: percentile is arbitrary
-        # TODO: "interpolation" param changed to "method" in numpy 1.22.0
-        #       confirm method="higher" is the same as interpolation="higher"
-        #       Current minimum version for numpy in tedana is 1.16 where
-        #       there is no "method" parameter. Either wait until we bump
-        #       our minimum numpy version to 1.22 or add a version check
-        #       or try/catch statement.
-        perc = np.percentile(first_echo, 33, interpolation="higher")
+        if np.lib.NumpyVersion(np.__version__) >= "1.22.0":
+            perc = np.percentile(first_echo, 33, method="higher")
+        else:
+            perc = np.percentile(first_echo, 33, interpolation="higher")
         perc_val = echo_means[:, 0] == perc
 
         # extract values from all echos at relevant index


### PR DESCRIPTION
Closes #1292

This pull request updates the way percentiles are calculated in the `make_adaptive_mask` function to ensure compatibility with different versions of NumPy. The code now checks the NumPy version at runtime and uses the appropriate parameter for the `np.percentile` function.

Compatibility improvements:

* Updated `make_adaptive_mask` in `tedana/utils.py` to use the `method` parameter for `np.percentile` if NumPy version is 1.22.0 or higher, and fall back to the deprecated `interpolation` parameter for older versions. This ensures the code works across a wider range of NumPy versions.