### PR TITLE
Add Spearman's rho metrics

### DIFF
--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -193,61 +193,32 @@ Having more cluster voxels in the S0-model F-statistic map than
 in the T2*-model F-statistic map is a good indicator that the component is noise.
 
 
-dice_FT2
-========
-:func:`tedana.metrics.dependence.compute_dice`
-
-The Dice similarity index between each component's cluster-extent thresholded
-T2*-model F-statistic map (using a p<0.05 threshold) and
-its cluster-extent thresholded unstandardized parameter estimate map (using a 5% threshold).
-This is a measure of the similarity between the T2*-model F-statistic map and the weight map.
-If the unstandardized parameter estimate map has a higher DSI with the T2*-model F-statistic map than the S0-model F-statistic map,
-it is more likely to be signal.
-
-
-dice_FS0
-========
-:func:`tedana.metrics.dependence.compute_dice`
-
-The Dice similarity index between each component's cluster-extent thresholded
-S0-model F-statistic map (using a p<0.05 threshold) and
-its cluster-extent thresholded unstandardized parameter estimate map (using a 5% threshold).
-This is a measure of the similarity between the S0-model F-statistic map and the standardized parameter estimate map.
-If the unstandardized parameter estimate map has a higher DSI with the S0-model F-statistic map than the T2*-model F-statistic map,
-it is more likely to be noise.
-
-
-spearman_FT2_beta
+dice_FT2/dice_FS0
 =================
+:func:`tedana.metrics.dependence.compute_dice`
+
+The Dice similarity index between each component's cluster-extent thresholded
+T2*-model (``dice_FT2``) or S0-model (``dice_FS0``) F-statistic map
+(using a p<0.05 threshold) and
+its cluster-extent thresholded unstandardized parameter estimate map (using a 5% threshold).
+These metrics are measures of the similarity between the models' F-statistic maps and the weight map.
+If the unstandardized parameter estimate map has a higher DSI with the T2*-model F-statistic map than the S0-model F-statistic map,
+it is more likely to be TE-dependent.
+
+
+spearman_FT2_beta/spearman_FS0_beta
+===================================
 :func:`tedana.metrics.dependence.compute_spearmans_rho`
 
 The Spearman's rank correlation coefficient between each component's squared
 standardized parameter estimate map and T2*-model F-statistic map.
 
-Like ``dice_FT2``, this metric measures the similarity between the
+Like ``dice_FT2``/``dice_FS0``, these metrics measure the similarity between the
 component spatial weights and the spatial distribution of the
-TE-dependence model strength.
-The two differences are that this metric does not use thresholded maps and it
-uses the squared standardized parameter estimate map instead of the
-unstandardized parameter estimate map.
-
-If ``spearman_FT2_beta`` is higher than ``spearman_FS0_beta``,
-it is more likely that the component is TE-dependent.
-
-
-spearman_FS0_beta
-=================
-:func:`tedana.metrics.dependence.compute_spearmans_rho`
-
-The Spearman's rank correlation coefficient between each component's squared
-standardized parameter estimate map and S0-model F-statistic map.
-
-Like ``dice_FS0``, this metric measures the similarity between the
-component spatial weights and the spatial distribution of the
-TE-independence model strength.
-The two differences are that this metric does not use thresholded maps and it
-uses the squared standardized parameter estimate map instead of the
-unstandardized parameter estimate map.
+TE-(in)dependence model strength.
+The two differences are that these metrics do not use thresholded maps and they
+use the squared standardized parameter estimate maps instead of the
+unstandardized parameter estimate maps.
 
 If ``spearman_FT2_beta`` is higher than ``spearman_FS0_beta``,
 it is more likely that the component is TE-dependent.
@@ -303,7 +274,7 @@ divided by the sum of the squares of the parameter estimates.
 
 
 normalized variance explained
-============================
+=============================
 :func:`tedana.metrics.dependence.calculate_varex_norm`
 
 The "normalized variance explained" by each component is calculated as the

--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -199,9 +199,9 @@ dice_FT2
 
 The Dice similarity index between each component's cluster-extent thresholded
 T2*-model F-statistic map (using a p<0.05 threshold) and
-its cluster-extent thresholded standardized parameter estimate map (using a 5% threshold).
+its cluster-extent thresholded unstandardized parameter estimate map (using a 5% threshold).
 This is a measure of the similarity between the T2*-model F-statistic map and the weight map.
-If the standardized parameter estimate map has a higher DSI with the T2*-model F-statistic map than the S0-model F-statistic map,
+If the unstandardized parameter estimate map has a higher DSI with the T2*-model F-statistic map than the S0-model F-statistic map,
 it is more likely to be signal.
 
 
@@ -211,10 +211,46 @@ dice_FS0
 
 The Dice similarity index between each component's cluster-extent thresholded
 S0-model F-statistic map (using a p<0.05 threshold) and
-its cluster-extent thresholded standardized parameter estimate map (using a 5% threshold).
+its cluster-extent thresholded unstandardized parameter estimate map (using a 5% threshold).
 This is a measure of the similarity between the S0-model F-statistic map and the standardized parameter estimate map.
-If the standardized parameter estimate map has a higher DSI with the S0-model F-statistic map than the T2*-model F-statistic map,
+If the unstandardized parameter estimate map has a higher DSI with the S0-model F-statistic map than the T2*-model F-statistic map,
 it is more likely to be noise.
+
+
+spearman_FT2_beta
+=================
+:func:`tedana.metrics.dependence.compute_spearmans_rho`
+
+The Spearman's rank correlation coefficient between each component's squared
+standardized parameter estimate map and T2*-model F-statistic map.
+
+Like ``dice_FT2``, this metric measures the similarity between the
+component spatial weights and the spatial distribution of the
+TE-dependence model strength.
+The two differences are that this metric does not use thresholded maps and it
+uses the squared standardized parameter estimate map instead of the
+unstandardized parameter estimate map.
+
+If ``spearman_FT2_beta`` is higher than ``spearman_FS0_beta``,
+it is more likely that the component is TE-dependent.
+
+
+spearman_FS0_beta
+=================
+:func:`tedana.metrics.dependence.compute_spearmans_rho`
+
+The Spearman's rank correlation coefficient between each component's squared
+standardized parameter estimate map and S0-model F-statistic map.
+
+Like ``dice_FS0``, this metric measures the similarity between the
+component spatial weights and the spatial distribution of the
+TE-independence model strength.
+The two differences are that this metric does not use thresholded maps and it
+uses the squared standardized parameter estimate map instead of the
+unstandardized parameter estimate map.
+
+If ``spearman_FT2_beta`` is higher than ``spearman_FS0_beta``,
+it is more likely that the component is TE-dependent.
 
 
 signal-noise_t

--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -328,6 +328,8 @@ averaged over voxels.
 
 This represents the variance in the data explained by each component
 without controlling for other components.
+
+
 partial R-squared
 =================
 :func:`tedana.metrics.dependence.calculate_partial_r2`

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -356,6 +356,26 @@ def generate_metrics(
             axis=0,
         )
 
+    if "spearman_FT2_beta" in required_metrics:
+        LGR.info(
+            "Calculating Spearman's rank correlation coefficient between squared standardized "
+            "parameter estimate maps and T2* F-statistic maps"
+        )
+        component_table["spearman_FT2_beta"] = dependence.compute_spearmans_rho(
+            maps1=metric_maps["map weight"] ** 2,
+            maps2=metric_maps["map FT2"],
+        )
+
+    if "spearman_FS0_beta" in required_metrics:
+        LGR.info(
+            "Calculating Spearman's rank correlation coefficient between squared standardized "
+            "parameter estimate maps and S0 F-statistic maps"
+        )
+        component_table["spearman_FS0_beta"] = dependence.compute_spearmans_rho(
+            maps1=metric_maps["map weight"] ** 2,
+            maps2=metric_maps["map FS0"],
+        )
+
     if "signal-noise_t" in required_metrics:
         LGR.info("Calculating signal-noise t-statistics")
         RepLGR.info(

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -643,6 +643,7 @@ def compute_spearmans_rho(
 
     n_components = maps1.shape[1]
     rho_values = np.zeros(n_components)
+    # Loop over components to avoid memory issues
     for i_comp in range(n_components):
         rho_values[i_comp] = stats.spearmanr(maps1[:, i_comp], maps2[:, i_comp]).statistic
     return rho_values

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -639,7 +639,8 @@ def compute_spearmans_rho(
     rho_values : (C) array_like
         Spearman's rank correlation coefficient between the two maps.
     """
-    assert maps1.shape == maps2.shape
+    if maps1.shape != maps2.shape:
+        raise ValueError("Maps must have the same shape.")
 
     n_components = maps1.shape[1]
     rho_values = np.zeros(n_components)

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -622,6 +622,32 @@ def compute_dice(
     return dice_values
 
 
+def compute_spearmans_rho(
+    *,
+    maps1: np.ndarray,
+    maps2: np.ndarray,
+) -> np.ndarray:
+    """Compute the Spearman's rank correlation coefficient between two unthresholded maps.
+
+    Parameters
+    ----------
+    maps1, maps2 : (S x C) array_like
+        Unthresholded maps.
+
+    Returns
+    -------
+    rho_values : (C) array_like
+        Spearman's rank correlation coefficient between the two maps.
+    """
+    assert maps1.shape == maps2.shape
+
+    n_components = maps1.shape[1]
+    rho_values = np.zeros(n_components)
+    for i_comp in range(n_components):
+        rho_values[i_comp] = stats.spearmanr(maps1[:, i_comp], maps2[:, i_comp]).statistic
+    return rho_values
+
+
 def compute_signal_minus_noise_z(
     *,
     z_maps: np.ndarray,

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -646,7 +646,7 @@ def compute_spearmans_rho(
     rho_values = np.zeros(n_components)
     # Loop over components to avoid memory issues
     for i_comp in range(n_components):
-        rho_values[i_comp] = stats.spearmanr(maps1[:, i_comp], maps2[:, i_comp]).statistic
+        rho_values[i_comp] = stats.spearmanr(maps1[:, i_comp], maps2[:, i_comp])[0]
     return rho_values
 
 

--- a/tedana/resources/config/metrics.json
+++ b/tedana/resources/config/metrics.json
@@ -35,6 +35,14 @@
             "map beta S0 clusterized",
             "map FS0 clusterized"
         ],
+        "spearman_FT2_beta": [
+            "map weight",
+            "map FT2"
+        ],
+        "spearman_FS0_beta": [
+            "map weight",
+            "map FS0"
+        ],
         "signal-noise_t": [
             "map weight",
             "map weight clusterized",

--- a/tedana/tests/test_metrics_dependence.py
+++ b/tedana/tests/test_metrics_dependence.py
@@ -329,3 +329,16 @@ def test_compute_countnoise_correctness():
 
     expected = np.array([1, 0])
     assert np.array_equal(countnoise, expected)
+
+
+def test_compute_spearmans_rho_correctness():
+    """Test numerical correctness of compute_spearmans_rho."""
+    # Test with equal maps
+    maps1 = np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]])
+    maps2 = np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]])
+    rho = dependence.compute_spearmans_rho(maps1=maps1, maps2=maps2)
+    assert np.allclose(rho, 1.0)  # Should be 1 when equal
+    assert rho.shape == (3,)
+
+    with pytest.raises(ValueError, match="Maps must have the same shape"):
+        dependence.compute_spearmans_rho(maps1=maps1, maps2=maps2[:-1])


### PR DESCRIPTION
Closes #1352. I'll work on testing out the metric this week.

Changes proposed in this pull request:

- Add "spearman_FT2_beta" (Spearman's rho between squared standardized parameter estimate map and T2* model F-statistic map) and "spearman_FS0_beta" (Spearman's rho between squared standardized parameter estimate map and S0 model F-statistic map) metrics.
