### PR TITLE
Fix PCA variance explained log output to show correct percentages

### DIFF
--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -239,15 +239,15 @@ def tedpca(
 
         # Extract number of components and variance explained for logging and plotting
         n_aic = aic["n_components"]
-        aic_varexp = np.round(aic["explained_variance_total"], 3)
+        aic_varexp = np.round(100 * aic["explained_variance_total"], 2)
         n_kic = kic["n_components"]
-        kic_varexp = np.round(kic["explained_variance_total"], 3)
+        kic_varexp = np.round(100 * kic["explained_variance_total"], 2)
         n_mdl = mdl["n_components"]
-        mdl_varexp = np.round(mdl["explained_variance_total"], 3)
+        mdl_varexp = np.round(100 * mdl["explained_variance_total"], 2)
         n_varex_90 = varex_90["n_components"]
-        varex_90_varexp = np.round(varex_90["explained_variance_total"], 3)
+        varex_90_varexp = np.round(100 * varex_90["explained_variance_total"], 2)
         n_varex_95 = varex_95["n_components"]
-        varex_95_varexp = np.round(varex_95["explained_variance_total"], 3)
+        varex_95_varexp = np.round(100 * varex_95["explained_variance_total"], 2)
         all_varex = np.round(all_comps["explained_variance_total"], 3)
 
         # Print out the results

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -259,8 +259,11 @@ def tedpca(
 
         LGR.info("Explained variance based on different criteria:")
         LGR.info(
-            f"AIC: {np.round(100 * aic_varexp, 2)}% | KIC: {np.round(100 * kic_varexp, 2)}% | MDL: {np.round(100 * mdl_varexp, 2)}% | "
-            f"90% varexp: {np.round(100 * varex_90_varexp, 2)}% | 95% varexp: {np.round(100 * varex_95_varexp, 2)}%"
+            f"AIC: {np.round(100 * aic_varexp, 2)}% | ",
+            f"KIC: {np.round(100 * kic_varexp, 2)}% | ",
+            f"MDL: {np.round(100 * mdl_varexp, 2)}% | ",
+            f"90% varexp: {np.round(100 * varex_90_varexp, 2)}% | ",
+            f"95% varexp: {np.round(100 * varex_95_varexp, 2)}% | ",
         )
 
         pca_optimization_curves = np.array([aic["value"], kic["value"], mdl["value"]])

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -239,15 +239,15 @@ def tedpca(
 
         # Extract number of components and variance explained for logging and plotting
         n_aic = aic["n_components"]
-        aic_varexp = np.round(100 * aic["explained_variance_total"], 2)
+        aic_varexp = np.round(aic["explained_variance_total"], 2)
         n_kic = kic["n_components"]
-        kic_varexp = np.round(100 * kic["explained_variance_total"], 2)
+        kic_varexp = np.round(kic["explained_variance_total"], 2)
         n_mdl = mdl["n_components"]
-        mdl_varexp = np.round(100 * mdl["explained_variance_total"], 2)
+        mdl_varexp = np.round(mdl["explained_variance_total"], 2)
         n_varex_90 = varex_90["n_components"]
-        varex_90_varexp = np.round(100 * varex_90["explained_variance_total"], 2)
+        varex_90_varexp = np.round(varex_90["explained_variance_total"], 2)
         n_varex_95 = varex_95["n_components"]
-        varex_95_varexp = np.round(100 * varex_95["explained_variance_total"], 2)
+        varex_95_varexp = np.round(varex_95["explained_variance_total"], 2)
         all_varex = np.round(all_comps["explained_variance_total"], 3)
 
         # Print out the results
@@ -259,8 +259,8 @@ def tedpca(
 
         LGR.info("Explained variance based on different criteria:")
         LGR.info(
-            f"AIC: {aic_varexp}% | KIC: {kic_varexp}% | MDL: {mdl_varexp}% | "
-            f"90% varexp: {varex_90_varexp}% | 95% varexp: {varex_95_varexp}%"
+            f"AIC: {np.round(100 * aic_varexp, 2)}% | KIC: {np.round(100 * kic_varexp, 2)}% | MDL: {np.round(100 * mdl_varexp, 2)}% | "
+            f"90% varexp: {np.round(100 * varex_90_varexp, 2)}% | 95% varexp: {np.round(100 * varex_95_varexp, 2)}%"
         )
 
         pca_optimization_curves = np.array([aic["value"], kic["value"], mdl["value"]])

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -239,15 +239,15 @@ def tedpca(
 
         # Extract number of components and variance explained for logging and plotting
         n_aic = aic["n_components"]
-        aic_varexp = np.round(aic["explained_variance_total"], 2)
+        aic_varexp = np.round(aic["explained_variance_total"], 3)
         n_kic = kic["n_components"]
-        kic_varexp = np.round(kic["explained_variance_total"], 2)
+        kic_varexp = np.round(kic["explained_variance_total"], 3)
         n_mdl = mdl["n_components"]
-        mdl_varexp = np.round(mdl["explained_variance_total"], 2)
+        mdl_varexp = np.round(mdl["explained_variance_total"], 3)
         n_varex_90 = varex_90["n_components"]
-        varex_90_varexp = np.round(varex_90["explained_variance_total"], 2)
+        varex_90_varexp = np.round(varex_90["explained_variance_total"], 3)
         n_varex_95 = varex_95["n_components"]
-        varex_95_varexp = np.round(varex_95["explained_variance_total"], 2)
+        varex_95_varexp = np.round(varex_95["explained_variance_total"], 3)
         all_varex = np.round(all_comps["explained_variance_total"], 3)
 
         # Print out the results

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -259,11 +259,11 @@ def tedpca(
 
         LGR.info("Explained variance based on different criteria:")
         LGR.info(
-            f"AIC: {np.round(100 * aic_varexp, 2)}% | ",
-            f"KIC: {np.round(100 * kic_varexp, 2)}% | ",
-            f"MDL: {np.round(100 * mdl_varexp, 2)}% | ",
-            f"90% varexp: {np.round(100 * varex_90_varexp, 2)}% | ",
-            f"95% varexp: {np.round(100 * varex_95_varexp, 2)}% | ",
+            f"AIC: {np.round(100 * aic_varexp, 2)}% | "
+            f"KIC: {np.round(100 * kic_varexp, 2)}% | "
+            f"MDL: {np.round(100 * mdl_varexp, 2)}% | "
+            f"90% varexp: {np.round(100 * varex_90_varexp, 2)}% | "
+            f"95% varexp: {np.round(100 * varex_95_varexp, 2)}%"
         )
 
         pca_optimization_curves = np.array([aic["value"], kic["value"], mdl["value"]])


### PR DESCRIPTION
Fixes #1384 

## Summary 
The explained_variance_total values from mapca are ratios (0-1), but were being displayed with a % suffix without first converting to percentages. This produced misleading output like "90% varexp: 0.901%" instead of "90% varexp: 90.1%".

Multiply `explained_variance_total` vals by 100 before displaying. The `all_varex` array used for the variance explained plot is left unchanged since the plot y-axis expects 0-1 range.

## Tests

Verified correct output on personal data, please try on yours, too. Also did pytest —skipintegration tedana/tests: 218 passed.  

Please let me know if I did anything wrong!

<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1384  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Multiply `explained_variance_total` vals by 100 before displaying.

