### PR TITLE
fixing a pandas string to bool issue

### DIFF
--- a/tedana/selection/component_selector.py
+++ b/tedana/selection/component_selector.py
@@ -653,12 +653,12 @@ class ComponentSelector:
     @property
     def likely_bold_comps_(self) -> int:
         """A boolean :obj:`pandas.Series` of components that are tagged "Likely BOLD"."""
-        likely_bold_comps = self.component_table_["classification_tags"].copy()
+        likely_bold_comps = asarray([False] * len(self.component_table_))
         for idx in range(len(likely_bold_comps)):
-            if "Likely BOLD" in likely_bold_comps.loc[idx]:
-                likely_bold_comps.loc[idx] = True
+            if "Likely BOLD" in self.component_table_["classification_tags"].loc[idx]:
+                likely_bold_comps[idx] = True
             else:
-                likely_bold_comps.loc[idx] = False
+                likely_bold_comps[idx] = False
         return likely_bold_comps
 
     @property

--- a/tedana/selection/component_selector.py
+++ b/tedana/selection/component_selector.py
@@ -653,13 +653,7 @@ class ComponentSelector:
     @property
     def likely_bold_comps_(self) -> int:
         """A boolean :obj:`pandas.Series` of components that are tagged "Likely BOLD"."""
-        likely_bold_comps = asarray([False] * len(self.component_table_))
-        for idx in range(len(likely_bold_comps)):
-            if "Likely BOLD" in self.component_table_["classification_tags"].loc[idx]:
-                likely_bold_comps[idx] = True
-            else:
-                likely_bold_comps[idx] = False
-        return likely_bold_comps
+        return self.component_table_["classification_tags"].str.contains("Likely BOLD")
 
     @property
     def n_likely_bold_comps_(self) -> int:


### PR DESCRIPTION
@marlyr was running tedana with the newest version of pandas and tedana crashed. We think the issue arises in https://pandas.pydata.org/docs/whatsnew/v3.0.0.html due to `The str dtype can only hold strings (or missing values), in contrast to object dtype. (setitem with non string fails)`

Changes proposed in this pull request:

- We identified one place in the code where we copied a pandas series will `str` values and then overwrote the values as `bool`. There was no reason to do this. This PR creates a numpy bool array and then assigns new values there.
