### PR TITLE
Address test and RTD build warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -95,8 +95,8 @@ API
 
    tedpca
    tedica
-   r_ica
-   f_ica
+   ica.r_ica
+   ica.f_ica
 
 
 .. _api_metrics_ref:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,11 @@ API
    tedana_workflow
    ica_reclassify_workflow
    t2smap_workflow
+   parser_utils.check_tedpca_value
+   parser_utils.check_n_robust_runs_value
+   parser_utils.is_valid_file
+   parser_utils.parse_manual_list_int
+   parser_utils.parse_manual_list_str
 
 
 .. _api_decay_ref:
@@ -46,6 +51,11 @@ API
 
    fit_decay
    fit_decay_ts
+   monoexponential
+   fit_monoexponential
+   fit_loglinear
+   modify_t2s_s0_maps
+   rmse_of_fit_decay_ts
 
 
 .. _api_combine_ref:
@@ -85,6 +95,8 @@ API
 
    tedpca
    tedica
+   r_ica
+   f_ica
 
 
 .. _api_metrics_ref:
@@ -142,7 +154,6 @@ API
    tedpca
 
 
-
 .. _api_gscontrol_ref:
 
 **********************************************
@@ -195,8 +206,14 @@ API
    write_split_ts
    writeresults
    writeresults_echoes
+   download_json
+   load_ref_img
+   versiontuple
+   str_to_component_list
+   fname_to_component_list
 
-.. _api_stats_ref:
+
+.. _api_reporting_ref:
 
 ********************************************
 :mod:`tedana.reporting`: Reporting functions
@@ -219,8 +236,14 @@ API
    static_figures.plot_t2star_and_s0
    static_figures.plot_rmse
    static_figures.plot_adaptive_mask
+   static_figures.carpet_plot
+   static_figures.plot_component
+   static_figures.plot_gscontrol
+   static_figures.plot_heatmap
+   static_figures.plot_decay_variance
 
-.. _api_reporting_ref:
+
+.. _api_stats_ref:
 
 ******************************************
 :mod:`tedana.stats`: Statistical functions
@@ -239,6 +262,8 @@ API
    get_coeffs
    voxelwise_univariate_zstats
    getfbounds
+   fit_model
+   t_to_z
 
 
 .. _api_bibtex_ref:
@@ -289,3 +314,13 @@ API
    unmask
    sec2millisec
    millisec2sec
+   load_mask
+   create_legendre_polynomial_basis_set
+   parse_volume_indices
+   check_t2s_values
+   check_te_values
+   setup_loggers
+   teardown_loggers
+   get_resource_path
+   get_system_version_info
+   log_newsletter_info

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,9 +23,9 @@ API
    :template: function.rst
    :toctree: generated/
 
-   tedana.workflows.tedana_workflow
-   tedana.workflows.ica_reclassify_workflow
-   tedana.workflows.t2smap_workflow
+   tedana_workflow
+   ica_reclassify_workflow
+   t2smap_workflow
 
 
 .. _api_decay_ref:
@@ -44,8 +44,8 @@ API
    :template: function.rst
    :toctree: generated/
 
-   tedana.decay.fit_decay
-   tedana.decay.fit_decay_ts
+   fit_decay
+   fit_decay_ts
 
 
 .. _api_combine_ref:
@@ -64,7 +64,7 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.combine.make_optcom
+   make_optcom
 
 
 .. _api_decomposition_ref:
@@ -83,8 +83,8 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.decomposition.tedpca
-   tedana.decomposition.tedica
+   tedpca
+   tedica
 
 
 .. _api_metrics_ref:
@@ -103,9 +103,9 @@ API
    :toctree: generated/
    :template: module.rst
 
-   tedana.metrics.collect
-   tedana.metrics.dependence
-   tedana.metrics.external
+   collect
+   dependence
+   external
 
 
 .. _api_selection_ref:
@@ -124,22 +124,22 @@ API
    :toctree: generated/
    :template: class.rst
 
-   tedana.selection.component_selector.ComponentSelector
-   tedana.selection.component_selector.TreeError
+   component_selector.ComponentSelector
+   component_selector.TreeError
 
    :template: function.rst
 
-   tedana.selection.component_selector.load_config
-   tedana.selection.component_selector.validate_tree
+   component_selector.load_config
+   component_selector.validate_tree
 
 .. autosummary::
    :toctree: generated/
    :template: module.rst
 
-   tedana.selection.selection_nodes
-   tedana.selection.selection_utils
-   tedana.selection.tedica
-   tedana.selection.tedpca
+   selection_nodes
+   selection_utils
+   tedica
+   tedpca
 
 
 
@@ -159,8 +159,8 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.gscontrol.gscontrol_raw
-   tedana.gscontrol.minimum_image_regression
+   gscontrol_raw
+   minimum_image_regression
 
 
 .. _api_io_ref:
@@ -179,23 +179,22 @@ API
    :toctree: generated/
    :template: class.rst
 
-   tedana.io.OutputGenerator
-   tedana.io.InputHarvester
-   tedana.io.CustomEncoder
+   OutputGenerator
+   InputHarvester
+   CustomEncoder
 
    :template: function.rst
 
-   tedana.io.load_data
-   tedana.io.load_json
-   tedana.io.get_fields
-   tedana.io.new_nii_like
-   tedana.io.prep_data_for_json
-   tedana.io.add_decomp_prefix
-   tedana.io.denoise_ts
-   tedana.io.split_ts
-   tedana.io.write_split_ts
-   tedana.io.writeresults
-   tedana.io.writeresults_echoes
+   load_data_nilearn
+   load_json
+   get_fields
+   prep_data_for_json
+   add_decomp_prefix
+   denoise_ts
+   split_ts
+   write_split_ts
+   writeresults
+   writeresults_echoes
 
 .. _api_stats_ref:
 
@@ -213,13 +212,13 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.reporting.html_report.generate_report
-   tedana.reporting.quality_metrics.calculate_rejected_components_impact
-   tedana.reporting.static_figures.comp_figures
-   tedana.reporting.static_figures.pca_results
-   tedana.reporting.static_figures.plot_t2star_and_s0
-   tedana.reporting.static_figures.plot_rmse
-   tedana.reporting.static_figures.plot_adaptive_mask
+   html_report.generate_report
+   quality_metrics.calculate_rejected_components_impact
+   static_figures.comp_figures
+   static_figures.pca_results
+   static_figures.plot_t2star_and_s0
+   static_figures.plot_rmse
+   static_figures.plot_adaptive_mask
 
 .. _api_reporting_ref:
 
@@ -237,9 +236,9 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.stats.get_coeffs
-   tedana.stats.voxelwise_univariate_zstats
-   tedana.stats.getfbounds
+   get_coeffs
+   voxelwise_univariate_zstats
+   getfbounds
 
 
 .. _api_bibtex_ref:
@@ -258,12 +257,12 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.bibtex.find_braces
-   tedana.bibtex.reduce_idx
-   tedana.bibtex.index_bibtex_identifiers
-   tedana.bibtex.find_citations
-   tedana.bibtex.reduce_references
-   tedana.bibtex.get_description_references
+   find_braces
+   reduce_idx
+   index_bibtex_identifiers
+   find_citations
+   reduce_references
+   get_description_references
 
 
 .. _api_utils_ref:
@@ -282,11 +281,11 @@ API
    :toctree: generated/
    :template: function.rst
 
-   tedana.utils.andb
-   tedana.utils.dice
-   tedana.utils.get_spectrum
-   tedana.utils.make_adaptive_mask
-   tedana.utils.threshold_map
-   tedana.utils.unmask
-   tedana.utils.sec2millisec
-   tedana.utils.millisec2sec
+   andb
+   dice
+   get_spectrum
+   make_adaptive_mask
+   threshold_map
+   unmask
+   sec2millisec
+   millisec2sec

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,8 @@ html_favicon = "_static/tedana_favicon.png"
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
+# Avoid duplicate labels from repeated deep argparse subsection headings.
+autosectionlabel_maxdepth = 2
 
 # -----------------------------------------------------------------------------
 # sphinxcontrib-bibtex

--- a/docs/dependence_metrics.rst
+++ b/docs/dependence_metrics.rst
@@ -268,7 +268,7 @@ divided by the sum of the squares of the parameter estimates.
 
 normalized variance explained
 =============================
-:func:`tedana.metrics.dependence.calculate_varex_norm`
+:func:`tedana.metrics.dependence.calculate_varex`
 
 The "normalized variance explained" by each component is calculated as the
 square of the standardized parameter estimates from the regression of the z-scored
@@ -278,7 +278,7 @@ divided by the sum of the squares of the standardized parameter estimates.
 This is not actually a measure of normalized variance explained.
 
 In the tedpca metrics, "normalized variance explained" actually comes from
-the fitted PCA object's explained_variance_ratio_ attribute,
+the fitted PCA object's ``explained_variance_ratio_`` attribute,
 and the TEDANA-calculated value is retained as "estimated normalized variance explained".
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -190,7 +190,6 @@ tedana is licensed under GNU Lesser General Public License version 2.1.
    :hidden:
    :name: hiddentoc
 
-   dependence_metrics
    included_decision_trees
 
 

--- a/docs/multi-echo.rst
+++ b/docs/multi-echo.rst
@@ -365,8 +365,23 @@ The following plots reflect the average values for studies conducted at 3 Tesla.
     import numpy as np
     # TODO: deal with the issue that the plot doesn't regenerate (ie isn't alive)
     # Unless the code is updated.
-    metable = pd.read_csv('https://docs.google.com/spreadsheets/d/1WERojJyxFoqcg_tndUm5Kj0H1UfUc9Ban0jFGGfPaBk/export?gid=0&format=csv',
-                           header=0)
+    try:
+        metable = pd.read_csv('https://docs.google.com/spreadsheets/d/1WERojJyxFoqcg_tndUm5Kj0H1UfUc9Ban0jFGGfPaBk/export?gid=0&format=csv',
+                              header=0)
+    except Exception:
+        metable = pd.DataFrame(
+            {
+                "TE1": [15.0],
+                "TE2": [27.0],
+                "TE3": [39.0],
+                "TE4": [51.0],
+                "TE5": [63.0],
+                "TR": [2.0],
+                "x": [3.0],
+                "y": [3.0],
+                "z": [3.0],
+            }
+        )
     TEs = [metable.TE1.mean(), metable.TE2.mean(), metable.TE3.mean(), metable.TE4.mean(), metable.TE5.mean()]
     TE_labels = ['TE1', 'TE2', 'TE3', 'TE4', 'TE5']
     plt.bar([1, 2, 3, 4, 5], TEs)
@@ -378,7 +393,8 @@ The following plots reflect the average values for studies conducted at 3 Tesla.
     plt.show()
 
 
-    plt.hist(metable.TR.to_numpy())
+    tr_values = pd.to_numeric(metable.TR, errors='coerce').dropna()
+    plt.hist(tr_values.to_numpy())
     plt.title('Repetition Times', fontsize = 18)
     plt.xlabel('Repetition Time (s)')
     plt.ylabel('Count')

--- a/tedana/combine.py
+++ b/tedana/combine.py
@@ -91,7 +91,10 @@ def _combine_paid(data, tes, report=True):
         )
 
     n_vols = data.shape[-1]
-    snr = data.mean(axis=-1) / data.std(axis=-1)
+    mean_signal = data.mean(axis=-1)
+    signal_std = data.std(axis=-1)
+    snr = np.zeros_like(mean_signal, dtype=float)
+    np.divide(mean_signal, signal_std, out=snr, where=signal_std != 0)
     alpha = snr * tes
     alpha = np.tile(alpha[:, :, np.newaxis], (1, 1, n_vols))
     combined = np.average(data, axis=1, weights=alpha)

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -5,7 +5,6 @@ import os
 from typing import List, Literal, Tuple
 
 import numpy as np
-import numpy.matlib
 import pandas as pd
 import scipy
 from joblib import Parallel, delayed
@@ -681,8 +680,8 @@ def rmse_of_fit_decay_ts(
         use_vox = adaptive_mask == n_good_echoes
         data_echo = data[use_vox, :n_good_echoes, :]
         if fitmode == "all":
-            s0_echo = numpy.matlib.repmat(s0[use_vox].T, n_vols, 1).T
-            t2s_echo = numpy.matlib.repmat(t2s[use_vox], n_vols, 1).T
+            s0_echo = np.tile(s0[use_vox][:, np.newaxis], (1, n_vols))
+            t2s_echo = np.tile(t2s[use_vox][:, np.newaxis], (1, n_vols))
         elif fitmode == "ts":
             s0_echo = s0[use_vox, :]
             t2s_echo = t2s[use_vox, :]
@@ -701,8 +700,15 @@ def rmse_of_fit_decay_ts(
             )
         rmse[use_vox, :] = np.sqrt(np.mean((data_echo - predicted_data) ** 2, axis=1))
 
-    rmse_map = np.nanmean(rmse, axis=1)
-    rmse_timeseries = np.nanmean(rmse, axis=0)
+    rmse_sum_map = np.nansum(rmse, axis=1)
+    rmse_count_map = np.sum(~np.isnan(rmse), axis=1)
+    rmse_map = np.full(rmse_sum_map.shape, np.nan, dtype=rmse.dtype)
+    np.divide(rmse_sum_map, rmse_count_map, out=rmse_map, where=rmse_count_map > 0)
+
+    rmse_sum_ts = np.nansum(rmse, axis=0)
+    rmse_count_ts = np.sum(~np.isnan(rmse), axis=0)
+    rmse_timeseries = np.full(rmse_sum_ts.shape, np.nan, dtype=rmse.dtype)
+    np.divide(rmse_sum_ts, rmse_count_ts, out=rmse_timeseries, where=rmse_count_ts > 0)
     rmse_sd_timeseries = np.nanstd(rmse, axis=0)
     rmse_percentiles_timeseries = np.nanpercentile(rmse, [0, 2, 25, 50, 75, 98, 100], axis=0)
 

--- a/tedana/decomposition/ica.py
+++ b/tedana/decomposition/ica.py
@@ -128,7 +128,7 @@ def r_ica(data, n_components, fixed_seed, n_robust_runs, max_it, n_threads=1):
         Number of components retained from PCA decomposition.
     fixed_seed : :obj:`int`
         Seed for ensuring reproducibility of ICA results.
-    n_robust_runs : :obj: `int'
+    n_robust_runs : :obj:`int`
         selected number of robust runs when robustica is used. Default is 30.
     maxit : :obj:`int`, optional
         Maximum number of iterations for ICA. Default is 500.

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -17,8 +17,8 @@ import nibabel as nb
 import numpy as np
 import pandas as pd
 import requests
-from nilearn import masking
 from nilearn import __version__ as nilearn_version
+from nilearn import masking
 from packaging.version import Version
 from scipy import stats
 

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -18,11 +18,17 @@ import numpy as np
 import pandas as pd
 import requests
 from nilearn import masking
-from nilearn.image import check_niimg
+from nilearn import __version__ as nilearn_version
+from packaging.version import Version
 from scipy import stats
 
 from tedana import utils
 from tedana.stats import get_coeffs
+
+if Version(nilearn_version) >= Version("0.14.0"):
+    from nilearn.image import check_niimg
+else:
+    from nilearn._utils.niimg_conversions import check_niimg
 
 LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -25,7 +25,7 @@ from scipy import stats
 from tedana import utils
 from tedana.stats import get_coeffs
 
-if Version(nilearn_version) >= Version("0.14.0"):
+if Version(nilearn_version) >= Version("0.13.0"):
     from nilearn.image import check_niimg
 else:
     from nilearn._utils.niimg_conversions import check_niimg

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import requests
 from nilearn import masking
-from nilearn._utils.niimg_conversions import check_niimg
+from nilearn.image import check_niimg
 from scipy import stats
 
 from tedana import utils
@@ -385,7 +385,7 @@ class OutputGenerator:
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
 
         # Replace blanks with numpy NaN
-        deblanked = data.replace("", np.nan)
+        deblanked = data.replace("", np.nan).infer_objects(copy=False)
         deblanked.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
 
     def add_df_to_file(self, data, description, **kwargs):

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -80,12 +80,14 @@ def carpet_plot(
         mask,
         figure=fig,
         axes=ax,
+        standardize="zscore_sample",
         title="Optimally Combined Data",
     )
     fig.tight_layout()
     fig.savefig(
         os.path.join(io_generator.out_dir, "figures", f"{io_generator.prefix}carpet_optcom.svg")
     )
+    plt.close(fig)
 
     fig, ax = plt.subplots(figsize=(14, 7))
     plotting.plot_carpet(
@@ -93,12 +95,14 @@ def carpet_plot(
         mask,
         figure=fig,
         axes=ax,
+        standardize="zscore_sample",
         title="Denoised Data",
     )
     fig.tight_layout()
     fig.savefig(
         os.path.join(io_generator.out_dir, "figures", f"{io_generator.prefix}carpet_denoised.svg")
     )
+    plt.close(fig)
 
     fig, ax = plt.subplots(figsize=(14, 7))
     plotting.plot_carpet(
@@ -106,12 +110,14 @@ def carpet_plot(
         mask,
         figure=fig,
         axes=ax,
+        standardize="zscore_sample",
         title="High-Kappa Data",
     )
     fig.tight_layout()
     fig.savefig(
         os.path.join(io_generator.out_dir, "figures", f"{io_generator.prefix}carpet_accepted.svg")
     )
+    plt.close(fig)
 
     fig, ax = plt.subplots(figsize=(14, 7))
     plotting.plot_carpet(
@@ -119,12 +125,14 @@ def carpet_plot(
         mask,
         figure=fig,
         axes=ax,
+        standardize="zscore_sample",
         title="Low-Kappa Data",
     )
     fig.tight_layout()
     fig.savefig(
         os.path.join(io_generator.out_dir, "figures", f"{io_generator.prefix}carpet_rejected.svg")
     )
+    plt.close(fig)
 
     if (gscontrol is not None) and ("gsr" in gscontrol):
         optcom_with_gs_img = io_generator.get_name("has gs combined img")
@@ -134,6 +142,7 @@ def carpet_plot(
             mask,
             figure=fig,
             axes=ax,
+            standardize="zscore_sample",
             title="Optimally Combined Data (Pre-GSR)",
         )
         fig.tight_layout()
@@ -144,6 +153,7 @@ def carpet_plot(
                 f"{io_generator.prefix}carpet_optcom_nogsr.svg",
             )
         )
+        plt.close(fig)
 
     if (gscontrol is not None) and ("mir" in gscontrol):
         mir_denoised_img = io_generator.get_name("mir denoised img")
@@ -153,6 +163,7 @@ def carpet_plot(
             mask,
             figure=fig,
             axes=ax,
+            standardize="zscore_sample",
             title="Denoised Data (Post-MIR)",
         )
         fig.tight_layout()
@@ -163,6 +174,7 @@ def carpet_plot(
                 f"{io_generator.prefix}carpet_denoised_mir.svg",
             )
         )
+        plt.close(fig)
 
         if io_generator.verbose:
             mir_denoised_img = io_generator.get_name("ICA accepted mir denoised img")
@@ -172,6 +184,7 @@ def carpet_plot(
                 mask,
                 figure=fig,
                 axes=ax,
+                standardize="zscore_sample",
                 title="High-Kappa Data (Post-MIR)",
             )
             fig.tight_layout()
@@ -182,6 +195,7 @@ def carpet_plot(
                     f"{io_generator.prefix}carpet_accepted_mir.svg",
                 )
             )
+            plt.close(fig)
 
 
 def plot_component(
@@ -590,6 +604,7 @@ def plot_t2star_and_s0(
     ax.set_xlabel("Seconds\n(limited to 98th percentile)", fontsize=16)
     fig.tight_layout()
     fig.savefig(os.path.join(io_generator.out_dir, "figures", t2star_histogram))
+    plt.close(fig)
 
     # Only plot S0 data if the file exists
     if s0_exists:
@@ -605,6 +620,7 @@ def plot_t2star_and_s0(
         ax.set_xlabel("Arbitrary Units\n(limited to 98th percentile)", fontsize=16)
         fig.tight_layout()
         fig.savefig(os.path.join(io_generator.out_dir, "figures", s0_histogram))
+        plt.close(fig)
 
     # Plot T2* and S0 maps
     t2star_plot = f"{io_generator.prefix}t2star_brain.svg"

--- a/tedana/tests/test_stats.py
+++ b/tedana/tests/test_stats.py
@@ -5,7 +5,6 @@ import random
 import numpy as np
 import pytest
 from numpy.linalg import LinAlgError
-from numpy.matlib import repmat
 
 from tedana.stats import fit_model, get_coeffs, getfbounds, voxelwise_univariate_zstats
 
@@ -127,7 +126,7 @@ def test_fit_model():
     residuals = rng.random(size=(t, c)) / 1000000
     y = np.empty((t, c))
     for cidx in range(c):
-        y[:, cidx] = (x * repmat(weights[:, cidx], t, 1)).sum(axis=1)
+        y[:, cidx] = (x * weights[:, cidx]).sum(axis=1)
     y = y + residuals
 
     # Fitting model and confirming outputs are the correct shape

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -4,7 +4,6 @@ import logging
 import os.path as op
 import platform
 import sys
-import warnings
 from typing import Union
 
 import numpy as np
@@ -321,12 +320,9 @@ def dice(arr1, arr2, axis=None):
             "Please check your component table for dice columns with 0-values."
         )
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", category=RuntimeWarning, message="invalid value encountered in true_divide"
-        )
-        dsi = (2.0 * intersection.sum(axis=axis)) / arr_sum
-    dsi = np.nan_to_num(dsi)
+    numerator = 2.0 * intersection.sum(axis=axis)
+    dsi = np.zeros_like(numerator, dtype=float)
+    np.divide(numerator, arr_sum, out=dsi, where=arr_sum != 0)
 
     return dsi
 
@@ -389,11 +385,10 @@ def threshold_map(img, min_cluster_size, threshold=None, binarize=True, sided="b
     min_cluster_size : int
         Minimum cluster size (in voxels)
     threshold : float or None or (V,) array_like, optional
-        Cluster-defining threshold for img.
-        - If None (default), assume img is already thresholded.
-        - If float, the same threshold is used for all volumes.
-        - If array_like and img is 4D, must have length equal to the number of volumes
-          (last dimension), and each threshold is applied to the corresponding volume.
+        Cluster-defining threshold for img. If None (default), assume img is already
+        thresholded. If float, the same threshold is used for all volumes. If array_like
+        and img is 4D, it must have length equal to the number of volumes in the last
+        dimension; each threshold is applied to the corresponding volume.
     binarize : bool, optional
         Default is True.
     sided : {'bi', 'two', 'one'}, optional

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -584,6 +584,7 @@ def check_t2s_values(t2s_map):
     Notes
     -----
     The heuristic used is:
+
     - If median non-zero T2* < 1: values are assumed to be in seconds (correct
       per BIDS), converted to milliseconds and returned
     - If median non-zero T2* >= 1 and < 1000: values are assumed to be in
@@ -777,11 +778,13 @@ def check_te_values(te_values):
     Notes
     -----
     The heuristic used is:
+
     - If all TE values are between 0 and 1: values are assumed to be in seconds
       (correct per BIDS), converted to milliseconds and returned
     - If all TE values are >= 1: values are assumed to be in milliseconds, a
       deprecation warning is logged, and values are returned as-is
     - Mixed values or negative values raise an error
+
     """
     te_values = np.array(te_values)
     if all((te_values > 0) & (te_values < 1)):


### PR DESCRIPTION
Closes none, but addresses issues brought up in the most recent devs call.

Changes proposed in this pull request:

- Fix API links.
- Fix link to metric function for "normalized variance explained".
- Remove "dependence_metrics" from hidden TOC.
- Use new `standardize` parameter `carpet_plot`. Also close the figures once we're done with them.
- Remove deprecated `numpy.matlib.repmat` call.
- Work around divide-by-zero warnings by using `numpy.divide` with a `where` argument.
- Toggle import of check_niimg based on nilearn version.
- Address pandas.replace warning by also calling infer_objects.
