### PR TITLE
Possible fix for CircleCI testing file download problem

### DIFF
--- a/tedana/tests/utils.py
+++ b/tedana/tests/utils.py
@@ -108,6 +108,7 @@ def download_test_data(osf_id, test_data_path):
 
     try:
         datainfo = requests.get(f"https://osf.io/metadata/{osf_id}/?format=datacite-json")
+        datainfo.raise_for_status()
     except Exception:
         if len(listdir(test_data_path)) == 0:
             raise ConnectionError(
@@ -120,7 +121,6 @@ def download_test_data(osf_id, test_data_path):
                 "but cannot validate that local copy is up-to-date"
             )
             return
-    datainfo.raise_for_status()
     metadata = json.loads(datainfo.content)
     # 'dates' is a list with all udpates to the file, the last item in the list
     # is the most recent and the 'date' field in the list is the date of the last


### PR DESCRIPTION
Closes #1330

CircleCI seems to periodically fail when trying to download data from osf. I suspect putting a call to `raise_for_status` into a `try` `except` clause might resolve this. It works on my local system so I figured I'd open up a PR to see if it functions well in interaction with CircleCI.

Changes proposed in this pull request:

- A `try` `except` clause is used `download_test_data` to see if `requests.get` failed, which was the main issue behind local filewalls. On the assumption that this might not immediately crash on CircleCI, but the subsequence `raise_for_status` call fails, that second statement is moved into the `try` clause.
