### PR TITLE
chore(ci): Add uv lock updater workflow

### DIFF
--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -1,0 +1,55 @@
+name: Update lockfile
+
+on:
+  # For testing changes to this workflow
+  push:
+    branches:
+      - ci/update-deps
+  # Monthly at 9am EST/10am EDT on the 10th
+  schedule:
+    - cron: "15 14 10 * *"
+  # Trigger manually
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Set a minimum dependency age to thwart supply-chain attacks
+  # See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+  MIN_AGE: 1 week
+
+jobs:
+  update:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
+      - name: Set git identity
+        run: |
+          git config --global user.name "tedana bot"
+          git config --global user.email "github-actions@users.noreply.github.com"
+      - name: Prepare markdown preamble
+        run: |
+          echo -e "Closes none.\n\nThis PR makes the following updates to \`uv.lock\`:\n\n\`\`\`" |
+          tee /tmp/pr.md
+      - name: Update lockfile
+        run: 'uv lock --upgrade --exclude-newer "$MIN_AGE" 2>&1 | tee -a /tmp/pr.md'
+        env:
+          NO_COLOR: 1
+      - name: Postamble
+        run: echo '```' | tee -a /tmp/pr.md
+      - name: Make pull request
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+        with:
+          branch: deps/uv-lock-upgrade
+          title: "chore(deps): uv lock --upgrade"
+          body-path: /tmp/pr.md


### PR DESCRIPTION
Closes #1265 .

This PR adds a GitHub workflow that runs monthly as well as on-demand to run `uv.lock` and open a PR against the main branch. You can see an example here: https://github.com/effigies/tedana/pull/4

It includes a [dependency cooldown](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) of 1 week to avoid falling prey to supply-chain attacks. This will also incidentally help avoid spending time testing `x.y.0` releases that are quickly followed with `x.y.1` bug fixes.

It also sets up a `ci/update-deps` branch, so that you can test any changes by pushing to `ci/update-deps` and it will run the action. If it creates a PR it will also do that against the `ci/update-deps` branch.