### PR TITLE
Fix handling of op3 in dec_left_op_right

### DIFF
--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -342,8 +342,8 @@ def dec_left_op_right(
                 f"left2={left2}, right2={right2}, op2={op2}"
             )
 
-    # If any of the values for the second boolean statement are set
-    if left3 or right3 or op3:
+    # If any of the values for the third boolean statement are set
+    if left3 is not None or right3 is not None or op3 is not None:
         if is_compound == 0:
             raise ValueError(
                 "left_op_right is includes parameters for a third conditional "
@@ -351,7 +351,7 @@ def dec_left_op_right(
                 "second statement"
             )
         # Check if they're all set & use them all or raise an error
-        if left3 and right3 and op3:
+        if left3 is not None and right3 is not None and op3 is not None:
             is_compound = 3
             left3_scale, left3, right3_scale, right3 = confirm_valid_conditional(
                 left3_scale, left3, right3_scale, right3, op3

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -429,7 +429,7 @@ def dec_left_op_right(
             # statement 1 is now the combination of the first two conditional statements
             statement1 = decision_boolean.copy()
             # statement 2 is now the third conditional statement
-            statement2 = eval(f"(left3_scale*left3_val) {op2} (right3_scale * right3_val)")
+            statement2 = eval(f"(left3_scale*left3_val) {op3} (right3_scale * right3_val)")
             # logical dot product for compound statement
             decision_boolean = statement1 * statement2
 


### PR DESCRIPTION
Closes none, but addresses a bug I identified while working on a decision tree. In nodes with three conditionals, the operator from the second conditional (op2) was being used in place of the third conditional's operator (op3).

Fortunately, the only decision tree impacted by this bug (i.e., the only one where op2 and op3 were different) is `demo_external_regressors_motion_task_models`, for the "Fits motion external regressors" (< vs >), "Fits CSF external regressors" (< vs >), and "Fits task" (just > vs >=) nodes.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use `op3` where appropriate in `dec_left_op_right`.
- Compare left3, right3, and op3 against None instead of implicit boolean, which would be a problem for thresholds of 0, to match handling of first and second conditionals.
