### PR TITLE
Add other time series to component plots

### DIFF
--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -391,16 +391,16 @@ def get_spectrum(data: np.array, tr: float = 1.0):
 
     Parameters
     ----------
-    data : (S, ) array_like
-            A timeseries S, on which you would like to perform an fft.
+    data : (S x P) array_like
+        A timeseries S, on which you would like to perform an fft.
     tr : :obj:`float`
-            Reptition time (TR) of the data
+        Reptition time (TR) of the data
     """
     # adapted from @dangom
-    power_spectrum = np.abs(np.fft.rfft(data)) ** 2
-    freqs = np.fft.rfftfreq(power_spectrum.size * 2 - 1, tr)
+    power_spectrum = np.abs(np.fft.rfft(data, axis=0)) ** 2
+    freqs = np.fft.rfftfreq(power_spectrum.shape[0] * 2 - 1, tr)
     idx = np.argsort(freqs)
-    return power_spectrum[idx], freqs[idx]
+    return power_spectrum[idx, :], freqs[idx]
 
 
 def threshold_map(img, min_cluster_size, threshold=None, mask=None, binarize=True, sided="bi"):

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -1187,6 +1187,19 @@ def tedana_workflow(
             io_generator=io_generator,
             gscontrol=gscontrol,
         )
+        other_mixing = None
+        if ("mir" in gscontrol) or tedort:
+            other_mixing = {}
+            if tedort:
+                ort_mixing_file = io_generator.get_name("ICA orthogonalized mixing tsv")
+                ort_mixing = pd.read_table(ort_mixing_file).values
+                other_mixing["tedort"] = ort_mixing
+
+            if "mir" in gscontrol:
+                mir_mixing_file = io_generator.get_name("ICA MIR mixing tsv")
+                mir_mixing = pd.read_table(mir_mixing_file).values
+                other_mixing["mir"] = mir_mixing
+
         reporting.static_figures.comp_figures(
             data_optcom,
             mask=mask_denoise,
@@ -1194,6 +1207,7 @@ def tedana_workflow(
             mixing=mixing_orig,
             io_generator=io_generator,
             png_cmap=png_cmap,
+            other_mixing=other_mixing,
         )
         reporting.static_figures.plot_t2star_and_s0(io_generator=io_generator, mask=mask_denoise)
         if t2smap is None:


### PR DESCRIPTION
Closes #1296.

Changes proposed in this pull request:

- Modify the component plots to include time series and FFTs for processed (post-orthogonalization if tedort is enabled, post-MIR if that is enabled) versions of the mixing matrix.
