### PR TITLE
Update 5-echo timeout from 10 to 20 mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
             uvx tox -e five-echo
             mkdir /tmp/src/coverage
             mv .coverage /tmp/src/coverage/.coverage.five-echo
+          no_output_timeout: 20m
       - save_cache:
           key: tox-py310-five-echo-v1-{{ checksum "uv.lock" }}
           paths:


### PR DESCRIPTION
Hopefully this will address the recent timeout issues we've been seeing with the 5-echo test.