### PR TITLE
account for user-provided nonbinary masks

### DIFF
--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -918,8 +918,9 @@ def load_mask(ref_img, mask=None, t2smap=None):
         LGR.info("Using user-defined mask")
         RepLGR.info("A user-defined mask was applied to the data.")
         mask_img = nb.load(mask)
-        # Convert to NIfTI1 if needed (e.g., AFNI format)
-        mask_img = io._convert_to_nifti1(mask_img)
+        # Convert mask to binary (assuming non-zero values indicate mask inclusion)
+        mask = mask_img.get_fdata().astype(np.uint8) > 0
+        mask_img = nb.Nifti1Image(mask, mask_img.affine, mask_img.header)
     elif t2smap and not mask:
         LGR.info("Assuming user-defined T2* map is masked and using it to generate mask")
         t2s_img = io._convert_to_nifti1(nb.load(t2smap))
@@ -934,7 +935,8 @@ def load_mask(ref_img, mask=None, t2smap=None):
         t2s_loaded = t2s_img.get_fdata()
         # Load and convert user-defined mask to NIfTI1 (e.g., AFNI format)
         mask_img = io._convert_to_nifti1(nb.load(mask))
-        mask = mask_img.get_fdata().astype(np.uint8)
+        # Convert mask to binary (assuming non-zero values indicate mask inclusion)
+        mask = mask_img.get_fdata().astype(np.uint8) > 0
         mask[t2s_loaded == 0] = 0  # reduce mask based on T2* map
         mask_img = nb.Nifti1Image(mask, mask_img.affine, mask_img.header)
         t2s = apply_mask(t2s_img, mask_img)

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -919,7 +919,7 @@ def load_mask(ref_img, mask=None, t2smap=None):
         RepLGR.info("A user-defined mask was applied to the data.")
         mask_img = nb.load(mask)
         # Convert mask to binary (assuming non-zero values indicate mask inclusion)
-        mask = mask_img.get_fdata().astype(np.uint8) > 0
+        mask = mask_img.get_fdata() > 0
         mask_img = nb.Nifti1Image(mask, mask_img.affine, mask_img.header)
     elif t2smap and not mask:
         LGR.info("Assuming user-defined T2* map is masked and using it to generate mask")
@@ -936,7 +936,7 @@ def load_mask(ref_img, mask=None, t2smap=None):
         # Load and convert user-defined mask to NIfTI1 (e.g., AFNI format)
         mask_img = io._convert_to_nifti1(nb.load(mask))
         # Convert mask to binary (assuming non-zero values indicate mask inclusion)
-        mask = mask_img.get_fdata().astype(np.uint8) > 0
+        mask = mask_img.get_fdata() > 0
         mask[t2s_loaded == 0] = 0  # reduce mask based on T2* map
         mask_img = nb.Nifti1Image(mask, mask_img.affine, mask_img.header)
         t2s = apply_mask(t2s_img, mask_img)


### PR DESCRIPTION
I just tried to run one of my existing scripts after merging #1305. I was using an adaptive mask as the input for the `--mask` parameter. I got the following error (with some of the full paths trimmed)

```
  File "tedana/tedana/workflows/tedana.py", line 744, in tedana_workflow
    io_generator.save_file(masksum_denoise, "adaptive mask img")
  File "tedana/tedana/io.py", line 282, in save_file
    self.save_img(data, name, mask=kwargs.get("mask", None))
  File "tedana/tedana/io.py", line 349, in save_img
    img = masking.unmask(data.T, mask)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "nilearn/masking.py", line 968, in unmask
    mask, affine = load_mask_img(mask_img)
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "nilearn/masking.py", line 82, in load_mask_img
    raise ValueError(
ValueError: Given mask is not made of 2 values: [0 1 2 3]. Cannot interpret as true or false.
```
This wasn't an issue in the past, but I think the new usage of `unmask` requires the mask to be binary. 

I'll defer to others on deciding whether making sure a useful, but undocumented functionally still works is considered a bug fix.

Changes proposed in this pull request:

- When a user provided mask is loaded, all values <=0 are defined as `False` and all values >0 are defined as `True`
  - I documented this in a comment in the code, but I'm not sure if we should document it in the logger. I think this was effectively what the functionality always was
