### PR TITLE
Bump CodeCov orb to 6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@5.2.1
+  codecov: codecov/codecov@6.0.0
 jobs:
   style_check:
     docker:


### PR DESCRIPTION
Hopefully this will fix the CodeCov-related test failures on other PRs.