### PR TITLE
chore(deps): Set cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,10 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# These set a minimum dependency age (cooldown) to thwart supply-chain attacks
+# See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+# Also avoids churn when dependencies put out buggy releases followed shortly by fixes
+
 version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
@@ -10,8 +14,12 @@ updates:
     labels: ["maintenance", "ignore-for-release"]
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: uv
     directory: "/"
     labels: ["maintenance", "ignore-for-release"]
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Closes #1321.
Closes #1265.

Changes proposed in this pull request:

- Adds a cooldown period to dependabot updates.

Via #1321:

> It includes a [dependency cooldown](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) of 1 week to avoid falling prey to supply-chain attacks. This will also incidentally help avoid spending time testing `x.y.0` releases that are quickly followed with `x.y.1` bug fixes.

This just implements this using Dependabot's built-in configuration option.