### PR TITLE
Deprecate support for z-concatenated inputs

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -870,6 +870,11 @@ def load_data(data, n_echos=None, dummy_scans=0):
                 raise TypeError(f"Unsupported type: {type(item)}")
 
         if len(data) == 1:  # a z-concatenated file was provided
+            LGR.warning(
+                "DEPRECATION WARNING: We are planning to deprecate supplying a single "
+                "z-concatenated data file at the end of 2026. "
+                "If you are using this option, contact the tedana developers ASAP."
+            )
             data = data[0]
         elif len(data) == 2:  # inviable -- need more than 2 echos
             raise ValueError(f"Cannot run `tedana` with only two echos: {data}")

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -873,7 +873,7 @@ def load_data(data, n_echos=None, dummy_scans=0):
             LGR.warning(
                 "DEPRECATION WARNING: We are planning to deprecate supplying a single "
                 "z-concatenated data file at the end of 2026. "
-                "If you are using this option, contact the tedana developers ASAP."
+                "If you are using this option, please comment on https://github.com/ME-ICA/tedana/issues/1313."
             )
             data = data[0]
         elif len(data) == 2:  # inviable -- need more than 2 echos

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -873,7 +873,8 @@ def load_data(data, n_echos=None, dummy_scans=0):
             LGR.warning(
                 "DEPRECATION WARNING: We are planning to deprecate supplying a single "
                 "z-concatenated data file at the end of 2026. "
-                "If you are using this option, please comment on https://github.com/ME-ICA/tedana/issues/1313."
+                "If you are using this option, "
+                "please comment on https://github.com/ME-ICA/tedana/issues/1313."
             )
             data = data[0]
         elif len(data) == 2:  # inviable -- need more than 2 echos

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -276,7 +276,7 @@ def test_integration_four_echo(skip_integration):
     }
 
 
-def test_integration_three_echo(skip_integration):
+def test_integration_three_echo(skip_integration, caplog):
     """Integration test of the full tedana workflow with the CLI using three-echo test data."""
 
     if skip_integration:
@@ -305,6 +305,9 @@ def test_integration_three_echo(skip_integration):
         "mdl",
     ]
     tedana_cli._main(args)
+
+    # Check that a deprecation warning about z-concatenated data is shown
+    assert "DEPRECATION WARNING" in caplog.text
 
     # compare the generated output files
     fn = resource_filename("tedana", "tests/data/cornell_three_echo_outputs.txt")

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -69,11 +69,10 @@ def _get_parser():
         metavar="FILE",
         type=lambda x: is_valid_file(parser, x),
         help=(
-            "Multi-echo dataset for analysis. May be a "
-            "single file with spatially concatenated data "
-            "or a set of echo-specific files, in the same "
-            "order as the TEs are listed in the -e "
-            "argument."
+            "Multi-echo dataset for analysis. "
+            "A set of echo-specific files in ascending order. "
+            "The TEs of the data should match "
+            "the TEs listed in the -e argument."
         ),
         required=True,
     )
@@ -84,7 +83,7 @@ def _get_parser():
         metavar="TE",
         type=float,
         help=(
-            "Echo times in seconds (per BIDS convention). E.g., 0.015 0.039 0.063. "
+            "Ascending echo times in seconds (per BIDS convention). E.g., 0.015 0.039 0.063. "
             "Millisecond values (e.g., 15.0 39.0 63.0) are still accepted but deprecated."
         ),
         required=True,


### PR DESCRIPTION
As discussed at in our dev call #1312, we do not think anyone is using the zcat option for input anymore. Since creates a non-trivial amount of special cases and may cause problems with some future changes, we plan to deprecate this option.

Changes proposed in this pull request:

- If a user provides zcat data as input, it puts up a warning that this option will be deprecated at the end of 2026 and asks the user to contact the tedana developers (so that we know if anyone is still using this option)
- Removes the descriptive text for the zcat option from the command line help (though it will still be functional). It is still mentioned in function docstrings.
- The command line doc strings implied that the echoes and data files could be in any order, but the function docstrings said they need to be in ascending order. I'm not sure if any order actually works in all our code, so I tweaked the command line docstring to also specify ascending order.
