### PR TITLE
Add "kappa proportion" metric

### DIFF
--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -331,15 +331,14 @@ Higher values indicate that the component is more dominated by either kappa or r
 which indicates "specificity" of the component to either TE-dependent or TE-independent signals.
 
 
-kappa_proportion/rho_proportion
+kappa proportion
 ================================
-:func:`tedana.metrics.dependence.compute_kappa_rho_proportion`
+:func:`tedana.metrics.dependence.compute_kappa_proportion`
 
-The proportion of the component's pseudo-F-statistics that is dominated by either kappa or rho,
-respectively.
+The proportion of the component's pseudo-F-statistics that is dominated by kappa.
 
-Higher values indicate that the component is more dominated by either kappa or rho,
-which indicates "specificity" of the component to either TE-dependent or TE-independent signals.
+Higher values indicate that the component is more dominated by kappa,
+which indicates "specificity" of the component to TE-dependent signals.
 
 
 d_table_score

--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -331,6 +331,17 @@ Higher values indicate that the component is more dominated by either kappa or r
 which indicates "specificity" of the component to either TE-dependent or TE-independent signals.
 
 
+kappa_proportion/rho_proportion
+================================
+:func:`tedana.metrics.dependence.compute_kappa_rho_proportion`
+
+The proportion of the component's pseudo-F-statistics that is dominated by either kappa or rho,
+respectively.
+
+Higher values indicate that the component is more dominated by either kappa or rho,
+which indicates "specificity" of the component to either TE-dependent or TE-independent signals.
+
+
 d_table_score
 =============
 :func:`tedana.metrics.dependence.generate_decision_table_score`

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -426,12 +426,9 @@ def generate_metrics(
             rho=component_table["rho"],
         )
 
-    if "kappa_proportion" in required_metrics or "rho_proportion" in required_metrics:
-        LGR.info("Calculating kappa or rho proportion")
-        (
-            component_table["kappa_proportion"],
-            component_table["rho_proportion"],
-        ) = dependence.compute_kappa_rho_proportion(
+    if "kappa proportion" in required_metrics:
+        LGR.info("Calculating kappa proportion")
+        component_table["kappa proportion"] = dependence.compute_kappa_proportion(
             kappa=component_table["kappa"],
             rho=component_table["rho"],
         )

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -426,6 +426,16 @@ def generate_metrics(
             rho=component_table["rho"],
         )
 
+    if "kappa_proportion" in required_metrics or "rho_proportion" in required_metrics:
+        LGR.info("Calculating kappa or rho proportion")
+        (
+            component_table["kappa_proportion"],
+            component_table["rho_proportion"],
+        ) = dependence.compute_kappa_rho_proportion(
+            kappa=component_table["kappa"],
+            rho=component_table["rho"],
+        )
+
     # External regressor-based metrics
     if external_regressors is not None and external_regressor_config is not None:
         # external_regressor_names = external_regressors.columns.tolist()

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -704,6 +704,14 @@ def get_metadata(component_table: pd.DataFrame) -> Dict:
             ),
             "Units": "percent",
         }
+    if "kappa proportion" in component_table:
+        metric_metadata["kappa proportion"] = {
+            "LongName": "Kappa proportion",
+            "Description": (
+                "Proportion of pseudo-F-statistics that is dominated by kappa."
+            ),
+            "Units": "percent",
+        }
     if "original_classification" in component_table:
         metric_metadata["original_classification"] = {
             "LongName": "Original classification",

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -707,9 +707,7 @@ def get_metadata(component_table: pd.DataFrame) -> Dict:
     if "kappa proportion" in component_table:
         metric_metadata["kappa proportion"] = {
             "LongName": "Kappa proportion",
-            "Description": (
-                "Proportion of pseudo-F-statistics that is dominated by kappa."
-            ),
+            "Description": "Proportion of pseudo-F-statistics that is dominated by kappa.",
             "Units": "percent",
         }
     if "original_classification" in component_table:

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -900,12 +900,12 @@ def compute_kappa_rho_difference(*, kappa: np.ndarray, rho: np.ndarray) -> np.nd
     return np.abs(kappa - rho) / (kappa + rho)
 
 
-def compute_kappa_rho_proportion(
+def compute_kappa_proportion(
     *,
     kappa: np.ndarray,
     rho: np.ndarray,
 ) -> typing.Tuple[np.ndarray, np.ndarray]:
-    """Compute the proportion of kappa or rho that dominates the component.
+    """Compute the proportion of kappa that dominates the component.
 
     Parameters
     ----------
@@ -916,18 +916,14 @@ def compute_kappa_rho_proportion(
 
     Returns
     -------
-    kappa_proportion : (C) array_like
+    kappa proportion : (C) array_like
         Proportion of kappa that dominates the component.
         Values above 0.5 indicate that kappa is dominating the component.
         Values below 0.5 indicate that rho is dominating the component.
-    rho_proportion : (C) array_like
-        Proportion of rho that dominates the component.
-        Values above 0.5 indicate that rho is dominating the component.
-        Values below 0.5 indicate that kappa is dominating the component.
     """
     assert kappa.shape == rho.shape
 
-    return kappa / (kappa + rho), rho / (kappa + rho)
+    return kappa / (kappa + rho)
 
 
 def _orthogonalize_by_others(*, arr: np.ndarray) -> np.ndarray:

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -900,6 +900,36 @@ def compute_kappa_rho_difference(*, kappa: np.ndarray, rho: np.ndarray) -> np.nd
     return np.abs(kappa - rho) / (kappa + rho)
 
 
+def compute_kappa_rho_proportion(
+    *,
+    kappa: np.ndarray,
+    rho: np.ndarray,
+) -> typing.Tuple[np.ndarray, np.ndarray]:
+    """Compute the proportion of kappa or rho that dominates the component.
+
+    Parameters
+    ----------
+    kappa : (C) array_like
+        Kappa values.
+    rho : (C) array_like
+        Rho values.
+
+    Returns
+    -------
+    kappa_proportion : (C) array_like
+        Proportion of kappa that dominates the component.
+        Values above 0.5 indicate that kappa is dominating the component.
+        Values below 0.5 indicate that rho is dominating the component.
+    rho_proportion : (C) array_like
+        Proportion of rho that dominates the component.
+        Values above 0.5 indicate that rho is dominating the component.
+        Values below 0.5 indicate that kappa is dominating the component.
+    """
+    assert kappa.shape == rho.shape
+
+    return kappa / (kappa + rho), rho / (kappa + rho)
+
+
 def _orthogonalize_by_others(*, arr: np.ndarray) -> np.ndarray:
     """Orthogonalize each column of the input array with respect to the other columns.
 

--- a/tedana/resources/config/metrics.json
+++ b/tedana/resources/config/metrics.json
@@ -68,11 +68,7 @@
             "kappa",
             "rho"
         ],
-        "kappa_proportion": [
-            "kappa",
-            "rho"
-        ],
-        "rho_proportion": [
+        "kappa proportion": [
             "kappa",
             "rho"
         ],

--- a/tedana/resources/config/metrics.json
+++ b/tedana/resources/config/metrics.json
@@ -68,6 +68,14 @@
             "kappa",
             "rho"
         ],
+        "kappa_proportion": [
+            "kappa",
+            "rho"
+        ],
+        "rho_proportion": [
+            "kappa",
+            "rho"
+        ],
         "d_table_score": [
             "kappa",
             "dice_FT2",

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -65,6 +65,7 @@ def test_smoke_generate_metrics(testdata1):
         "semi-partial R-squared",
         "d_table_score",
         "kappa_rho_difference",
+        "kappa proportion",
     ]
 
     external_regressors, _ = sample_external_regressors()

--- a/tedana/tests/test_metrics_collect.py
+++ b/tedana/tests/test_metrics_collect.py
@@ -24,6 +24,7 @@ def test_get_metadata():
             "signal-noise_p": [0.01, 0.001],
             "d_table_score": [5.0, 3.0],
             "d_table_score_scrub": [4.0, 2.0],
+            "kappa proportion": [0.5, 0.4],
             "marginal R-squared": [0.3, 0.25],
             "partial R-squared": [0.2, 0.15],
             "semi-partial R-squared": [0.1, 0.05],
@@ -51,6 +52,7 @@ def test_get_metadata():
     assert "signal-noise_t" in metadata
     assert "signal-noise_p" in metadata
     assert "d_table_score" in metadata
+    assert "kappa proportion" in metadata
     assert "classification" in metadata
     assert "rationale" in metadata
     assert "optimal sign" in metadata

--- a/tedana/tests/test_metrics_dependence.py
+++ b/tedana/tests/test_metrics_dependence.py
@@ -329,3 +329,11 @@ def test_compute_countnoise_correctness():
 
     expected = np.array([1, 0])
     assert np.array_equal(countnoise, expected)
+
+
+def test_compute_kappa_proportion_correctness():
+    """Test numerical correctness of compute_kappa_proportion."""
+    kappa = np.array([10.0, 0, 10.0])
+    rho = np.array([0, 10.0, 10.0])
+    proportion = dependence.compute_kappa_proportion(kappa=kappa, rho=rho)
+    assert np.allclose(proportion, np.array([1.0, 0.0, 0.5]))


### PR DESCRIPTION
Closes none. This is just an idea that might be useful.

Changes proposed in this pull request:

- Add "kappa proportion" metric defined as `kappa / (kappa + rho)`.
