### PR TITLE
Use z-statistic threshold of 1.96 (two-sided p < 0.05) instead of 1.95

### DIFF
--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -226,7 +226,7 @@ def generate_metrics(
 
     if "map Z clusterized" in required_metrics:
         LGR.info("Thresholding z-statistic maps")
-        z_thresh = 1.95
+        z_thresh = 1.96  # p < 0.05 two-sided
         metric_maps["map Z clusterized"] = dependence.threshold_map(
             maps=metric_maps["map Z"],
             mask=mask,

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -235,7 +235,7 @@ def generate_metrics(
         )
 
     if "map FT2 clusterized" in required_metrics:
-        LGR.info("Calculating T2* F-statistic maps")
+        LGR.info("Thresholding T2* F-statistic maps")
         metric_maps["map FT2 clusterized"] = dependence.threshold_map(
             maps=metric_maps["map FT2"],
             mask=mask,
@@ -244,7 +244,7 @@ def generate_metrics(
         )
 
     if "map FS0 clusterized" in required_metrics:
-        LGR.info("Calculating S0 F-statistic maps")
+        LGR.info("Thresholding S0 F-statistic maps")
         metric_maps["map FS0 clusterized"] = dependence.threshold_map(
             maps=metric_maps["map FS0"],
             mask=mask,

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -453,7 +453,7 @@ def compute_signal_minus_noise_z(
     z_maps: np.ndarray,
     z_clmaps: np.ndarray,
     f_t2_maps: np.ndarray,
-    z_thresh: float = 1.95,
+    z_thresh: float = 1.96,
 ) -> typing.Tuple[np.ndarray, np.ndarray]:
     """Compare signal and noise z-statistic distributions with a two-sample t-test.
 
@@ -474,7 +474,7 @@ def compute_signal_minus_noise_z(
         Each voxel reflects the model fit for the component weights to the
         TE-dependence model across echoes.
     z_thresh : float, optional
-        Z-statistic threshold for voxel-wise significance. Default is 1.95.
+        Z-statistic threshold for voxel-wise significance. Default is 1.96 (p < 0.05 two-sided).
 
     Returns
     -------
@@ -521,7 +521,7 @@ def compute_signal_minus_noise_t(
     z_maps: np.ndarray,
     z_clmaps: np.ndarray,
     f_t2_maps: np.ndarray,
-    z_thresh: float = 1.95,
+    z_thresh: float = 1.96,
 ) -> typing.Tuple[np.ndarray, np.ndarray]:
     """Compare signal and noise t-statistic distributions with a two-sample t-test.
 
@@ -541,7 +541,7 @@ def compute_signal_minus_noise_t(
         Each voxel reflects the model fit for the component weights to the
         TE-dependence model across echoes.
     z_thresh : float, optional
-        Z-statistic threshold for voxel-wise significance. Default is 1.95.
+        Z-statistic threshold for voxel-wise significance. Default is 1.96 (p < 0.05 two-sided).
 
     Returns
     -------
@@ -593,7 +593,7 @@ def compute_countnoise(
     *,
     stat_maps: np.ndarray,
     stat_cl_maps: np.ndarray,
-    stat_thresh: float = 1.95,
+    stat_thresh: float = 1.96,
 ) -> np.ndarray:
     """Count the number of significant voxels from non-significant clusters.
 
@@ -607,8 +607,7 @@ def compute_countnoise(
     stat_cl_maps : (S x C) array_like
         Cluster-extent thresholded and binarized version of stat_maps.
     stat_thresh : float, optional
-        Statistical threshold. Default is 1.95 (Z-statistic threshold
-        corresponding to p<X one-sided).
+        Z-statistic threshold corresponding to p<X two-sided. Default is 1.96 (p < 0.05 two-sided).
 
     Returns
     -------

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -319,7 +319,7 @@ def test_smoke_compute_signal_minus_noise_z():
         z_maps=z_maps,
         z_clmaps=z_clmaps,
         f_t2_maps=f_t2_maps,
-        z_thresh=1.95,
+        z_thresh=1.96,
     )
     assert signal_minus_noise_z.shape == signal_minus_noise_p.shape == (n_components,)
 
@@ -337,7 +337,7 @@ def test_smoke_compute_signal_minus_noise_t():
         z_maps=z_maps,
         z_clmaps=z_clmaps,
         f_t2_maps=f_t2_maps,
-        z_thresh=1.95,
+        z_thresh=1.96,
     )
     assert signal_minus_noise_t.shape == signal_minus_noise_p.shape == (n_components,)
 
@@ -358,7 +358,7 @@ def test_smoke_compute_countnoise():
     countnoise = dependence.compute_countnoise(
         stat_maps=stat_maps,
         stat_cl_maps=stat_cl_maps,
-        stat_thresh=1.95,
+        stat_thresh=1.96,
     )
     assert countnoise.shape == (n_components,)
 

--- a/tedana/tests/test_metrics_dependence.py
+++ b/tedana/tests/test_metrics_dependence.py
@@ -224,20 +224,20 @@ def test_compute_countnoise_correctness():
     # Create test data
     stat_maps = np.array([[3.0, 1.0], [2.5, 0.5], [1.0, 2.5], [-2.5, -1.5]])
     stat_cl_maps = np.array([[1, 0], [1, 0], [0, 1], [0, 0]])
-    stat_thresh = 1.95
+    stat_thresh = 1.96
 
     countnoise = dependence.compute_countnoise(
         stat_maps=stat_maps, stat_cl_maps=stat_cl_maps, stat_thresh=stat_thresh
     )
 
     # For component 0: abs(stat_maps[:, 0]) = [3.0, 2.5, 1.0, 2.5]
-    # Values > 1.95: [3.0, 2.5, 2.5] at indices [0, 1, 3]
+    # Values > 1.96: [3.0, 2.5, 2.5] at indices [0, 1, 3]
     # stat_cl_maps at these indices: [1, 1, 0]
     # Noise voxels (>thresh and not in cluster): only index 3
     # Count: 1
 
     # For component 1: abs(stat_maps[:, 1]) = [1.0, 0.5, 2.5, 1.5]
-    # Values > 1.95: [2.5] at index [2]
+    # Values > 1.96: [2.5] at index [2]
     # stat_cl_maps at index 2: 1 (in cluster)
     # Noise voxels: 0
 


### PR DESCRIPTION
Closes none. I was originally going to bundle this into #1328, but felt like it was a self-contained change that should go in its own PR.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace z-statistic threshold of 1.95 (not a common threshold) with 1.96 (a common threshold and probably what we wanted).
- Make logged messages about a couple of metric collection steps more accurate.
