### PR TITLE
Remove unused z_maps parameter in calculate_f_maps

### DIFF
--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -215,7 +215,6 @@ def generate_metrics(
         LGR.info("Calculating F-statistic maps")
         m_t2, m_s0, p_m_t2, p_m_s0 = dependence.calculate_f_maps(
             data_cat=data_cat,
-            z_maps=metric_maps["map Z"],
             mixing=mixing,
             adaptive_mask=adaptive_mask,
             tes=tes,

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -132,7 +132,6 @@ def calculate_z_maps(
 def calculate_f_maps(
     *,
     data_cat: np.ndarray,
-    z_maps: np.ndarray,
     mixing: np.ndarray,
     adaptive_mask: np.ndarray,
     tes: np.ndarray,
@@ -145,8 +144,6 @@ def calculate_f_maps(
     ----------
     data_cat : (M x E x T) array_like
         Multi-echo data, already masked.
-    z_maps : (M x C) array_like
-        Z-statistic maps for components, reflecting voxel-wise component loadings.
     mixing : (T x C) array_like
         Mixing matrix
     adaptive_mask : (M) array_like
@@ -168,10 +165,9 @@ def calculate_f_maps(
         Pseudo-F-statistic maps for TE-dependence and -independence models,
         respectively.
     """
-    assert data_cat.shape[0] == z_maps.shape[0] == adaptive_mask.shape[0]
+    assert data_cat.shape[0] == adaptive_mask.shape[0]
     assert data_cat.shape[1] == tes.shape[0]
     assert data_cat.shape[2] == mixing.shape[0]
-    assert z_maps.shape[1] == mixing.shape[1]
 
     # TODO: Remove mask arg from get_coeffs
     me_betas = get_coeffs(data_cat, mixing, mask=np.ones(data_cat.shape[:2], bool), add_const=True)

--- a/tedana/resources/config/metrics.json
+++ b/tedana/resources/config/metrics.json
@@ -63,14 +63,12 @@
             "countsigFT2"
         ],
         "map FT2": [
-            "map Z",
             "mixing",
             "tes",
             "data_cat",
             "adaptive_mask"
         ],
         "map FS0": [
-            "map Z",
             "mixing",
             "tes",
             "data_cat",

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -214,7 +214,6 @@ def test_smoke_calculate_f_maps():
     """Smoke test for tedana.metrics.dependence.calculate_f_maps."""
     n_voxels, n_echos, n_volumes, n_components = 1000, 5, 100, 50
     data_cat = np.random.random((n_voxels, n_echos, n_volumes))
-    z_maps = np.random.normal(size=(n_voxels, n_components))
     mixing = np.random.random((n_volumes, n_components))
     # The ordering is random, but make sure the adaptive mask always includes values of 1-5
     adaptive_mask = np.random.permutation(
@@ -231,7 +230,6 @@ def test_smoke_calculate_f_maps():
     tes = np.array([15, 25, 35, 45, 55])
     f_t2_maps_orig, f_s0_maps_orig, _, _ = dependence.calculate_f_maps(
         data_cat=data_cat,
-        z_maps=z_maps,
         mixing=mixing,
         adaptive_mask=adaptive_mask,
         tes=tes,
@@ -242,7 +240,6 @@ def test_smoke_calculate_f_maps():
     # rerunning with n_independent_echos=3
     f_t2_maps, f_s0_maps, _, _ = dependence.calculate_f_maps(
         data_cat=data_cat,
-        z_maps=z_maps,
         mixing=mixing,
         adaptive_mask=adaptive_mask,
         tes=tes,


### PR DESCRIPTION
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove unused `z_maps` parameter in `calculate_f_maps`.
- Remove "map Z" requirement for "map FT2" and "map FS0" metrics.
