### PR TITLE
fix: Add cache-control for data files and improve Rica modal accessibility

### DIFF
--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -307,16 +307,16 @@
 
 <!-- Rica Button -->
 <div class="rica-button-container">
-  <button type="button" class="rica-button" onclick="openRicaModal()">
+  <button type="button" class="rica-button" onclick="openRicaModal()" aria-haspopup="dialog">
     🔍 Open in Rica
   </button>
 </div>
 
 <!-- Rica Modal -->
-<div class="rica-modal-overlay" id="ricaModal">
+<div class="rica-modal-overlay" id="ricaModal" role="dialog" aria-modal="true" aria-labelledby="ricaModalTitle">
   <div class="rica-modal">
-    <button type="button" class="rica-modal-close" onclick="closeRicaModal()">×</button>
-    <h2>Open in Rica</h2>
+    <button type="button" class="rica-modal-close" onclick="closeRicaModal()" aria-label="Close modal">×</button>
+    <h2 id="ricaModalTitle">Open in Rica</h2>
     <p>
       <strong>Rica</strong> is an interactive web-based tool for exploring ICA components
       with 3D brain visualization and
@@ -525,13 +525,25 @@
     document.getElementById("imgCarpetPlot").src = carpetPlot;
   }
 
-  // Rica modal functions
+  // Rica modal functions with accessibility support
+  var ricaModalTrigger = null;
+
   function openRicaModal() {
-    document.getElementById("ricaModal").style.display = "flex";
+    ricaModalTrigger = document.activeElement;
+    var modal = document.getElementById("ricaModal");
+    modal.style.display = "flex";
+    // Focus the close button when modal opens
+    var closeBtn = modal.querySelector(".rica-modal-close");
+    if (closeBtn) closeBtn.focus();
   }
 
   function closeRicaModal() {
     document.getElementById("ricaModal").style.display = "none";
+    // Return focus to the element that opened the modal
+    if (ricaModalTrigger) {
+      ricaModalTrigger.focus();
+      ricaModalTrigger = null;
+    }
   }
 
   function openRicaWebsite() {
@@ -545,10 +557,29 @@
     }
   });
 
-  // Close modal with Escape key
+  // Close modal with Escape key and trap focus within modal
   document.addEventListener("keydown", function(event) {
+    var modal = document.getElementById("ricaModal");
+    if (modal.style.display !== "flex") return;
+
     if (event.key === "Escape") {
       closeRicaModal();
+      return;
+    }
+
+    // Trap focus within modal
+    if (event.key === "Tab") {
+      var focusable = modal.querySelectorAll("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])");
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     }
   });
 </script>

--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -570,6 +570,9 @@
     // Trap focus within modal
     if (event.key === "Tab") {
       var focusable = modal.querySelectorAll("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])");
+      if (!focusable || focusable.length === 0) {
+        return;
+      }
       var first = focusable[0];
       var last = focusable[focusable.length - 1];
 

--- a/tedana/rica.py
+++ b/tedana/rica.py
@@ -286,21 +286,33 @@ def download_rica(force: bool = False) -> Path:
 
     LGR.info(f"Downloading Rica {latest_version}...")
 
-    # Download each file
-    for filename in RICA_FILES:
-        if filename not in assets:
-            LGR.warning(f"Rica asset {filename} not found in release")
-            continue
+    # Download each file to temporary paths first to avoid partial downloads
+    # corrupting the cache if something fails partway through
+    downloaded_files = []
+    try:
+        for filename in RICA_FILES:
+            if filename not in assets:
+                LGR.warning(f"Rica asset {filename} not found in release")
+                continue
 
-        dest_path = cache_dir / filename
-        try:
-            download_rica_file(assets[filename], dest_path)
+            temp_path = cache_dir / f".{filename}.tmp"
+            download_rica_file(assets[filename], temp_path)
+            downloaded_files.append((temp_path, cache_dir / filename))
             LGR.debug(f"Downloaded {filename}")
-        except urllib.error.URLError as e:
-            raise RuntimeError(f"Failed to download {filename}: {e}") from e
 
-    # Write version file
-    (cache_dir / "VERSION").write_text(latest_version)
+        # All downloads succeeded - move temp files to final locations
+        for temp_path, final_path in downloaded_files:
+            temp_path.rename(final_path)
+
+        # Write version file only after all files are in place
+        (cache_dir / "VERSION").write_text(latest_version)
+
+    except urllib.error.URLError as e:
+        # Clean up any temp files on failure
+        for temp_path, _ in downloaded_files:
+            if temp_path.exists():
+                temp_path.unlink()
+        raise RuntimeError(f"Failed to download Rica: {e}") from e
 
     LGR.info(f"Rica {latest_version} downloaded to {cache_dir}")
     return cache_dir
@@ -533,14 +545,37 @@ def setup_rica(output_dir, force_download=False):
 class RicaHandler(http.server.SimpleHTTPRequestHandler):
     """HTTP handler with CORS support, cache control, and file listing endpoint."""
 
+    # Data file extensions that should never be cached (fixes tedana#1323)
+    # These files have identical names across different datasets, so caching
+    # causes stale data to be served when switching between datasets
+    # Note: .gz catches all gzip files including .nii.gz
+    DATA_EXTENSIONS = (
+        ".tsv", ".png", ".svg", ".json", ".txt",
+        ".nii", ".gz",
+    )
+
     def end_headers(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # Restrict CORS to localhost origins only for security
+        origin = self.headers.get("Origin")
+        if origin and (
+            origin.startswith("http://localhost")
+            or origin.startswith("http://127.0.0.1")
+            or origin.startswith("https://localhost")
+            or origin.startswith("https://127.0.0.1")
+        ):
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
         self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
-        # Add cache-control headers for Rica core files to prevent browser caching
-        # This ensures updated Rica versions are always served fresh
+        # Add cache-control headers to prevent browser caching
+        # This is critical for:
+        # 1. Rica core files (.html, .py) - ensures updated versions are served
+        # 2. Data files (.tsv, .png, .svg, etc.) - prevents stale data when
+        #    switching between different tedana output directories (#1323)
         path = unquote(self.path) if hasattr(self, 'path') else ""
-        if "/rica/" in path and (path.endswith(".html") or path.endswith(".py")):
+        is_rica_core = "/rica/" in path and (path.endswith(".html") or path.endswith(".py"))
+        is_data_file = any(path.endswith(ext) for ext in self.DATA_EXTENSIONS)
+        if is_rica_core or is_data_file:
             self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
             self.send_header("Pragma", "no-cache")
             self.send_header("Expires", "0")
@@ -560,10 +595,26 @@ class RicaHandler(http.server.SimpleHTTPRequestHandler):
     def send_file_list(self):
         files = []
         cwd = Path.cwd()
-        for f in cwd.rglob("*"):
-            if f.is_file() and any(p in f.name for p in RICA_FILE_PATTERNS):
-                files.append(f.relative_to(cwd).as_posix())
-        response_data = {"files": sorted(files), "path": str(cwd), "count": len(files)}
+
+        # Limit traversal depth to avoid performance issues on large directories
+        max_depth = 3
+
+        for root, dirs, filenames in os.walk(cwd):
+            root_path = Path(root)
+            rel_root = root_path.relative_to(cwd)
+
+            # Stop descending once max depth is reached
+            if len(rel_root.parts) >= max_depth:
+                dirs[:] = []
+                continue
+
+            for name in filenames:
+                if any(p in name for p in RICA_FILE_PATTERNS):
+                    f = root_path / name
+                    files.append(f.relative_to(cwd).as_posix())
+
+        # Don't expose full path for security
+        response_data = {"files": sorted(files), "path": ".", "count": len(files)}
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()


### PR DESCRIPTION
## Summary
This PR fixes the browser caching issue reported in #1323 and addresses PR review comments for accessibility improvements.

## Cache Control Fixes (#1323)
When users run tedana on different datasets and open Rica reports consecutively, the browser was caching data files (TSV, PNG, SVG, NIfTI) from the previous dataset because they have identical filenames.

**Changes:**
- Add `DATA_EXTENSIONS` tuple to `RicaHandler` to identify data files that should not be cached
- Extend cache-control headers to all data file types (`.tsv`, `.png`, `.svg`, `.json`, `.txt`, `.nii`, `.gz`)
- Restrict CORS to localhost origins only for security
- Add depth limit (3 levels) to file search to avoid performance issues on large directories
- Use atomic temp file downloads to avoid inconsistent cache state if download fails

## Accessibility Improvements
**HTML changes:**
- Add `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to Rica modal
- Add `aria-label="Close modal"` to close button
- Add `aria-haspopup="dialog"` to trigger button

**JavaScript changes:**
- Move focus to close button when modal opens
- Return focus to trigger element when modal closes
- Trap Tab key focus within modal while open

## Defense in Depth
A complementary fix has been submitted to Rica (ME-ICA/rica#99) that adds client-side cache-busting.

## Test plan
- [ ] Run tedana on dataset A, open Rica via `python open_rica_report.py`
- [ ] Close Rica and stop the server
- [ ] Run tedana on dataset B, open Rica via `python open_rica_report.py`
- [ ] Verify dataset B's data is displayed (not dataset A's cached data)
- [ ] Test modal accessibility with keyboard navigation

Fixes #1323

🤖 Generated with [Claude Code](https://claude.ai/code)