### PR TITLE
Account for dummy scans in workflows

### DIFF
--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -190,6 +190,7 @@ def test_integration_five_echo(skip_integration):
     suffix = ".sm.nii.gz"
     datalist = [prepend + str(i + 1) + suffix for i in range(5)]
     echo_times = [15.4, 29.7, 44.0, 58.3, 72.6]
+    dummy_scans = 2
     # adding n_independent_echos=4 to test workflow code using n_independent_echos is executed
     tedana_cli.tedana_workflow(
         data=datalist,
@@ -205,7 +206,7 @@ def test_integration_five_echo(skip_integration):
         tedort=True,
         verbose=True,
         prefix="sub-01",
-        dummy_scans=2,
+        dummy_scans=dummy_scans,
     )
 
     # Just a check on the component table pending a unit test of load_comptable
@@ -223,7 +224,7 @@ def test_integration_five_echo(skip_integration):
     optcom_file = os.path.join(out_dir, "sub-01_desc-optcom_bold.nii.gz")
     output_shape = list(nb.load(optcom_file).shape)
     target_shape = list(nb.load(datalist[0]).shape)
-    target_shape[3] = target_shape[3] - 2  # account for dummy scans
+    target_shape[3] = target_shape[3] - dummy_scans
     assert output_shape == target_shape
 
 

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 from importlib.resources import files
 
+import nibabel as nb
 import pandas as pd
 import pytest
 
@@ -204,6 +205,7 @@ def test_integration_five_echo(skip_integration):
         tedort=True,
         verbose=True,
         prefix="sub-01",
+        dummy_scans=2,
     )
 
     # Just a check on the component table pending a unit test of load_comptable
@@ -216,6 +218,13 @@ def test_integration_five_echo(skip_integration):
     # Since robustica with only 4 iterations might result in a variable number of finale comps,
     #  using max_expected_comp=-1 to not check the number of component files.
     check_integration_outputs(fn, out_dir, max_expected_comp=-1)
+
+    # Check that dummy scans are removed from the optimally combined data
+    optcom_file = os.path.join(out_dir, "sub-01_desc-optcom_bold.nii.gz")
+    output_shape = list(nb.load(optcom_file).shape)
+    target_shape = list(nb.load(datalist[0]).shape)
+    target_shape[3] = target_shape[3] - 2  # account for dummy scans
+    assert output_shape == target_shape
 
 
 def test_integration_four_echo(skip_integration):

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -173,10 +173,13 @@ class TestT2smap:
         assert len(img.shape) == 3
         img = nb.load(op.join(out_dir, "desc-optcom_bold.nii.gz"))
         assert len(img.shape) == 4
-        target_shape = list(nb.load(data[0]).shape)
-        target_shape[3] = target_shape[3] - 1  # account for dummy scans, but not exclude
+        in_img = nb.load(data[0])
+        target_shape = list(in_img.shape)
+        target_shape[3] = target_shape[3] - 1  # account for dummy scans, but not exclude; #1401
         output_shape = list(img.shape)
         assert output_shape == target_shape
+        assert in_img.get_data_dtype() == img.get_data_dtype()  # See #1389
+
 
     def test_failing_t2smap_01(self):
         """A simple failing configuration for t2smap."""

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -176,7 +176,7 @@ class TestT2smap:
         target_shape = list(nb.load(data[0]).shape)
         target_shape[3] = target_shape[3] - 1  # account for dummy scans, but not exclude
         output_shape = list(img.shape)
-        assert target_shape == output_shape
+        assert output_shape == target_shape
 
     def test_failing_t2smap_01(self):
         """A simple failing configuration for t2smap."""

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -178,7 +178,6 @@ class TestT2smap:
         target_shape[3] = target_shape[3] - 1  # account for dummy scans, but not exclude; #1401
         output_shape = list(img.shape)
         assert output_shape == target_shape
-        assert in_img.get_data_dtype() == img.get_data_dtype()  # See #1389
 
 
     def test_failing_t2smap_01(self):

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -151,7 +151,7 @@ class TestT2smap:
                 "--dummy-scans",
                 "1",
                 "--exclude",
-                "0:1",
+                "0:2",  # exclude one volume beyond the dummy scan
                 "--combmode",
                 "t2s",
                 "--fitmode",
@@ -173,6 +173,10 @@ class TestT2smap:
         assert len(img.shape) == 3
         img = nb.load(op.join(out_dir, "desc-optcom_bold.nii.gz"))
         assert len(img.shape) == 4
+        target_shape = list(nb.load(data[0]).shape)
+        target_shape[3] = target_shape[3] - 1  # account for dummy scans, but not exclude
+        output_shape = list(img.shape)
+        assert target_shape == output_shape
 
     def test_failing_t2smap_01(self):
         """A simple failing configuration for t2smap."""

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -179,7 +179,6 @@ class TestT2smap:
         output_shape = list(img.shape)
         assert output_shape == target_shape
 
-
     def test_failing_t2smap_01(self):
         """A simple failing configuration for t2smap."""
         data_dir = get_test_data_path()

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -386,18 +386,6 @@ def t2smap_workflow(
             "Please set fitmode='all' or remove the exclude argument."
         )
 
-    if dummy_scans > 0:
-        LGR.warning(f"Removing the first {dummy_scans} volumes as dummy scans.")
-    if n_exclude > 0:
-        LGR.info(f"Excluding volumes: {exclude_idx}")
-        # Adjust exclude indices for dummy scans that are already removed
-        exclude_idx = np.setdiff1d(exclude_idx, np.arange(dummy_scans))
-        # Offset exclude indices by the number of dummy scans so they index into loaded data_cat
-        exclude_idx = exclude_idx - dummy_scans
-        n_exclude = len(exclude_idx)
-        if n_exclude == 0:
-            LGR.warning(f"All exclude indices overlap with dummy scans ({dummy_scans}).")
-
     # ensure tes are in appropriate format
     tes = [float(te) for te in tes]
     tes = utils.check_te_values(tes)
@@ -426,10 +414,24 @@ def t2smap_workflow(
     LGR.info(f"Loading input data: {[f for f in data]}")
     data_cat = io.load_data_nilearn(data, mask_img=mask_img, n_echos=n_echos)
 
+    if dummy_scans > 0:
+        LGR.warning(f"Removing the first {dummy_scans} volumes as dummy scans.")
+        data_cat = data_cat[..., dummy_scans:]
+
     n_samp, n_echos, n_vols = data_cat.shape
     LGR.debug(f"Resulting data shape: {data_cat.shape}")
 
     # Create mask for volumes to use based on exclude indices
+    if n_exclude > 0:
+        LGR.info(f"Excluding volumes: {exclude_idx}")
+        # Adjust exclude indices for dummy scans that are already removed
+        exclude_idx = np.setdiff1d(exclude_idx, np.arange(dummy_scans))
+        # Offset exclude indices by the number of dummy scans so they index into loaded data_cat
+        exclude_idx = exclude_idx - dummy_scans
+        n_exclude = len(exclude_idx)
+        if n_exclude == 0:
+            LGR.warning(f"All exclude indices overlap with dummy scans ({dummy_scans}).")
+
     if n_exclude > 0 and np.max(exclude_idx) > n_vols:
         raise ValueError(
             f"The maximum exclude index ({np.max(exclude_idx)}) is greater than the number of "

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -689,6 +689,9 @@ def tedana_workflow(
 
     LGR.info(f"Loading input data: {[f for f in data]}")
     data_cat = io.load_data_nilearn(data, mask_img=mask_img, n_echos=n_echos)
+    if dummy_scans > 0:
+        LGR.warning(f"Removing the first {dummy_scans} volumes as dummy scans.")
+        data_cat = data_cat[..., dummy_scans:]
 
     # Load external regressors if provided
     # Decided to do the validation here so that, if there are issues, an error


### PR DESCRIPTION
Closes #1401. One thing that I have been failing to do is write and push tests that fail before implementing a bug fix. I am trying to adopt that approach more consistently, starting in this PR. Note that the first commit fails due to #1401 because I added an explicit check, and then the next commit fixes it.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Update tests to fail when dummy scans are not accounted for correctly (i.e., the optcom file should be `dummy_scans` shorter than the input data).
- Remove `dummy_scans` from `data_cat` in t2smap and tedana workflows. It looks like ica_reclassify is already good.
