### PR TITLE
Add store_artifacts steps to integration test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.three-echo
+      - run:
+          name: Remove NIfTI files to reduce artifact size
+          command: find /tmp/src/tedana/.testing_data_cache/outputs -name "*.nii*" -delete || true
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs/three-echo
           destination: three-echo-outputs
@@ -202,6 +205,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.four-echo
+      - run:
+          name: Remove NIfTI files to reduce artifact size
+          command: find /tmp/src/tedana/.testing_data_cache/outputs -name "*.nii*" -delete || true
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs/four-echo
           destination: four-echo-outputs
@@ -230,6 +236,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.five-echo
+      - run:
+          name: Remove NIfTI files to reduce artifact size
+          command: find /tmp/src/tedana/.testing_data_cache/outputs -name "*.nii*" -delete || true
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs/five-echo
           destination: five-echo-outputs
@@ -258,6 +267,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.reclassify
+      - run:
+          name: Remove NIfTI files to reduce artifact size
+          command: find /tmp/src/tedana/.testing_data_cache/outputs -name "*.nii*" -delete || true
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs/reclassify
           destination: reclassify-outputs
@@ -286,6 +298,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.t2smap
+      - run:
+          name: Remove NIfTI files to reduce artifact size
+          command: find /tmp/src/tedana/.testing_data_cache/outputs -name "*.nii*" -delete || true
       - store_artifacts:
           path: /tmp/src/tedana/.testing_data_cache/outputs/t2smap_five-echo
           destination: t2smap-outputs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           paths:
             - src/coverage/.coverage.three-echo
       - store_artifacts:
-          path: /tmp/src/.testing_data_cache/outputs/three-echo
+          path: /tmp/src/tedana/.testing_data_cache/outputs/three-echo
           destination: three-echo-outputs
 
   four-echo:
@@ -203,7 +203,7 @@ jobs:
           paths:
             - src/coverage/.coverage.four-echo
       - store_artifacts:
-          path: /tmp/src/.testing_data_cache/outputs/four-echo
+          path: /tmp/src/tedana/.testing_data_cache/outputs/four-echo
           destination: four-echo-outputs
 
   five-echo:
@@ -231,7 +231,7 @@ jobs:
           paths:
             - src/coverage/.coverage.five-echo
       - store_artifacts:
-          path: /tmp/src/.testing_data_cache/outputs/five-echo
+          path: /tmp/src/tedana/.testing_data_cache/outputs/five-echo
           destination: five-echo-outputs
 
   reclassify:
@@ -259,7 +259,7 @@ jobs:
           paths:
             - src/coverage/.coverage.reclassify
       - store_artifacts:
-          path: /tmp/src/.testing_data_cache/outputs/reclassify
+          path: /tmp/src/tedana/.testing_data_cache/outputs/reclassify
           destination: reclassify-outputs
 
   t2smap:
@@ -287,7 +287,7 @@ jobs:
           paths:
             - src/coverage/.coverage.t2smap
       - store_artifacts:
-          path: /tmp/src/.testing_data_cache/outputs/t2smap_five-echo
+          path: /tmp/src/tedana/.testing_data_cache/outputs/t2smap_five-echo
           destination: t2smap-outputs
 
   merge_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.three-echo
+      - store_artifacts:
+          path: /tmp/src/.testing_data_cache/outputs/three-echo
+          destination: three-echo-outputs
 
   four-echo:
     docker:
@@ -199,6 +202,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.four-echo
+      - store_artifacts:
+          path: /tmp/src/.testing_data_cache/outputs/four-echo
+          destination: four-echo-outputs
 
   five-echo:
     docker:
@@ -224,6 +230,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.five-echo
+      - store_artifacts:
+          path: /tmp/src/.testing_data_cache/outputs/five-echo
+          destination: five-echo-outputs
 
   reclassify:
     docker:
@@ -249,6 +258,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.reclassify
+      - store_artifacts:
+          path: /tmp/src/.testing_data_cache/outputs/reclassify
+          destination: reclassify-outputs
 
   t2smap:
     docker:
@@ -274,6 +286,9 @@ jobs:
           root: /tmp
           paths:
             - src/coverage/.coverage.t2smap
+      - store_artifacts:
+          path: /tmp/src/.testing_data_cache/outputs/t2smap_five-echo
+          destination: t2smap-outputs
 
   merge_coverage:
     working_directory: /tmp/src/tedana


### PR DESCRIPTION
## Summary
- Adds `store_artifacts` steps to the three-echo, four-echo, five-echo, reclassify, and t2smap CircleCI jobs
- Makes integration test outputs visible in the CircleCI Artifacts tab for debugging purposes
- Artifacts are stored at `/tmp/src/.testing_data_cache/outputs/<test-name>`

Closes #1317

## Test plan
- [x] Verify CircleCI builds complete successfully
- [x] Check that the Artifacts tab shows test outputs for each integration test job

🤖 Generated with [Claude Code](https://claude.com/claude-code)