### PR TITLE
Add option to estimate S0/T2* from complex-valued data

### DIFF
--- a/docs/superpowers/plans/2026-06-23-t2smap-complex-nlls.md
+++ b/docs/superpowers/plans/2026-06-23-t2smap-complex-nlls.md
@@ -1,0 +1,1195 @@
+# t2smap Complex NLLS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a complex non-linear least-squares (NLLS) T2*/S0 fit to the `t2smap` workflow, exposed via `--fittype nlls`, a new `--phase` argument, and a new `--fitmode varys0`.
+
+**Architecture:** Port the core complex decay estimator from the `dahnke` subpackage into `tedana/decay.py` (model, per-sample fitter, adaptive-mask driver, and joint fit), stripped of the Dahnke modulation term (implicitly 1, kept as a future hook). The `t2smap` workflow gains a dedicated nlls branch calling a new `fit_complex_decay` dispatcher; `fit_decay`/`fit_decay_ts` are left untouched so the main `tedana` workflow is unaffected. Magnitude data still drives the adaptive mask, optimal combination, and RMSE; only T2*/S0 estimation uses the complex data.
+
+**Tech Stack:** Python, NumPy, SciPy (`scipy.optimize.least_squares`), joblib (`Parallel`/`delayed`), pytest. Reference source: `/mnt/c/Users/tsalo/Documents/tsalo/complex-tedana/dahnke/src/dahnke/correction.py`.
+
+## Global Constraints
+
+- Modulation is **not** ported. The model keeps a `modulation=1.0` parameter as a forward-compatibility hook only; no gradient/slice-profile code.
+- The complex model is `S(TE) = S0 * exp((-R2* + 1j*2*pi*f) * TE) * modulation`, with `S0` complex; fit parameters are `[log(|S0|), R2*, frequency_hz, phase0]` and `S0 = exp(log|S0|) * exp(1j*phase0)`.
+- Echo times are in **seconds**.
+- `fit_decay` and `fit_decay_ts` signatures and return tuples MUST NOT change (called by `tedana/workflows/tedana.py`).
+- `--fitmode varys0` is valid only with `--fittype nlls`. `--phase` is required for nlls and rejected for other fittypes. `--phase` must have one file per echo, matching `-d`.
+- `varys0` permits `--exclude`; excluded volumes are dropped from the shared R2*/frequency estimate only, while per-volume S0 is computed for all volumes.
+- All new public functions get NumPy-style docstrings matching the surrounding file. Follow existing logging (`LGR`, `RepLGR`) and `joblib`/`tqdm` patterns from `fit_monoexponential`.
+- Run tests with the project venv: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest`.
+
+---
+
+### Task 1: Complex decay model, parameter initialization, and per-sample fitter
+
+**Files:**
+- Modify: `tedana/decay.py` (add functions after `_fit_single_voxel`, near line 121; `scipy`/`numpy` already imported)
+- Test: `tedana/tests/test_decay.py`
+
+**Interfaces:**
+- Produces:
+  - `complex_decay_model(echo_times, s0, r2star, frequency_hz=0.0, modulation=1.0) -> np.ndarray` (complex)
+  - `_initial_complex_decay_params(signal, echo_times) -> np.ndarray` shape `(4,)` = `[log|S0|, R2*, frequency_hz, phase0]`
+  - `_fit_complex_decay_1d(signal, echo_times, *, lower_bounds, upper_bounds, max_nfev=None) -> dict | None` with keys `s0` (complex), `r2star`, `frequency_hz`, `phase0`, `cost`, `nfev`, `success`. Returns `None` only when fewer than 2 finite echoes.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tedana/tests/test_decay.py`:
+
+```python
+def test_complex_decay_model():
+    """complex_decay_model returns the analytic complex signal."""
+    tes = np.array([0.01, 0.02, 0.03])
+    s0 = 100.0 * np.exp(1j * 0.5)
+    r2star = 20.0
+    freq = 3.0
+    sig = me.complex_decay_model(tes, s0, r2star, freq)
+    expected = s0 * np.exp((-r2star + 1j * 2 * np.pi * freq) * tes)
+    assert np.allclose(sig, expected)
+
+
+def test__fit_complex_decay_1d_recovers_params():
+    """_fit_complex_decay_1d recovers known params from noiseless data."""
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    s0 = 250.0 * np.exp(1j * 0.7)
+    r2star = 18.0
+    freq = 4.0
+    signal = me.complex_decay_model(tes, s0, r2star, freq)
+    lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper = np.array([np.inf, np.inf, np.inf, np.inf])
+    out = me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper)
+    assert out is not None
+    assert np.isclose(out["r2star"], r2star, atol=1e-3)
+    assert np.isclose(out["frequency_hz"], freq, atol=1e-3)
+    assert np.isclose(np.abs(out["s0"]), np.abs(s0), rtol=1e-3)
+    assert out["success"]
+
+
+def test__fit_complex_decay_1d_too_few_echoes():
+    """_fit_complex_decay_1d returns None with fewer than 2 finite echoes."""
+    tes = np.array([0.01, 0.02])
+    signal = np.array([np.nan + 1j * np.nan, 5 + 1j * 2])
+    lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper = np.array([np.inf, np.inf, np.inf, np.inf])
+    assert me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k complex_decay -v`
+Expected: FAIL with `AttributeError: module 'tedana.decay' has no attribute 'complex_decay_model'`.
+
+- [ ] **Step 3: Implement the functions**
+
+Add to `tedana/decay.py` after `_fit_single_voxel` (after line 120):
+
+```python
+def complex_decay_model(echo_times, s0, r2star, frequency_hz=0.0, modulation=1.0):
+    """Evaluate a single-pool complex R2* decay model.
+
+    The model is ``S(TE) = S0 * exp((-R2* + 1j*2*pi*f) * TE) * modulation``.
+    ``s0`` is complex and absorbs the initial phase. ``modulation`` is a
+    forward-compatibility hook for a future Dahnke correction; pass 1 for none.
+
+    Parameters
+    ----------
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    s0 : complex or array_like
+        Complex signal at TE=0.
+    r2star : float or array_like
+        R2* decay rate in s^-1.
+    frequency_hz : float or array_like, optional
+        Off-resonance frequency in Hz. Default is 0.0.
+    modulation : complex or array_like, optional
+        Through-slice modulation term. Default is 1.0 (no modulation).
+
+    Returns
+    -------
+    signal : :obj:`numpy.ndarray`
+        Complex predicted signal, broadcast over the inputs.
+    """
+    echo_times = np.asarray(echo_times, dtype=float)
+    decay = -np.asarray(r2star) + 1j * 2.0 * np.pi * np.asarray(frequency_hz)
+    return np.asarray(s0) * np.exp(decay * echo_times) * np.asarray(modulation)
+
+
+def _initial_complex_decay_params(signal, echo_times):
+    """Derive initial ``[log|S0|, R2*, frequency_hz, phase0]`` for one echo train.
+
+    Parameters
+    ----------
+    signal : (E,) array_like
+        Complex echo train for one sample.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+
+    Returns
+    -------
+    params : (4,) :obj:`numpy.ndarray`
+        Initial estimates from a log-linear magnitude fit (slope -> R2*,
+        intercept -> log|S0|) and an unwrapped-phase linear fit
+        (slope -> frequency_hz, intercept -> phase0).
+    """
+    amplitude = np.maximum(np.abs(signal), np.finfo(float).tiny)
+    if echo_times.size > 1:
+        slope, intercept = np.polyfit(echo_times, np.log(amplitude), 1)
+        r2star = max(0.0, -float(slope))
+        phase = np.unwrap(np.angle(signal))
+        phase_slope, phase_intercept = np.polyfit(echo_times, phase, 1)
+        frequency_hz = float(phase_slope / (2.0 * np.pi))
+        phase0 = float(phase_intercept)
+    else:
+        intercept = float(np.log(amplitude[0]))
+        r2star = 0.0
+        frequency_hz = 0.0
+        phase0 = float(np.angle(signal[0]))
+    return np.array([float(intercept), r2star, frequency_hz, phase0], dtype=float)
+
+
+def _fit_complex_decay_1d(signal, echo_times, *, lower_bounds, upper_bounds, max_nfev=None):
+    """Fit one complex echo train with nonlinear least squares.
+
+    Parameters
+    ----------
+    signal : (E,) array_like
+        Complex-valued data for one sample.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    lower_bounds, upper_bounds : (4,) array_like
+        Bounds for ``[log|S0|, R2*, frequency_hz, phase0]``.
+    max_nfev : int or None, optional
+        Maximum function evaluations for :func:`scipy.optimize.least_squares`.
+
+    Returns
+    -------
+    result : dict or None
+        Dict with ``s0`` (complex), ``r2star``, ``frequency_hz``, ``phase0``,
+        ``cost``, ``nfev``, ``success``. ``None`` only when fewer than 2 finite
+        echoes are available. On optimizer error, falls back to the initial
+        estimate with ``success=False``.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    if int(valid.sum()) < 2:
+        return None
+
+    y_valid = signal[valid]
+    te_valid = echo_times[valid]
+    x0 = _initial_complex_decay_params(y_valid, te_valid)
+    x0 = np.minimum(np.maximum(x0, lower_bounds), upper_bounds)
+
+    def residuals(params):
+        log_s0_abs, r2, freq, phi0 = params
+        pred = complex_decay_model(te_valid, np.exp(log_s0_abs) * np.exp(1j * phi0), r2, freq)
+        residual = pred - y_valid
+        return np.concatenate([residual.real, residual.imag])
+
+    try:
+        result = scipy.optimize.least_squares(
+            residuals, x0, bounds=(lower_bounds, upper_bounds), max_nfev=max_nfev
+        )
+    except (ValueError, RuntimeError, FloatingPointError):
+        log_s0_abs, r2star, frequency_hz, phase0 = x0
+        return {
+            "s0": np.exp(log_s0_abs) * np.exp(1j * phase0),
+            "r2star": r2star,
+            "frequency_hz": frequency_hz,
+            "phase0": phase0,
+            "cost": np.nan,
+            "nfev": 0,
+            "success": False,
+        }
+
+    log_s0_abs, r2star, frequency_hz, phase0 = result.x
+    return {
+        "s0": np.exp(log_s0_abs) * np.exp(1j * phase0),
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "phase0": phase0,
+        "cost": result.cost,
+        "nfev": result.nfev,
+        "success": result.success,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k complex_decay -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tedana/decay.py tedana/tests/test_decay.py
+git commit -m "feat(decay): add complex decay model and per-sample NLLS fitter"
+```
+
+---
+
+### Task 2: Adaptive-mask complex driver (`fit_complex_monoexponential`)
+
+**Files:**
+- Modify: `tedana/decay.py` (add after `_fit_complex_decay_1d`)
+- Test: `tedana/tests/test_decay.py`
+
+**Interfaces:**
+- Consumes: `_fit_complex_decay_1d`, `complex_decay_model` (Task 1); pattern mirrors `fit_monoexponential` (lines 123-282) and its `echos_to_run`/`echo_masks` logic.
+- Produces: `fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1) -> dict` with `(Md,)` arrays `t2s`, `s0` (magnitude), `r2star`, `frequency_hz`, `phase0`, `failures` (bool). `data_cat` is **complex** `(Md x E x T)`; echoes and timepoints are flattened into one fit per voxel.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_fit_complex_monoexponential_recovers_maps():
+    """fit_complex_monoexponential recovers R2*/S0 over the adaptive mask."""
+    rng = np.random.default_rng(0)
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vox, n_echo, n_vol = 6, 5, 3
+    r2star_true = rng.uniform(10, 30, n_vox)
+    s0_true = rng.uniform(100, 300, n_vox) * np.exp(1j * rng.uniform(-1, 1, n_vox))
+    data = np.zeros((n_vox, n_echo, n_vol), dtype=np.complex128)
+    for v in range(n_vox):
+        sig = me.complex_decay_model(tes, s0_true[v], r2star_true[v], 2.0)
+        data[v] = np.repeat(sig[:, None], n_vol, axis=1)
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    out = me.fit_complex_monoexponential(data, tes, adaptive_mask, report=False)
+    assert out["t2s"].shape == (n_vox,)
+    assert np.allclose(out["t2s"], 1.0 / r2star_true, rtol=1e-2)
+    assert np.allclose(out["s0"], np.abs(s0_true), rtol=1e-2)
+    assert out["frequency_hz"].shape == (n_vox,)
+    assert not out["failures"].any()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py::test_fit_complex_monoexponential_recovers_maps -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'fit_complex_monoexponential'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `tedana/decay.py` after `_fit_complex_decay_1d`:
+
+```python
+def fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
+    """Fit a complex monoexponential decay model per voxel across all timepoints.
+
+    Echoes and timepoints are flattened into a single fit per voxel (the
+    complex analog of the ``fittype="curvefit"``/``fitmode="all"`` scheme),
+    using the adaptive mask to choose how many echoes each voxel uses.
+
+    Parameters
+    ----------
+    data_cat : (Md x E x T) :obj:`numpy.ndarray`
+        Complex multi-echo data. Md is samples in the denoising mask.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel. See ``make_adaptive_mask``.
+    report : bool, optional
+        Whether to log a description of this step. Default is True.
+    n_threads : int, optional
+        Number of threads. If None or <= 0, uses all CPU cores.
+
+    Returns
+    -------
+    result : dict
+        ``(Md,)`` arrays ``t2s``, ``s0`` (magnitude), ``r2star``,
+        ``frequency_hz``, ``phase0``, and boolean ``failures``.
+    """
+    if n_threads is None or n_threads <= 0:
+        n_threads = os.cpu_count() or 1
+    if report:
+        RepLGR.info(
+            "A complex monoexponential model was fit to the magnitude and "
+            "phase data at each voxel using nonlinear least squares, jointly "
+            "estimating T2*, S0, off-resonance frequency, and initial phase."
+        )
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_samp, _, n_vols = data_cat.shape
+
+    echos_to_run = np.unique(adaptive_mask)
+    if 1 in echos_to_run:
+        echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+
+    lower_bounds = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper_bounds = np.array([np.inf, np.inf, np.inf, np.inf])
+
+    r2star = np.zeros(n_samp)
+    s0_mag = np.zeros(n_samp)
+    frequency_hz = np.zeros(n_samp)
+    phase0 = np.zeros(n_samp)
+    failures = np.zeros(n_samp, dtype=bool)
+
+    for echo_num in echos_to_run:
+        if echo_num == 2:
+            voxel_idx = np.where(adaptive_mask <= echo_num)[0]
+        else:
+            voxel_idx = np.where(adaptive_mask == echo_num)[0]
+
+        data_2d = data_cat[:, :echo_num, :].reshape(n_samp, -1)
+        echo_times_1d = np.repeat(echo_times[:echo_num], n_vols)
+
+        results = Parallel(n_jobs=n_threads)(
+            delayed(_fit_complex_decay_1d)(
+                data_2d[voxel],
+                echo_times_1d,
+                lower_bounds=lower_bounds,
+                upper_bounds=upper_bounds,
+            )
+            for voxel in tqdm(voxel_idx, desc=f"{echo_num}-echo complex NLLS")
+        )
+
+        for voxel, res in zip(voxel_idx, results):
+            if res is None:
+                failures[voxel] = True
+                continue
+            r2star[voxel] = res["r2star"]
+            s0_mag[voxel] = np.abs(res["s0"])
+            frequency_hz[voxel] = res["frequency_hz"]
+            phase0[voxel] = res["phase0"]
+            failures[voxel] = not res["success"]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
+
+    return {
+        "t2s": t2s,
+        "s0": s0_mag,
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "phase0": phase0,
+        "failures": failures,
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py::test_fit_complex_monoexponential_recovers_maps -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tedana/decay.py tedana/tests/test_decay.py
+git commit -m "feat(decay): add adaptive-mask complex monoexponential driver"
+```
+
+---
+
+### Task 3: Joint fit (`_fit_complex_decay_joint`) and shared S0 solver
+
+**Files:**
+- Modify: `tedana/decay.py` (add after `fit_complex_monoexponential`)
+- Test: `tedana/tests/test_decay.py`
+
+**Interfaces:**
+- Consumes: `complex_decay_model`, `_initial_complex_decay_params` (Task 1).
+- Produces:
+  - `_solve_complex_s0(signal, echo_times, r2star, frequency_hz) -> np.ndarray` complex, shape `(T,)`. `signal` is `(T, E)` complex; analytic least-squares S0 per volume given fixed R2*/frequency; NaN for volumes with < 2 finite echoes.
+  - `_fit_complex_decay_joint(signal, echo_times, *, max_r2star=np.inf, max_frequency_hz=np.inf, max_nfev=None) -> dict | None` with scalar `r2star`, `frequency_hz`, `cost`, `nfev`, `success` and `(T,)` arrays `s0` (complex), `phase0`. `signal` is `(T, E)` complex.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test__fit_complex_decay_joint_shared_params():
+    """Joint fit recovers shared R2*/frequency with per-volume S0."""
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    r2star, freq = 15.0, 3.0
+    s0_per_vol = np.array([100.0, 150.0, 200.0]) * np.exp(1j * np.array([0.2, -0.4, 0.6]))
+    signal = np.stack(
+        [me.complex_decay_model(tes, s0, r2star, freq) for s0 in s0_per_vol]
+    )  # (T, E)
+    out = me._fit_complex_decay_joint(signal, tes)
+    assert out is not None
+    assert np.isclose(out["r2star"], r2star, atol=1e-3)
+    assert np.isclose(out["frequency_hz"], freq, atol=1e-3)
+    assert out["s0"].shape == (3,)
+    assert np.allclose(np.abs(out["s0"]), np.abs(s0_per_vol), rtol=1e-3)
+
+
+def test__solve_complex_s0_all_volumes():
+    """_solve_complex_s0 returns one complex S0 per volume."""
+    tes = np.array([0.01, 0.02, 0.03])
+    s0_per_vol = np.array([100.0 + 0j, 200.0 + 0j])
+    signal = np.stack([me.complex_decay_model(tes, s0, 20.0, 0.0) for s0 in s0_per_vol])
+    out = me._solve_complex_s0(signal, tes, 20.0, 0.0)
+    assert out.shape == (2,)
+    assert np.allclose(np.abs(out), np.abs(s0_per_vol), rtol=1e-6)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k "joint or solve_complex" -v`
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 3: Implement**
+
+Add to `tedana/decay.py` after `fit_complex_monoexponential`:
+
+```python
+def _solve_complex_s0(signal, echo_times, r2star, frequency_hz):
+    """Analytically solve per-volume complex S0 for fixed R2*/frequency.
+
+    Parameters
+    ----------
+    signal : (T, E) array_like
+        Complex data for one voxel; volumes on axis 0, echoes on axis 1.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    r2star : float
+        Shared R2* in s^-1.
+    frequency_hz : float
+        Shared off-resonance frequency in Hz.
+
+    Returns
+    -------
+    s0 : (T,) :obj:`numpy.ndarray`
+        Complex S0 per volume. NaN for volumes with fewer than 2 finite echoes.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_vols = signal.shape[0]
+    decay = np.exp((-r2star + 1j * 2.0 * np.pi * frequency_hz) * echo_times)
+    s0 = np.full(n_vols, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    for vol in range(n_vols):
+        echo_mask = valid[vol]
+        if int(echo_mask.sum()) < 2:
+            continue
+        basis = decay[echo_mask]
+        denom = np.sum(np.abs(basis) ** 2)
+        if denom <= 0 or not np.isfinite(denom):
+            continue
+        s0[vol] = np.sum(np.conj(basis) * signal[vol, echo_mask]) / denom
+    return s0
+
+
+def _fit_complex_decay_joint(
+    signal, echo_times, *, max_r2star=np.inf, max_frequency_hz=np.inf, max_nfev=None
+):
+    """Fit one voxel with shared R2*/frequency and per-volume complex S0.
+
+    Per-volume complex S0 is linear given fixed R2*/frequency and is solved
+    analytically inside the residual, keeping the optimizer to two parameters.
+
+    Parameters
+    ----------
+    signal : (T, E) array_like
+        Complex data for one voxel; volumes on axis 0, echoes on axis 1.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    max_r2star : float, optional
+        Upper bound for R2* in s^-1. Default is inf.
+    max_frequency_hz : float, optional
+        Symmetric bound for off-resonance in Hz. Default is inf.
+    max_nfev : int or None, optional
+        Maximum function evaluations.
+
+    Returns
+    -------
+    result : dict or None
+        Scalar ``r2star``, ``frequency_hz``, ``cost``, ``nfev``, ``success``
+        and ``(T,)`` arrays ``s0`` (complex) and ``phase0``. ``None`` if no
+        volume has >= 2 finite echoes or optimization fails.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_vols = signal.shape[0]
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    valid_vols = np.flatnonzero(valid.sum(axis=1) >= 2)
+    if valid_vols.size == 0:
+        return None
+
+    initial = np.asarray(
+        [
+            _initial_complex_decay_params(signal[vol, valid[vol]], echo_times[valid[vol]])
+            for vol in valid_vols
+        ]
+    )
+    lower_bounds = np.array([0.0, -max_frequency_hz])
+    upper_bounds = np.array([max_r2star, max_frequency_hz])
+    x0 = np.array([float(np.nanmedian(initial[:, 1])), float(np.nanmedian(initial[:, 2]))])
+    x0 = np.minimum(np.maximum(x0, lower_bounds), upper_bounds)
+
+    def residuals(params):
+        r2, freq = params
+        s0_est = _solve_complex_s0(signal, echo_times, r2, freq)
+        parts = []
+        for vol in valid_vols:
+            if not np.isfinite(s0_est[vol]):
+                continue
+            echo_mask = valid[vol]
+            pred = complex_decay_model(echo_times[echo_mask], s0_est[vol], r2, freq)
+            residual = pred - signal[vol, echo_mask]
+            parts.extend([residual.real, residual.imag])
+        return np.concatenate(parts)
+
+    try:
+        result = scipy.optimize.least_squares(
+            residuals, x0, bounds=(lower_bounds, upper_bounds), max_nfev=max_nfev
+        )
+    except (ValueError, RuntimeError, FloatingPointError):
+        return None
+
+    r2star, frequency_hz = result.x
+    s0 = _solve_complex_s0(signal, echo_times, r2star, frequency_hz)
+    return {
+        "s0": s0,
+        "phase0": np.angle(s0),
+        "r2star": float(r2star),
+        "frequency_hz": float(frequency_hz),
+        "cost": result.cost,
+        "nfev": result.nfev,
+        "success": result.success,
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k "joint or solve_complex" -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tedana/decay.py tedana/tests/test_decay.py
+git commit -m "feat(decay): add joint complex fit and analytic S0 solver"
+```
+
+---
+
+### Task 4: Public nlls dispatcher (`fit_complex_decay`)
+
+**Files:**
+- Modify: `tedana/decay.py` (add after `_fit_complex_decay_joint`)
+- Test: `tedana/tests/test_decay.py`
+
+**Interfaces:**
+- Consumes: `fit_complex_monoexponential` (Task 2), `_fit_complex_decay_joint`, `_solve_complex_s0` (Task 3).
+- Produces: `fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None, n_threads=1) -> dict`.
+  - `data`, `phase`: real magnitude/phase `(Md x E x T)`; complex formed internally as `data * exp(1j*phase)`.
+  - `fitmode="all"`: dict of `(Md,)` arrays `t2s`, `s0`, `frequency_hz`, `phase0`, `failures`.
+  - `fitmode="ts"`: same keys as `(Md, T)` arrays.
+  - `fitmode="varys0"`: `t2s`, `frequency_hz`, `failures` `(Md,)`; `s0`, `phase0` `(Md, T)`. `use_volumes` (bool `(T,)` or None) selects volumes used for the shared R2*/frequency estimate; per-volume S0 computed for all volumes.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@pytest.fixture
+def complex_testdata():
+    rng = np.random.default_rng(1)
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vox, n_echo, n_vol = 5, 5, 4
+    r2star = rng.uniform(10, 25, n_vox)
+    s0 = rng.uniform(100, 250, n_vox)
+    mag = np.zeros((n_vox, n_echo, n_vol))
+    phase = np.zeros((n_vox, n_echo, n_vol))
+    for v in range(n_vox):
+        sig = me.complex_decay_model(tes, s0[v] * np.exp(1j * 0.3), r2star[v], 2.0)
+        mag[v] = np.repeat(np.abs(sig)[:, None], n_vol, axis=1)
+        phase[v] = np.repeat(np.angle(sig)[:, None], n_vol, axis=1)
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    return dict(mag=mag, phase=phase, tes=tes, adaptive_mask=adaptive_mask,
+               r2star=r2star, s0=s0, n_vol=n_vol)
+
+
+def test_fit_complex_decay_all(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "all")
+    assert out["t2s"].shape == (5,)
+    assert out["s0"].shape == (5,)
+    assert np.allclose(out["t2s"], 1.0 / d["r2star"], rtol=1e-2)
+
+
+def test_fit_complex_decay_ts(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "ts")
+    assert out["t2s"].shape == (5, d["n_vol"])
+    assert out["s0"].shape == (5, d["n_vol"])
+
+
+def test_fit_complex_decay_varys0(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "varys0")
+    assert out["t2s"].shape == (5,)
+    assert out["frequency_hz"].shape == (5,)
+    assert out["s0"].shape == (5, d["n_vol"])
+    assert out["phase0"].shape == (5, d["n_vol"])
+    assert np.allclose(out["t2s"], 1.0 / d["r2star"], rtol=1e-2)
+
+
+def test_fit_complex_decay_varys0_use_volumes(complex_testdata):
+    """use_volumes restricts the shared fit but S0 is returned for all volumes."""
+    d = complex_testdata
+    use_volumes = np.array([True, True, False, True])
+    out = me.fit_complex_decay(
+        d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "varys0",
+        use_volumes=use_volumes,
+    )
+    assert out["s0"].shape == (5, d["n_vol"])
+    assert np.isfinite(out["s0"][:, 2]).all()  # excluded volume still gets S0
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k fit_complex_decay -v`
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 3: Implement**
+
+Add to `tedana/decay.py` after `_fit_complex_decay_joint`:
+
+```python
+def fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None, n_threads=1):
+    """Estimate complex T2*/S0 maps from magnitude and phase data.
+
+    Parameters
+    ----------
+    data : (Md x E x T) :obj:`numpy.ndarray`
+        Magnitude multi-echo data in the denoising mask.
+    phase : (Md x E x T) :obj:`numpy.ndarray`
+        Phase multi-echo data in radians, same shape as ``data``.
+    tes : (E,) array_like
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel.
+    fitmode : {"all", "ts", "varys0"}
+        ``"all"`` fits one model per voxel across all timepoints. ``"ts"`` fits
+        per voxel and timepoint. ``"varys0"`` shares R2*/frequency across
+        timepoints with per-volume complex S0.
+    use_volumes : (T,) :obj:`numpy.ndarray` of bool or None, optional
+        For ``"varys0"`` only: volumes used to estimate the shared
+        R2*/frequency. Per-volume S0 is computed for all volumes regardless.
+        ``None`` uses all volumes.
+    n_threads : int, optional
+        Number of threads. If None or <= 0, uses all CPU cores.
+
+    Returns
+    -------
+    result : dict
+        For ``"all"``: ``(Md,)`` arrays ``t2s``, ``s0``, ``r2star``,
+        ``frequency_hz``, ``phase0``, ``failures``. For ``"ts"``: same keys as
+        ``(Md, T)``. For ``"varys0"``: ``t2s``/``r2star``/``frequency_hz``/
+        ``failures`` are ``(Md,)`` and ``s0``/``phase0`` are ``(Md, T)``.
+    """
+    if n_threads is None or n_threads <= 0:
+        n_threads = os.cpu_count() or 1
+    data = np.asarray(data)
+    phase = np.asarray(phase)
+    tes = np.asarray(tes, dtype=float)
+    complex_data = data * np.exp(1j * phase)
+    n_samp, _, n_vols = complex_data.shape
+
+    if fitmode == "all":
+        return fit_complex_monoexponential(
+            complex_data, tes, adaptive_mask, n_threads=n_threads
+        )
+
+    if fitmode == "ts":
+        keys = ("t2s", "s0", "r2star", "frequency_hz", "phase0")
+        out = {k: np.zeros((n_samp, n_vols)) for k in keys}
+        out["failures"] = np.zeros((n_samp, n_vols), dtype=bool)
+        report = True
+        for vol in range(n_vols):
+            res = fit_complex_monoexponential(
+                complex_data[:, :, vol][:, :, None],
+                tes,
+                adaptive_mask,
+                report=report,
+                n_threads=n_threads,
+            )
+            for k in keys:
+                out[k][:, vol] = res[k]
+            out["failures"][:, vol] = res["failures"]
+            report = False
+        return out
+
+    if fitmode == "varys0":
+        if use_volumes is None:
+            use_volumes = np.ones(n_vols, dtype=bool)
+        return _fit_complex_decay_varys0(
+            complex_data, tes, adaptive_mask, use_volumes, n_threads
+        )
+
+    raise ValueError(f"Unknown fitmode option: {fitmode}")
+
+
+def _fit_complex_decay_varys0(complex_data, tes, adaptive_mask, use_volumes, n_threads):
+    """Joint-fit driver: shared R2*/frequency, per-volume complex S0.
+
+    Parameters
+    ----------
+    complex_data : (Md x E x T) :obj:`numpy.ndarray`
+        Complex multi-echo data.
+    tes : (E,) :obj:`numpy.ndarray`
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel.
+    use_volumes : (T,) :obj:`numpy.ndarray` of bool
+        Volumes used for the shared R2*/frequency estimate.
+    n_threads : int
+        Number of threads.
+
+    Returns
+    -------
+    result : dict
+        ``(Md,)`` ``t2s``, ``r2star``, ``frequency_hz``, ``failures`` and
+        ``(Md, T)`` ``s0`` (magnitude) and ``phase0``.
+    """
+    n_samp, _, n_vols = complex_data.shape
+    echos_to_run = np.unique(adaptive_mask)
+    if 1 in echos_to_run:
+        echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+
+    r2star = np.zeros(n_samp)
+    frequency_hz = np.zeros(n_samp)
+    failures = np.zeros(n_samp, dtype=bool)
+    s0_mag = np.zeros((n_samp, n_vols))
+    phase0 = np.zeros((n_samp, n_vols))
+
+    def _fit_voxel(voxel, echo_num):
+        # (T, E) for the shared fit (used volumes only) and all volumes for S0
+        signal_all = complex_data[voxel, :echo_num, :].T
+        joint = _fit_complex_decay_joint(signal_all[use_volumes], tes[:echo_num])
+        if joint is None:
+            return voxel, None
+        s0_all = _solve_complex_s0(
+            signal_all, tes[:echo_num], joint["r2star"], joint["frequency_hz"]
+        )
+        return voxel, {"joint": joint, "s0_all": s0_all}
+
+    for echo_num in echos_to_run:
+        if echo_num == 2:
+            voxel_idx = np.where(adaptive_mask <= echo_num)[0]
+        else:
+            voxel_idx = np.where(adaptive_mask == echo_num)[0]
+
+        results = Parallel(n_jobs=n_threads)(
+            delayed(_fit_voxel)(voxel, echo_num)
+            for voxel in tqdm(voxel_idx, desc=f"{echo_num}-echo varys0 NLLS")
+        )
+
+        for voxel, res in results:
+            if res is None:
+                failures[voxel] = True
+                continue
+            joint = res["joint"]
+            r2star[voxel] = joint["r2star"]
+            frequency_hz[voxel] = joint["frequency_hz"]
+            failures[voxel] = not joint["success"]
+            s0_all = res["s0_all"]
+            s0_mag[voxel, :] = np.abs(s0_all)
+            phase0[voxel, :] = np.angle(s0_all)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
+
+    return {
+        "t2s": t2s,
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "s0": s0_mag,
+        "phase0": phase0,
+        "failures": failures,
+    }
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py -k fit_complex_decay -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tedana/decay.py tedana/tests/test_decay.py
+git commit -m "feat(decay): add fit_complex_decay nlls dispatcher (all/ts/varys0)"
+```
+
+---
+
+### Task 5: `rmse_of_fit_decay_ts` varys0 branch
+
+**Files:**
+- Modify: `tedana/decay.py:630-701` (`rmse_of_fit_decay_ts`)
+- Test: `tedana/tests/test_decay.py`
+
+**Interfaces:**
+- Consumes: existing `rmse_of_fit_decay_ts` (lines 630-736).
+- Produces: `rmse_of_fit_decay_ts(..., fitmode="varys0")` handling 3D `t2s` `(Mb,)` + 4D `s0` `(Mb, T)`. (`modify_t2s_s0_maps` is unchanged: row-indexing already broadcasts a `(Md,)` t2s and `(Md, T)` s0.)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_rmse_of_fit_decay_ts_varys0():
+    """rmse handles 3D t2s with 4D s0 for fitmode='varys0'."""
+    rng = np.random.default_rng(2)
+    tes = [0.01, 0.02, 0.03]
+    n_vox, n_echo, n_vol = 4, 3, 5
+    data = rng.uniform(50, 200, (n_vox, n_echo, n_vol))
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    t2s = np.full(n_vox, 0.04)            # (Mb,)
+    s0 = np.full((n_vox, n_vol), 150.0)   # (Mb, T)
+    rmse_map, rmse_df = me.rmse_of_fit_decay_ts(
+        data=data, tes=tes, adaptive_mask=adaptive_mask, t2s=t2s, s0=s0, fitmode="varys0"
+    )
+    assert rmse_map.shape == (n_vox,)
+    assert len(rmse_df) == n_vol
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py::test_rmse_of_fit_decay_ts_varys0 -v`
+Expected: FAIL with `ValueError: Unknown fitmode option varys0`.
+
+- [ ] **Step 3: Implement**
+
+Update the `Literal` type hint on line 637 from `Literal["all", "ts"]` to `Literal["all", "ts", "varys0"]`, then add a branch in the loop. Change lines 685-689:
+
+```python
+        elif fitmode == "ts":
+            s0_echo = s0[use_vox, :]
+            t2s_echo = t2s[use_vox, :]
+        elif fitmode == "varys0":
+            s0_echo = s0[use_vox, :]
+            t2s_echo = np.tile(t2s[use_vox][:, np.newaxis], (1, n_vols))
+        else:
+            raise ValueError(f"Unknown fitmode option {fitmode}")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py::test_rmse_of_fit_decay_ts_varys0 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tedana/decay.py tedana/tests/test_decay.py
+git commit -m "feat(decay): support fitmode='varys0' in rmse_of_fit_decay_ts"
+```
+
+---
+
+### Task 6: Output descriptors
+
+**Files:**
+- Modify: `tedana/resources/config/outputs.json` (after the `s0 variance img` entry, ~line 25)
+- Test: `tedana/tests/test_io.py` (config-load sanity) — or validate via Task 7 integration.
+
+**Interfaces:**
+- Produces config keys consumed by Task 7: `"frequency img"`, `"phase0 img"`, `"fit cost img"`, `"fit nfev img"`.
+
+- [ ] **Step 1: Add descriptors**
+
+Insert into `tedana/resources/config/outputs.json` after the `s0 variance img` block:
+
+```json
+    "frequency img": {
+        "orig": "frequencyHz",
+        "bidsv1.5.0": "frequencyHzmap"
+    },
+    "phase0 img": {
+        "orig": "phase0",
+        "bidsv1.5.0": "phase0map"
+    },
+    "fit cost img": {
+        "orig": "fit_cost",
+        "bidsv1.5.0": "desc-fitCost_statmap"
+    },
+    "fit nfev img": {
+        "orig": "fit_nfev",
+        "bidsv1.5.0": "desc-fitNfev_statmap"
+    },
+```
+
+- [ ] **Step 2: Verify JSON parses and keys load**
+
+Run:
+```bash
+cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -c "import json; from tedana.tests.utils import get_test_data_path; from importlib.resources import files; d=json.load(open(files('tedana.resources.config')/'outputs.json')); print(d['frequency img'], d['phase0 img'], d['fit cost img'], d['fit nfev img'])"
+```
+Expected: prints the four dicts without `KeyError`/`JSONDecodeError`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tedana/resources/config/outputs.json
+git commit -m "feat(io): add nlls output descriptors (frequency, phase0, cost, nfev)"
+```
+
+---
+
+### Task 7: t2smap CLI and workflow integration
+
+**Files:**
+- Modify: `tedana/workflows/t2smap.py` (parser ~lines 150-170; `--phase` near data arg; workflow signature ~line 250; validation/loading/dispatch/saving in the body)
+- Test: deferred to Task 8 (integration).
+
+**Interfaces:**
+- Consumes: `decay.fit_complex_decay` (Task 4), output descriptors (Task 6), `decay.rmse_of_fit_decay_ts(fitmode="varys0")` (Task 5).
+- Produces: `t2smap_workflow(..., phase=None, fittype in {loglin,curvefit,nlls}, fitmode in {all,ts,varys0})`.
+
+- [ ] **Step 1: Update the parser**
+
+In `_get_parser`, change `--fittype` choices (line 154) to include `nlls` and update help:
+
+```python
+        choices=["loglin", "curvefit", "nlls"],
+        help=(
+            "Desired T2*/S0 fitting method. "
+            '"loglin" means that a linear model is fit to the log of the data. '
+            '"curvefit" means that a more computationally demanding monoexponential model is fit '
+            "to the raw data. "
+            '"nlls" fits a complex monoexponential model to magnitude+phase data and requires '
+            "--phase. "
+        ),
+```
+
+Change `--fitmode` choices (line 166) to `["all", "ts", "varys0"]` and append to its help:
+
+```python
+            '"varys0" (nlls only) shares R2*/frequency across timepoints while '
+            "allowing complex S0 to vary per timepoint. "
+```
+
+Add a `--phase` argument in the Required/data group, immediately after the `-d` block (after line 42):
+
+```python
+    required_args.add_argument(
+        "--phase",
+        dest="phase",
+        nargs="+",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "Phase images for each echo, in radians, in ascending echo order "
+            "matching -d. Required when --fittype is 'nlls'."
+        ),
+        default=None,
+    )
+```
+
+- [ ] **Step 2: Update workflow signature and validation**
+
+Add `phase=None` to `t2smap_workflow` parameters (after `data,`/`tes,`, near line 241). Add validation after the existing `fitmode == "ts" and n_exclude > 0` check (after line 387):
+
+```python
+    if fittype == "nlls" and phase is None:
+        raise ValueError("fittype='nlls' requires phase images (--phase).")
+    if phase is not None and fittype != "nlls":
+        raise ValueError("phase images are only used with fittype='nlls'.")
+    if fitmode == "varys0" and fittype != "nlls":
+        raise ValueError("fitmode='varys0' is only valid with fittype='nlls'.")
+    if fitmode == "ts" and n_exclude > 0:
+        # already handled above; varys0 intentionally permits exclude
+        pass
+    if isinstance(phase, str):
+        phase = [phase]
+    if phase is not None and len(phase) != len(data if isinstance(data, list) else [data]):
+        raise ValueError("--phase must have the same number of files as -d.")
+```
+
+(Place the `isinstance(data, str)` coercion at line 395 before this length check, or reuse the existing coercion — ensure `data` is a list first.)
+
+- [ ] **Step 3: Load phase and dispatch the complex fit**
+
+After `data_cat` is loaded and trimmed (after line 446, where `data_without_excluded_vols` is built), load phase and branch. Replace the estimation block (lines 458-487) with:
+
+```python
+    LGR.info("Computing T2* map")
+    data_fit = data_without_excluded_vols[mask_denoise, ...]
+    masksum_masked = masksum_denoise[mask_denoise]
+
+    if fittype == "nlls":
+        phase_cat = io.load_data_nilearn(phase, mask_img=mask_img, n_echos=n_echos)
+        if dummy_scans > 0:
+            phase_cat = phase_cat[..., dummy_scans:]
+        if phase_cat.shape != data_cat.shape:
+            raise ValueError(
+                f"Phase shape {phase_cat.shape} does not match data shape {data_cat.shape}."
+            )
+        # For varys0, pass all volumes plus a use_volumes mask; otherwise drop excluded volumes.
+        if fitmode == "varys0":
+            phase_fit = phase_cat[mask_denoise, ...]
+            data_complex_mag = data_cat[mask_denoise, ...]
+            if n_exclude > 0:
+                vol_mask = use_volumes
+            else:
+                vol_mask = np.ones(n_vols, dtype=bool)
+            complex_results = decay.fit_complex_decay(
+                data=data_complex_mag, phase=phase_fit, tes=tes,
+                adaptive_mask=masksum_masked, fitmode="varys0",
+                use_volumes=vol_mask, n_threads=n_threads,
+            )
+        else:
+            phase_fit = phase_cat[..., :][mask_denoise, ...] if n_exclude == 0 else \
+                phase_cat[:, :, use_volumes][mask_denoise, ...]
+            complex_results = decay.fit_complex_decay(
+                data=data_fit, phase=phase_fit, tes=tes,
+                adaptive_mask=masksum_masked, fitmode=fitmode, n_threads=n_threads,
+            )
+        t2s_full = complex_results["t2s"]
+        s0_full = complex_results["s0"]
+        failures = complex_results["failures"]
+        t2s_var = s0_var = t2s_s0_covar = None
+    else:
+        decay_function = decay.fit_decay if fitmode == "all" else decay.fit_decay_ts
+        t2s_full, s0_full, failures, t2s_var, s0_var, t2s_s0_covar = decay_function(
+            data=data_fit, tes=tes, adaptive_mask=masksum_masked,
+            fittype=fittype, n_threads=n_threads,
+        )
+    del data_without_excluded_vols
+```
+
+Note: `data_fit` replaces the prior in-place reassignment of `data_without_excluded_vols`; keep `del data_without_excluded_vols` and remove the old `data_without_excluded_vols = data_without_excluded_vols[mask_denoise, ...]` line (459) and `masksum_masked` line (460), since they are now set above.
+
+- [ ] **Step 4: Save fit-quality and nlls maps**
+
+Replace the `if fittype == "curvefit":` save block (lines 471-484) with:
+
+```python
+    if fittype in ("curvefit", "nlls"):
+        io_generator.save_file(
+            failures.astype(np.uint8), "fit failures img", mask=mask_denoise
+        )
+    if fittype == "curvefit" and verbose:
+        io_generator.save_file(t2s_var, "t2star variance img", mask=mask_denoise)
+        io_generator.save_file(s0_var, "s0 variance img", mask=mask_denoise)
+        io_generator.save_file(t2s_s0_covar, "t2star-s0 covariance img", mask=mask_denoise)
+
+    if fittype == "nlls":
+        io_generator.save_file(
+            utils.unmask(complex_results["frequency_hz"], mask_denoise), "frequency img"
+        )
+        io_generator.save_file(
+            utils.unmask(complex_results["phase0"], mask_denoise), "phase0 img"
+        )
+```
+
+(Keep the existing `del failures, t2s_var, s0_var, t2s_s0_covar` line; guard it or set the unused ones to `None` for nlls as above so the `del` still works.)
+
+- [ ] **Step 5: Pass fitmode to RMSE**
+
+The RMSE call (line 506-513) already passes `fitmode=fitmode`; confirm it now receives `"varys0"` when applicable (no change needed beyond Task 5).
+
+- [ ] **Step 6: Run the full t2smap test module (regression)**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_t2smap.py -v`
+Expected: existing tests PASS (no nlls tests yet; this confirms no regressions).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tedana/workflows/t2smap.py
+git commit -m "feat(t2smap): add --fittype nlls, --phase, and --fitmode varys0"
+```
+
+---
+
+### Task 8: Integration tests for nlls
+
+**Files:**
+- Modify: `tedana/tests/test_t2smap.py`
+- Reference: existing fixtures/patterns in `test_t2smap.py` and three-echo test data via `tedana.tests.utils.get_test_data_path` (`echo1.nii.gz`..`echo3.nii.gz`, `mask.nii.gz`).
+
+**Interfaces:**
+- Consumes: `t2smap_workflow` (Task 7).
+
+- [ ] **Step 1: Write a helper to synthesize phase files and the failing tests**
+
+Add to `tedana/tests/test_t2smap.py` (imports `os.path as op`, `numpy as np`, `nibabel as nb`, `pytest`, `get_test_data_path`, and `from tedana.workflows import t2smap_workflow`):
+
+```python
+def _make_zero_phase_files(echo_files, out_dir):
+    """Write zero-valued phase NIfTIs matching the given magnitude echoes."""
+    phase_files = []
+    for i, f in enumerate(echo_files):
+        img = nb.load(f)
+        phase = nb.Nifti1Image(np.zeros(img.shape, dtype=np.float32), img.affine, img.header)
+        path = op.join(out_dir, f"phase{i + 1}.nii.gz")
+        phase.to_filename(path)
+        phase_files.append(path)
+    return phase_files
+
+
+@pytest.mark.parametrize("fitmode", ["all", "ts", "varys0"])
+def test_t2smap_nlls(tmp_path, fitmode):
+    """t2smap runs with fittype='nlls' across fitmodes and writes expected maps."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    mask = op.join(data_dir, "mask.nii.gz")
+    phase_files = _make_zero_phase_files(echo_files, str(tmp_path))
+    t2smap_workflow(
+        data=echo_files,
+        tes=[14.5, 38.5, 62.5],
+        phase=phase_files,
+        mask=mask,
+        fittype="nlls",
+        fitmode=fitmode,
+        out_dir=str(tmp_path),
+    )
+    assert op.exists(op.join(tmp_path, "T2starmap.nii.gz"))
+    assert op.exists(op.join(tmp_path, "S0map.nii.gz"))
+    assert op.exists(op.join(tmp_path, "frequencyHzmap.nii.gz"))
+    assert op.exists(op.join(tmp_path, "phase0map.nii.gz"))
+    assert op.exists(op.join(tmp_path, "desc-optcom_bold.nii.gz"))
+    # varys0 should produce a 4D S0 timeseries; all/ts produce maps too
+    s0 = nb.load(op.join(tmp_path, "S0map.nii.gz"))
+    if fitmode == "varys0":
+        assert s0.ndim == 4
+
+
+def test_t2smap_nlls_requires_phase(tmp_path):
+    """fittype='nlls' without --phase raises."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    with pytest.raises(ValueError, match="requires phase"):
+        t2smap_workflow(
+            data=echo_files, tes=[14.5, 38.5, 62.5],
+            fittype="nlls", out_dir=str(tmp_path),
+        )
+
+
+def test_t2smap_varys0_requires_nlls(tmp_path):
+    """fitmode='varys0' with a non-nlls fittype raises."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    with pytest.raises(ValueError, match="varys0"):
+        t2smap_workflow(
+            data=echo_files, tes=[14.5, 38.5, 62.5],
+            fittype="loglin", fitmode="varys0", out_dir=str(tmp_path),
+        )
+```
+
+(Confirm the actual TEs for the test data from existing `test_t2smap.py`; reuse whatever value the existing tests pass to `tes`.)
+
+- [ ] **Step 2: Run to verify failures (pre-fix) / passes (post-Task-7)**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_t2smap.py -k nlls -v`
+Expected: PASS (Tasks 4-7 already implemented). If a 4D-S0 assertion fails, inspect the `varys0` save path in Task 7 Step 3/4.
+
+- [ ] **Step 3: Run the whole decay + t2smap suites**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/tsalo/tedana && python -m pytest tedana/tests/test_decay.py tedana/tests/test_t2smap.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tedana/tests/test_t2smap.py
+git commit -m "test(t2smap): integration tests for complex nlls fitting"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** `--fittype nlls` (Task 7), `--phase` (Task 7), `--fitmode varys0` (Tasks 4/5/7), complex model + per-sample fit (Task 1), adaptive-mask driver/`all` (Task 2), joint fit (Task 3), dispatcher/`ts`/`varys0` + `use_volumes`/exclude (Task 4/7), downstream RMSE shape handling (Task 5), `modify_t2s_s0_maps` reuse verified unchanged (Task 5 note), extra output maps (Task 6/7), tests (Tasks 1-5, 8). Modulation explicitly deferred (Task 1 model hook). Dahnke future work: out of scope, no task — correct.
+- **Placeholder scan:** none — all steps carry runnable code/commands.
+- **Type consistency:** `fit_complex_decay` returns a dict consumed by the workflow in Task 7; `frequency_hz`/`phase0`/`failures`/`t2s`/`s0` keys match across Tasks 2, 4, 7. `_solve_complex_s0`/`_fit_complex_decay_joint` signatures match their callers in Task 4.
+- **Open verification during execution:** in Task 7, confirm the exact line numbers for the estimation block and the `data_without_excluded_vols[mask_denoise]` reassignment, since edits there are the trickiest; and confirm the test-data TEs in Task 8 against the existing `test_t2smap.py`.

--- a/docs/superpowers/specs/2026-06-23-t2smap-complex-nlls-design.md
+++ b/docs/superpowers/specs/2026-06-23-t2smap-complex-nlls-design.md
@@ -1,0 +1,219 @@
+# Design: Complex NLLS T2*/S0 fitting for t2smap
+
+Date: 2026-06-23
+
+## Summary
+
+Add a complex non-linear least-squares (NLLS) decay fit to the `t2smap`
+workflow, ported from the `dahnke` subpackage's `fit_complex_decay_nlls`
+(in `complex-tedana/dahnke/src/dahnke/correction.py`). The complex model
+jointly estimates `R2*`, complex `S0`, off-resonance `frequency_hz`, and
+initial phase `phase0` from complex data `magnitude · exp(i·phase)` per voxel
+using `scipy.optimize.least_squares`.
+
+Three user-facing additions:
+
+- A new `--fittype nlls` option.
+- A new `--phase` argument supplying per-echo phase NIfTI files (radians).
+- A new `--fitmode varys0` option (nlls-only) for the shared-R2*/frequency,
+  per-volume-complex-S0 joint fit.
+
+The Dahnke through-slice modulation / gradient / slice-profile machinery is
+**not** ported in this project; modulation is implicitly 1. Only the core
+complex decay estimator is ported. Dahnke correction is intended as a future
+addition that will build on this complex NLLS foundation — it is deferred, not
+abandoned (see "Future work" below).
+
+## Scope decisions (confirmed)
+
+1. **Core NLLS only** — port the per-voxel complex monoexponential fit; drop
+   the modulation/gradient/slice-profile code.
+2. **Extra outputs** — write `frequency_hz`, `phase0`, and fit-quality
+   (success/cost/nfev) maps.
+3. **Fitmodes** — `nlls` supports the standard fitmodes, plus a new `varys0`
+   joint-fit mode (see below).
+4. `varys0` is **nlls-only** (error if combined with `loglin`/`curvefit`).
+5. `varys0` outputs **3D** R2*/T2*/frequency maps and **4D** S0-magnitude
+   (and 4D phase0) timeseries.
+
+## The model
+
+`complex_decay_model(te, s0, r2star, frequency_hz)`:
+
+```
+signal(te) = s0 * exp((-r2star + i·2π·frequency_hz) · te)
+```
+
+where `s0` is complex. Fit parameters are
+`[log(|S0|), R2*, frequency_hz, phase0]`, with `s0 = exp(log|S0|) · exp(i·phase0)`.
+Residuals are the concatenation of real and imaginary parts of
+`(predicted - observed)`. Initial parameters come from a log-linear fit of the
+magnitude (slope → R2*, intercept → log|S0|) and an unwrapped-phase linear fit
+(slope → frequency_hz, intercept → phase0), ported from
+`_initial_complex_decay_params`.
+
+## CLI changes (`tedana/workflows/t2smap.py`)
+
+- `--fittype` choices → `["loglin", "curvefit", "nlls"]`; help text updated to
+  describe `nlls` and that it requires `--phase`.
+- `--fitmode` choices → `["all", "ts", "varys0"]`; help text updated.
+- New `--phase` argument: `nargs="+"`, `metavar="FILE"`, validated via
+  `is_valid_file`, in the data/masking group, default `None`. Help: per-echo
+  phase NIfTI files in radians, in ascending echo order, required for `nlls`.
+- `t2smap_workflow` signature gains `phase=None`.
+
+### Validation (in `t2smap_workflow`)
+
+- `fittype == "nlls"` requires `phase is not None` → else `ValueError`.
+- `phase is not None` requires `len(phase) == len(data)` and matching shapes
+  after loading → else `ValueError`.
+- `phase is not None` with `fittype != "nlls"` → `ValueError` (phase only used
+  by nlls).
+- `fitmode == "varys0"` requires `fittype == "nlls"` → else `ValueError`.
+- Existing constraint retained: excluding volumes is unsupported with `ts`.
+  `varys0` **permits** `exclude`: because R2*/frequency are shared across
+  volumes, the goal is an accurate shared T2* uncontaminated by excluded
+  volumes, while per-volume S0 is secondary. Excluded volumes are dropped from
+  the shared R2*/frequency estimation only.
+
+## Data flow in the workflow
+
+1. Magnitude data loaded as today → `data_cat` (samples × echos × time).
+2. When `phase` is provided, phase loaded identically
+   (`io.load_data_nilearn`), with the same dummy-scan trimming and `exclude`
+   handling, producing `phase_cat` of the same shape. Shape mismatch → error.
+3. **Adaptive mask, `make_optcom`, and RMSE continue to use magnitude
+   `data_cat` only** — unchanged behavior.
+4. The T2*/S0 estimation step receives the complex data. The masked magnitude
+   and masked phase are passed to the decay functions; the complex array
+   `magnitude · exp(i·phase)` is formed inside `decay.py`.
+5. The written `S0` map is `np.abs(complex S0)`. Real `T2*` flows through
+   `modify_t2s_s0_maps` / floor logic unchanged.
+
+### Dispatch
+
+`fit_decay` is also called by the main `tedana` workflow (`workflows/tedana.py`)
+and unpacks exactly six return values, so its signature must **not** change.
+Therefore the complex path uses a **dedicated entry point** rather than
+extending `fit_decay`:
+
+```
+if fittype == "nlls":
+    complex_results = decay.fit_complex_decay(
+        data=...,            # masked magnitude (Md x E x T)
+        phase=...,           # masked phase, radians (Md x E x T)
+        tes=tes,
+        adaptive_mask=...,
+        fitmode=fitmode,     # "all", "ts", or "varys0"
+        use_volumes=...,     # boolean (T,) volume mask; None == all volumes
+        n_threads=n_threads,
+    )
+    # dict with keys: t2s, s0, frequency_hz, phase0, failures, cost, nfev
+else:
+    decay_function = decay.fit_decay if fitmode == "all" else decay.fit_decay_ts
+    t2s_full, s0_full, failures, t2s_var, s0_var, t2s_s0_covar = decay_function(...)
+```
+
+`fit_decay`/`fit_decay_ts` are left untouched (loglin/curvefit only).
+`fit_complex_decay` is the single new public dispatcher for nlls; it routes to
+the per-mode helpers below.
+
+## New code in `tedana/decay.py`
+
+Ported from `dahnke`, stripped of modulation:
+
+- `complex_decay_model(echo_times, s0, r2star, frequency_hz)` — the model.
+- `_initial_complex_decay_params(signal, echo_times)` — loglin + phase init.
+- `_fit_complex_decay_1d(signal, echo_times, bounds, max_nfev)` — per-sample
+  fit returning `s0, r2star, frequency_hz, phase0, cost, nfev, success`.
+  Returns failure sentinel when fewer than 2 finite echoes are available or the
+  optimizer raises.
+- `fit_complex_monoexponential(data_cat, phase_cat, echo_times, adaptive_mask,
+  report, n_threads)` — mirrors `fit_monoexponential`'s adaptive-mask echo-group
+  loop (`echos_to_run`, first-`echo_num`-echoes, limited/full assembly via
+  `echo_masks`), but calls the complex fitter. Returns `t2s, s0` (magnitude)
+  plus `frequency_hz`, `phase0`, and `failures` arrays. Parallelized with
+  `joblib` like `fit_monoexponential`.
+- `_fit_complex_decay_joint(signal, echo_times, max_r2star, max_frequency_hz,
+  max_nfev)` — ported joint fit: shared R2*/frequency, per-volume complex S0
+  estimated analytically (linear for fixed R2*/frequency). Returns per-volume
+  `s0`/`phase0`, scalar `r2star`/`frequency_hz`, and optimizer diagnostics.
+- `fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes,
+  n_threads)` — the public nlls dispatcher. Forms the complex array and routes:
+  - `"all"`  → `fit_complex_monoexponential` (single fit per voxel) → returns a
+    dict with `(Md,)` arrays.
+  - `"ts"`   → loops volumes calling `fit_complex_monoexponential` per volume
+    (mirroring `fit_decay_ts`) → `(Md, T)` arrays.
+  - `"varys0"` → `_fit_complex_decay_joint` per voxel over the `use_volumes`
+    subset for shared R2*/frequency, then analytic per-volume S0 over **all**
+    volumes → `t2s`/`frequency_hz` `(Md,)`, `s0`/`phase0` `(Md, T)`.
+
+`fit_decay`/`fit_decay_ts` are unchanged. The extra `frequency_hz`/`phase0`/
+diagnostics are returned only through `fit_complex_decay`'s result dict.
+
+## Downstream shape handling
+
+- `all` (nlls): single complex fit over all (echo, time) samples per voxel,
+  one `S0`/`phase0`/`R2*`/`frequency_hz` per voxel → 3D maps. Mirrors
+  `curvefit`'s flatten approach.
+- `ts`: per-timepoint complex fit → 4D maps, as for curvefit.
+- `varys0`: 3D `T2*`/`R2*`/`frequency_hz`, 4D `S0`-magnitude and 4D `phase0`.
+  - Shared R2*/frequency are fit from the **non-excluded** volumes only. The
+    per-volume complex S0 (linear given fixed R2*/frequency) is then computed
+    for **all** retained volumes — including any `exclude`d ones — by analytic
+    solve, yielding a full-length 4D S0/phase0 timeseries. To do this,
+    `fit_decay_varys0` receives both the full data and a boolean
+    `use_volumes` mask (the workflow already computes this for `exclude`).
+  - `modify_t2s_s0_maps`: floor the 3D T2*; apply the limited-map masking to
+    the 4D S0 by broadcasting the adaptive mask across the time axis.
+  - `make_optcom`: uses the 3D T2* for echo weighting (unchanged).
+  - `rmse_of_fit_decay_ts`: handle 3D-T2* / 4D-S0 by broadcasting T2* across
+    time when reconstructing the per-volume model fit.
+
+## Outputs (`tedana/resources/config/outputs.json`)
+
+New descriptors:
+
+- `frequency img` → orig `frequencyHz`, bids `frequencyHzmap`.
+- `phase0 img` → orig `phase0`, bids `phase0map`.
+- `fit cost img` → orig `fit_cost`, bids `desc-fitCost_statmap` (verbose only).
+- `fit nfev img` → orig `fit_nfev`, bids `desc-fitNfev_statmap` (verbose only).
+
+Fit failures reuse the existing `fit failures img` descriptor (derived from
+`success`). `frequency img` and `phase0 img` are written whenever
+`fittype == "nlls"`; cost/nfev under `--verbose`.
+
+## Testing (TDD)
+
+Unit tests (`tedana/tests/test_decay.py`):
+
+- `complex_decay_model` returns the analytic complex signal.
+- `_fit_complex_decay_1d` recovers known `R2*`, `|S0|`, `frequency_hz`,
+  `phase0` from noiseless synthetic complex decay; degrades gracefully with
+  noise; returns failure with <2 finite echoes.
+- `fit_complex_monoexponential` respects the adaptive-mask echo grouping.
+- `_fit_complex_decay_joint` / `fit_decay_varys0` recover shared R2*/frequency
+  with per-volume S0.
+
+Integration test (`tedana/tests/test_t2smap.py`): run
+`t2smap_workflow(fittype="nlls", phase=...)` on the existing five-echo test
+data (synthesizing zero/known phase), asserting the expected output files exist
+and have correct shapes for `all`, `ts`, and `varys0`. Validation-error tests
+for the constraint matrix above.
+
+## Out of scope (this project)
+
+- Dahnke modulation / gradient / slice-profile correction.
+- Adding `nlls`/`--phase` to the main `tedana` workflow (this spec is
+  `t2smap`-only).
+- A magnitude-only `varys0` analog for loglin/curvefit.
+
+## Future work
+
+- **Dahnke correction.** The full Dahnke through-slice modulation / gradient /
+  slice-profile correction (present in the `dahnke` subpackage's
+  `fit_complex_decay_nlls`) is a planned future addition. The complex NLLS
+  model, per-sample fitter, and joint fit ported here are deliberately designed
+  so the modulation term can be reintroduced later (the model already
+  multiplies by a `modulation` factor of 1). This project intentionally defers
+  it to keep the scope focused; it is not being abandoned.

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -333,7 +333,7 @@ def fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True
             phase0[voxel] = res["phase0"]
             failures[voxel] = not res["success"]
 
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
         t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
 
     return {
@@ -607,7 +607,7 @@ def _fit_complex_decay_varys0(complex_data, tes, adaptive_mask, use_volumes, n_t
             s0_mag[voxel, :] = np.abs(s0_all)
             phase0[voxel, :] = np.angle(s0_all)
 
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
         t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
 
     return {

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -431,7 +431,6 @@ def _fit_complex_decay_joint(
     """
     signal = np.asarray(signal)
     echo_times = np.asarray(echo_times, dtype=float)
-    n_vols = signal.shape[0]
     valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
     valid_vols = np.flatnonzero(valid.sum(axis=1) >= 2)
     if valid_vols.size == 0:
@@ -1122,7 +1121,8 @@ def modify_t2s_s0_maps(t2s, s0, adaptive_mask, tes):
     :math:`T_2^*` values less than or equal to zero with 0.001 s.
     Additionally, very small :math:`T_2^*` values above zero are replaced with a floor
     value to prevent zero-division errors later on in the workflow.
-    It also replaces NaN, infinite, and float32-unrepresentable values in the :math:`S_0` map with 0.
+    It also replaces NaN, infinite, and float32-unrepresentable values in the :math:`S_0` map
+    with 0.
     """
     # Apply floors and ceilings to the T2* and S0 maps
     t2s[np.isinf(t2s)] = 0.5  # why 0.5 s?

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -1131,7 +1131,7 @@ def rmse_of_fit_decay_ts(
     adaptive_mask: np.ndarray,
     t2s: np.ndarray,
     s0: np.ndarray,
-    fitmode: Literal["all", "ts"],
+    fitmode: Literal["all", "ts", "varys0"],
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Estimate model fit of voxel- and timepoint-wise monoexponential decay models to ``data``.
 
@@ -1182,6 +1182,9 @@ def rmse_of_fit_decay_ts(
         elif fitmode == "ts":
             s0_echo = s0[use_vox, :]
             t2s_echo = t2s[use_vox, :]
+        elif fitmode == "varys0":
+            s0_echo = s0[use_vox, :]
+            t2s_echo = np.tile(t2s[use_vox][:, np.newaxis], (1, n_vols))
         else:
             raise ValueError(f"Unknown fitmode option {fitmode}")
 

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -252,6 +252,99 @@ def _fit_complex_decay_1d(signal, echo_times, *, lower_bounds, upper_bounds, max
     }
 
 
+def fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
+    """Fit a complex monoexponential decay model per voxel across all timepoints.
+
+    Echoes and timepoints are flattened into a single fit per voxel (the
+    complex analog of the ``fittype="curvefit"``/``fitmode="all"`` scheme),
+    using the adaptive mask to choose how many echoes each voxel uses.
+
+    Parameters
+    ----------
+    data_cat : (Md x E x T) :obj:`numpy.ndarray`
+        Complex multi-echo data. Md is samples in the denoising mask.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel. See ``make_adaptive_mask``.
+    report : bool, optional
+        Whether to log a description of this step. Default is True.
+    n_threads : int, optional
+        Number of threads. If None or <= 0, uses all CPU cores.
+
+    Returns
+    -------
+    result : dict
+        ``(Md,)`` arrays ``t2s``, ``s0`` (magnitude), ``r2star``,
+        ``frequency_hz``, ``phase0``, and boolean ``failures``.
+    """
+    if n_threads is None or n_threads <= 0:
+        n_threads = os.cpu_count() or 1
+    if report:
+        RepLGR.info(
+            "A complex monoexponential model was fit to the magnitude and "
+            "phase data at each voxel using nonlinear least squares, jointly "
+            "estimating T2*, S0, off-resonance frequency, and initial phase."
+        )
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_samp, _, n_vols = data_cat.shape
+
+    echos_to_run = np.unique(adaptive_mask)
+    if 1 in echos_to_run:
+        echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+
+    lower_bounds = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper_bounds = np.array([np.inf, np.inf, np.inf, np.inf])
+
+    r2star = np.zeros(n_samp)
+    s0_mag = np.zeros(n_samp)
+    frequency_hz = np.zeros(n_samp)
+    phase0 = np.zeros(n_samp)
+    failures = np.zeros(n_samp, dtype=bool)
+
+    for echo_num in echos_to_run:
+        if echo_num == 2:
+            voxel_idx = np.where(adaptive_mask <= echo_num)[0]
+        else:
+            voxel_idx = np.where(adaptive_mask == echo_num)[0]
+
+        data_2d = data_cat[:, :echo_num, :].reshape(n_samp, -1)
+        echo_times_1d = np.repeat(echo_times[:echo_num], n_vols)
+
+        results = Parallel(n_jobs=n_threads)(
+            delayed(_fit_complex_decay_1d)(
+                data_2d[voxel],
+                echo_times_1d,
+                lower_bounds=lower_bounds,
+                upper_bounds=upper_bounds,
+            )
+            for voxel in tqdm(voxel_idx, desc=f"{echo_num}-echo complex NLLS")
+        )
+
+        for voxel, res in zip(voxel_idx, results):
+            if res is None:
+                failures[voxel] = True
+                continue
+            r2star[voxel] = res["r2star"]
+            s0_mag[voxel] = np.abs(res["s0"])
+            frequency_hz[voxel] = res["frequency_hz"]
+            phase0[voxel] = res["phase0"]
+            failures[voxel] = not res["success"]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
+
+    return {
+        "t2s": t2s,
+        "s0": s0_mag,
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "phase0": phase0,
+        "failures": failures,
+    }
+
+
 def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
     """Fit monoexponential decay model with nonlinear curve-fitting.
 

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -16,6 +16,13 @@ from tedana import utils
 LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 
+# Brain T2* at typical field strengths is well under a second. This generous
+# ceiling leaves real estimates untouched while preventing the nonlinear fits
+# from driving R2* toward 0, which would send T2* = 1/R2* to absurd (and, once
+# cast to float32, infinite) values.
+MAX_PHYSIOLOGICAL_T2STAR = 5.0  # seconds
+MIN_R2STAR = 1.0 / MAX_PHYSIOLOGICAL_T2STAR  # s^-1
+
 
 def _apply_t2s_floor(t2s, echo_times):
     """Apply a floor to T2* values to prevent zero division errors during optimal combination.
@@ -295,7 +302,9 @@ def fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True
         echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
     echos_to_run = echos_to_run[echos_to_run >= 2]
 
-    lower_bounds = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    # R2* is bounded below by MIN_R2STAR so a (near-)flat decay cannot drive
+    # T2* = 1/R2* toward infinity.
+    lower_bounds = np.array([-np.inf, MIN_R2STAR, -np.inf, -np.inf])
     upper_bounds = np.array([np.inf, np.inf, np.inf, np.inf])
 
     r2star = np.zeros(n_samp)
@@ -385,7 +394,13 @@ def _solve_complex_s0(signal, echo_times, r2star, frequency_hz):
 
 
 def _fit_complex_decay_joint(
-    signal, echo_times, *, max_r2star=np.inf, max_frequency_hz=np.inf, max_nfev=None
+    signal,
+    echo_times,
+    *,
+    min_r2star=0.0,
+    max_r2star=np.inf,
+    max_frequency_hz=np.inf,
+    max_nfev=None,
 ):
     """Fit one voxel with shared R2*/frequency and per-volume complex S0.
 
@@ -398,6 +413,8 @@ def _fit_complex_decay_joint(
         Complex data for one voxel; volumes on axis 0, echoes on axis 1.
     echo_times : (E,) array_like
         Echo times in seconds.
+    min_r2star : float, optional
+        Lower bound for R2* in s^-1. Default is 0.0.
     max_r2star : float, optional
         Upper bound for R2* in s^-1. Default is inf.
     max_frequency_hz : float, optional
@@ -426,7 +443,7 @@ def _fit_complex_decay_joint(
             for vol in valid_vols
         ]
     )
-    lower_bounds = np.array([0.0, -max_frequency_hz])
+    lower_bounds = np.array([min_r2star, -max_frequency_hz])
     upper_bounds = np.array([max_r2star, max_frequency_hz])
     x0 = np.array([float(np.nanmedian(initial[:, 1])), float(np.nanmedian(initial[:, 2]))])
     x0 = np.minimum(np.maximum(x0, lower_bounds), upper_bounds)
@@ -506,9 +523,7 @@ def fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None
     n_samp, _, n_vols = complex_data.shape
 
     if fitmode == "all":
-        return fit_complex_monoexponential(
-            complex_data, tes, adaptive_mask, n_threads=n_threads
-        )
+        return fit_complex_monoexponential(complex_data, tes, adaptive_mask, n_threads=n_threads)
 
     if fitmode == "ts":
         keys = ("t2s", "s0", "r2star", "frequency_hz", "phase0")
@@ -534,9 +549,7 @@ def fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None
             use_volumes = np.ones(n_vols, dtype=bool)
         else:
             use_volumes = np.asarray(use_volumes, dtype=bool)
-        return _fit_complex_decay_varys0(
-            complex_data, tes, adaptive_mask, use_volumes, n_threads
-        )
+        return _fit_complex_decay_varys0(complex_data, tes, adaptive_mask, use_volumes, n_threads)
 
     raise ValueError(f"Unknown fitmode option: {fitmode}")
 
@@ -578,7 +591,9 @@ def _fit_complex_decay_varys0(complex_data, tes, adaptive_mask, use_volumes, n_t
     def _fit_voxel(voxel, echo_num):
         # (T, E) for the shared fit (used volumes only) and all volumes for S0
         signal_all = complex_data[voxel, :echo_num, :].T
-        joint = _fit_complex_decay_joint(signal_all[use_volumes], tes[:echo_num])
+        joint = _fit_complex_decay_joint(
+            signal_all[use_volumes], tes[:echo_num], min_r2star=MIN_R2STAR
+        )
         if joint is None:
             return voxel, None
         s0_all = _solve_complex_s0(
@@ -1126,6 +1141,10 @@ def modify_t2s_s0_maps(t2s, s0, adaptive_mask, tes):
     # anything that is 10x higher than the 99.5 %ile will be reset to 99.5 %ile
     cap_t2s = stats.scoreatpercentile(t2s_limited.flatten(), 99.5, interpolation_method="lower")
     LGR.debug(f"Setting cap on T2* map at {cap_t2s * 10:.5f}")
+    # Apply the cap to both the full and limited maps. Without it, blown-up
+    # finite estimates from a poorly constrained fit leak into the full map (and
+    # overflow to +Inf when saved as float32).
+    t2s[t2s > cap_t2s * 10] = cap_t2s
     t2s_limited[t2s_limited > cap_t2s * 10] = cap_t2s
 
     return t2s, s0, t2s_limited, s0_limited

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -167,6 +167,8 @@ def _initial_complex_decay_params(signal, echo_times):
         intercept -> log|S0|) and an unwrapped-phase linear fit
         (slope -> frequency_hz, intercept -> phase0).
     """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
     amplitude = np.maximum(np.abs(signal), np.finfo(float).tiny)
     if echo_times.size > 1:
         slope, intercept = np.polyfit(echo_times, np.log(amplitude), 1)

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -532,6 +532,8 @@ def fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None
     if fitmode == "varys0":
         if use_volumes is None:
             use_volumes = np.ones(n_vols, dtype=bool)
+        else:
+            use_volumes = np.asarray(use_volumes, dtype=bool)
         return _fit_complex_decay_varys0(
             complex_data, tes, adaptive_mask, use_volumes, n_threads
         )
@@ -1105,13 +1107,15 @@ def modify_t2s_s0_maps(t2s, s0, adaptive_mask, tes):
     :math:`T_2^*` values less than or equal to zero with 0.001 s.
     Additionally, very small :math:`T_2^*` values above zero are replaced with a floor
     value to prevent zero-division errors later on in the workflow.
-    It also replaces NaN values in the :math:`S_0` map with 0.
+    It also replaces NaN, infinite, and float32-unrepresentable values in the :math:`S_0` map with 0.
     """
     # Apply floors and ceilings to the T2* and S0 maps
     t2s[np.isinf(t2s)] = 0.5  # why 0.5 s?
     t2s[t2s <= 0] = 0.001  # set negative values to a small positive value
     t2s = _apply_t2s_floor(t2s, tes)
-    s0[np.isnan(s0)] = 0.0  # why 0?
+    # Zero out NaN, inf, and values too large to represent in float32
+    s0_f32_max = np.finfo(np.float32).max
+    s0[~np.isfinite(s0) | (np.abs(s0) > s0_f32_max)] = 0.0
 
     t2s_limited = t2s.copy()
     s0_limited = s0.copy()
@@ -1154,8 +1158,8 @@ def rmse_of_fit_decay_ts(
         :func:`~tedana.decay.fit_decay_ts`.
     s0 : (Mb [x T]) :obj:`numpy.ndarray`
         Voxel-wise (and possibly volume-wise) S0 estimates from :func:`~tedana.decay.fit_decay_ts`.
-    fitmode : {"fit", "all"}
-        Whether the T2* and S0 estimates are volume-wise ("fit") or not ("all").
+    fitmode : {"all", "ts", "varys0"}
+        Whether the T2* and S0 estimates are volume-wise ("ts", "varys0") or not ("all").
 
     Returns
     -------

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -220,8 +220,9 @@ def _fit_complex_decay_1d(signal, echo_times, *, lower_bounds, upper_bounds, max
 
     def residuals(params):
         log_s0_abs, r2, freq, phi0 = params
-        pred = complex_decay_model(te_valid, np.exp(log_s0_abs) * np.exp(1j * phi0), r2, freq)
-        residual = pred - y_valid
+        with np.errstate(over="ignore", invalid="ignore"):
+            pred = complex_decay_model(te_valid, np.exp(log_s0_abs) * np.exp(1j * phi0), r2, freq)
+            residual = pred - y_valid
         return np.concatenate([residual.real, residual.imag])
 
     try:
@@ -367,7 +368,8 @@ def _solve_complex_s0(signal, echo_times, r2star, frequency_hz):
     signal = np.asarray(signal)
     echo_times = np.asarray(echo_times, dtype=float)
     n_vols = signal.shape[0]
-    decay = np.exp((-r2star + 1j * 2.0 * np.pi * frequency_hz) * echo_times)
+    with np.errstate(over="ignore", invalid="ignore"):
+        decay = np.exp((-r2star + 1j * 2.0 * np.pi * frequency_hz) * echo_times)
     s0 = np.full(n_vols, np.nan + 1j * np.nan, dtype=np.complex128)
     valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
     for vol in range(n_vols):
@@ -431,15 +433,16 @@ def _fit_complex_decay_joint(
 
     def residuals(params):
         r2, freq = params
-        s0_est = _solve_complex_s0(signal, echo_times, r2, freq)
-        parts = []
-        for vol in valid_vols:
-            if not np.isfinite(s0_est[vol]):
-                continue
-            echo_mask = valid[vol]
-            pred = complex_decay_model(echo_times[echo_mask], s0_est[vol], r2, freq)
-            residual = pred - signal[vol, echo_mask]
-            parts.extend([residual.real, residual.imag])
+        with np.errstate(over="ignore", invalid="ignore"):
+            s0_est = _solve_complex_s0(signal, echo_times, r2, freq)
+            parts = []
+            for vol in valid_vols:
+                if not np.isfinite(s0_est[vol]):
+                    continue
+                echo_mask = valid[vol]
+                pred = complex_decay_model(echo_times[echo_mask], s0_est[vol], r2, freq)
+                residual = pred - signal[vol, echo_mask]
+                parts.extend([residual.real, residual.imag])
         return np.concatenate(parts)
 
     try:

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -120,6 +120,136 @@ def _fit_single_voxel(voxel, echo_times_1d, data_column, s0_init, t2s_init, boun
         return (voxel, None, None, True, None, None, None)
 
 
+def complex_decay_model(echo_times, s0, r2star, frequency_hz=0.0, modulation=1.0):
+    """Evaluate a single-pool complex R2* decay model.
+
+    The model is ``S(TE) = S0 * exp((-R2* + 1j*2*pi*f) * TE) * modulation``.
+    ``s0`` is complex and absorbs the initial phase. ``modulation`` is a
+    forward-compatibility hook for a future Dahnke correction; pass 1 for none.
+
+    Parameters
+    ----------
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    s0 : complex or array_like
+        Complex signal at TE=0.
+    r2star : float or array_like
+        R2* decay rate in s^-1.
+    frequency_hz : float or array_like, optional
+        Off-resonance frequency in Hz. Default is 0.0.
+    modulation : complex or array_like, optional
+        Through-slice modulation term. Default is 1.0 (no modulation).
+
+    Returns
+    -------
+    signal : :obj:`numpy.ndarray`
+        Complex predicted signal, broadcast over the inputs.
+    """
+    echo_times = np.asarray(echo_times, dtype=float)
+    decay = -np.asarray(r2star) + 1j * 2.0 * np.pi * np.asarray(frequency_hz)
+    return np.asarray(s0) * np.exp(decay * echo_times) * np.asarray(modulation)
+
+
+def _initial_complex_decay_params(signal, echo_times):
+    """Derive initial ``[log|S0|, R2*, frequency_hz, phase0]`` for one echo train.
+
+    Parameters
+    ----------
+    signal : (E,) array_like
+        Complex echo train for one sample.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+
+    Returns
+    -------
+    params : (4,) :obj:`numpy.ndarray`
+        Initial estimates from a log-linear magnitude fit (slope -> R2*,
+        intercept -> log|S0|) and an unwrapped-phase linear fit
+        (slope -> frequency_hz, intercept -> phase0).
+    """
+    amplitude = np.maximum(np.abs(signal), np.finfo(float).tiny)
+    if echo_times.size > 1:
+        slope, intercept = np.polyfit(echo_times, np.log(amplitude), 1)
+        r2star = max(0.0, -float(slope))
+        phase = np.unwrap(np.angle(signal))
+        phase_slope, phase_intercept = np.polyfit(echo_times, phase, 1)
+        frequency_hz = float(phase_slope / (2.0 * np.pi))
+        phase0 = float(phase_intercept)
+    else:
+        intercept = float(np.log(amplitude[0]))
+        r2star = 0.0
+        frequency_hz = 0.0
+        phase0 = float(np.angle(signal[0]))
+    return np.array([float(intercept), r2star, frequency_hz, phase0], dtype=float)
+
+
+def _fit_complex_decay_1d(signal, echo_times, *, lower_bounds, upper_bounds, max_nfev=None):
+    """Fit one complex echo train with nonlinear least squares.
+
+    Parameters
+    ----------
+    signal : (E,) array_like
+        Complex-valued data for one sample.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    lower_bounds, upper_bounds : (4,) array_like
+        Bounds for ``[log|S0|, R2*, frequency_hz, phase0]``.
+    max_nfev : int or None, optional
+        Maximum function evaluations for :func:`scipy.optimize.least_squares`.
+
+    Returns
+    -------
+    result : dict or None
+        Dict with ``s0`` (complex), ``r2star``, ``frequency_hz``, ``phase0``,
+        ``cost``, ``nfev``, ``success``. ``None`` only when fewer than 2 finite
+        echoes are available. On optimizer error, falls back to the initial
+        estimate with ``success=False``.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    if int(valid.sum()) < 2:
+        return None
+
+    y_valid = signal[valid]
+    te_valid = echo_times[valid]
+    x0 = _initial_complex_decay_params(y_valid, te_valid)
+    x0 = np.minimum(np.maximum(x0, lower_bounds), upper_bounds)
+
+    def residuals(params):
+        log_s0_abs, r2, freq, phi0 = params
+        pred = complex_decay_model(te_valid, np.exp(log_s0_abs) * np.exp(1j * phi0), r2, freq)
+        residual = pred - y_valid
+        return np.concatenate([residual.real, residual.imag])
+
+    try:
+        result = scipy.optimize.least_squares(
+            residuals, x0, bounds=(lower_bounds, upper_bounds), max_nfev=max_nfev
+        )
+    except (ValueError, RuntimeError, FloatingPointError):
+        log_s0_abs, r2star, frequency_hz, phase0 = x0
+        return {
+            "s0": np.exp(log_s0_abs) * np.exp(1j * phase0),
+            "r2star": r2star,
+            "frequency_hz": frequency_hz,
+            "phase0": phase0,
+            "cost": np.nan,
+            "nfev": 0,
+            "success": False,
+        }
+
+    log_s0_abs, r2star, frequency_hz, phase0 = result.x
+    return {
+        "s0": np.exp(log_s0_abs) * np.exp(1j * phase0),
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "phase0": phase0,
+        "cost": result.cost,
+        "nfev": result.nfev,
+        "success": result.success,
+    }
+
+
 def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
     """Fit monoexponential decay model with nonlinear curve-fitting.
 

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -345,6 +345,123 @@ def fit_complex_monoexponential(data_cat, echo_times, adaptive_mask, report=True
     }
 
 
+def _solve_complex_s0(signal, echo_times, r2star, frequency_hz):
+    """Analytically solve per-volume complex S0 for fixed R2*/frequency.
+
+    Parameters
+    ----------
+    signal : (T, E) array_like
+        Complex data for one voxel; volumes on axis 0, echoes on axis 1.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    r2star : float
+        Shared R2* in s^-1.
+    frequency_hz : float
+        Shared off-resonance frequency in Hz.
+
+    Returns
+    -------
+    s0 : (T,) :obj:`numpy.ndarray`
+        Complex S0 per volume. NaN for volumes with fewer than 2 finite echoes.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_vols = signal.shape[0]
+    decay = np.exp((-r2star + 1j * 2.0 * np.pi * frequency_hz) * echo_times)
+    s0 = np.full(n_vols, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    for vol in range(n_vols):
+        echo_mask = valid[vol]
+        if int(echo_mask.sum()) < 2:
+            continue
+        basis = decay[echo_mask]
+        denom = np.sum(np.abs(basis) ** 2)
+        if denom <= 0 or not np.isfinite(denom):
+            continue
+        s0[vol] = np.sum(np.conj(basis) * signal[vol, echo_mask]) / denom
+    return s0
+
+
+def _fit_complex_decay_joint(
+    signal, echo_times, *, max_r2star=np.inf, max_frequency_hz=np.inf, max_nfev=None
+):
+    """Fit one voxel with shared R2*/frequency and per-volume complex S0.
+
+    Per-volume complex S0 is linear given fixed R2*/frequency and is solved
+    analytically inside the residual, keeping the optimizer to two parameters.
+
+    Parameters
+    ----------
+    signal : (T, E) array_like
+        Complex data for one voxel; volumes on axis 0, echoes on axis 1.
+    echo_times : (E,) array_like
+        Echo times in seconds.
+    max_r2star : float, optional
+        Upper bound for R2* in s^-1. Default is inf.
+    max_frequency_hz : float, optional
+        Symmetric bound for off-resonance in Hz. Default is inf.
+    max_nfev : int or None, optional
+        Maximum function evaluations.
+
+    Returns
+    -------
+    result : dict or None
+        Scalar ``r2star``, ``frequency_hz``, ``cost``, ``nfev``, ``success``
+        and ``(T,)`` arrays ``s0`` (complex) and ``phase0``. ``None`` if no
+        volume has >= 2 finite echoes or optimization fails.
+    """
+    signal = np.asarray(signal)
+    echo_times = np.asarray(echo_times, dtype=float)
+    n_vols = signal.shape[0]
+    valid = np.isfinite(signal.real) & np.isfinite(signal.imag)
+    valid_vols = np.flatnonzero(valid.sum(axis=1) >= 2)
+    if valid_vols.size == 0:
+        return None
+
+    initial = np.asarray(
+        [
+            _initial_complex_decay_params(signal[vol, valid[vol]], echo_times[valid[vol]])
+            for vol in valid_vols
+        ]
+    )
+    lower_bounds = np.array([0.0, -max_frequency_hz])
+    upper_bounds = np.array([max_r2star, max_frequency_hz])
+    x0 = np.array([float(np.nanmedian(initial[:, 1])), float(np.nanmedian(initial[:, 2]))])
+    x0 = np.minimum(np.maximum(x0, lower_bounds), upper_bounds)
+
+    def residuals(params):
+        r2, freq = params
+        s0_est = _solve_complex_s0(signal, echo_times, r2, freq)
+        parts = []
+        for vol in valid_vols:
+            if not np.isfinite(s0_est[vol]):
+                continue
+            echo_mask = valid[vol]
+            pred = complex_decay_model(echo_times[echo_mask], s0_est[vol], r2, freq)
+            residual = pred - signal[vol, echo_mask]
+            parts.extend([residual.real, residual.imag])
+        return np.concatenate(parts)
+
+    try:
+        result = scipy.optimize.least_squares(
+            residuals, x0, bounds=(lower_bounds, upper_bounds), max_nfev=max_nfev
+        )
+    except (ValueError, RuntimeError, FloatingPointError):
+        return None
+
+    r2star, frequency_hz = result.x
+    s0 = _solve_complex_s0(signal, echo_times, r2star, frequency_hz)
+    return {
+        "s0": s0,
+        "phase0": np.angle(s0),
+        "r2star": float(r2star),
+        "frequency_hz": float(frequency_hz),
+        "cost": result.cost,
+        "nfev": result.nfev,
+        "success": result.success,
+    }
+
+
 def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
     """Fit monoexponential decay model with nonlinear curve-fitting.
 

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -462,6 +462,161 @@ def _fit_complex_decay_joint(
     }
 
 
+def fit_complex_decay(data, phase, tes, adaptive_mask, fitmode, use_volumes=None, n_threads=1):
+    """Estimate complex T2*/S0 maps from magnitude and phase data.
+
+    Parameters
+    ----------
+    data : (Md x E x T) :obj:`numpy.ndarray`
+        Magnitude multi-echo data in the denoising mask.
+    phase : (Md x E x T) :obj:`numpy.ndarray`
+        Phase multi-echo data in radians, same shape as ``data``.
+    tes : (E,) array_like
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel.
+    fitmode : {"all", "ts", "varys0"}
+        ``"all"`` fits one model per voxel across all timepoints. ``"ts"`` fits
+        per voxel and timepoint. ``"varys0"`` shares R2*/frequency across
+        timepoints with per-volume complex S0.
+    use_volumes : (T,) :obj:`numpy.ndarray` of bool or None, optional
+        For ``"varys0"`` only: volumes used to estimate the shared
+        R2*/frequency. Per-volume S0 is computed for all volumes regardless.
+        ``None`` uses all volumes.
+    n_threads : int, optional
+        Number of threads. If None or <= 0, uses all CPU cores.
+
+    Returns
+    -------
+    result : dict
+        For ``"all"``: ``(Md,)`` arrays ``t2s``, ``s0``, ``r2star``,
+        ``frequency_hz``, ``phase0``, ``failures``. For ``"ts"``: same keys as
+        ``(Md, T)``. For ``"varys0"``: ``t2s``/``r2star``/``frequency_hz``/
+        ``failures`` are ``(Md,)`` and ``s0``/``phase0`` are ``(Md, T)``.
+    """
+    if n_threads is None or n_threads <= 0:
+        n_threads = os.cpu_count() or 1
+    data = np.asarray(data)
+    phase = np.asarray(phase)
+    tes = np.asarray(tes, dtype=float)
+    complex_data = data * np.exp(1j * phase)
+    n_samp, _, n_vols = complex_data.shape
+
+    if fitmode == "all":
+        return fit_complex_monoexponential(
+            complex_data, tes, adaptive_mask, n_threads=n_threads
+        )
+
+    if fitmode == "ts":
+        keys = ("t2s", "s0", "r2star", "frequency_hz", "phase0")
+        out = {k: np.zeros((n_samp, n_vols)) for k in keys}
+        out["failures"] = np.zeros((n_samp, n_vols), dtype=bool)
+        report = True
+        for vol in range(n_vols):
+            res = fit_complex_monoexponential(
+                complex_data[:, :, vol][:, :, None],
+                tes,
+                adaptive_mask,
+                report=report,
+                n_threads=n_threads,
+            )
+            for k in keys:
+                out[k][:, vol] = res[k]
+            out["failures"][:, vol] = res["failures"]
+            report = False
+        return out
+
+    if fitmode == "varys0":
+        if use_volumes is None:
+            use_volumes = np.ones(n_vols, dtype=bool)
+        return _fit_complex_decay_varys0(
+            complex_data, tes, adaptive_mask, use_volumes, n_threads
+        )
+
+    raise ValueError(f"Unknown fitmode option: {fitmode}")
+
+
+def _fit_complex_decay_varys0(complex_data, tes, adaptive_mask, use_volumes, n_threads):
+    """Joint-fit driver: shared R2*/frequency, per-volume complex S0.
+
+    Parameters
+    ----------
+    complex_data : (Md x E x T) :obj:`numpy.ndarray`
+        Complex multi-echo data.
+    tes : (E,) :obj:`numpy.ndarray`
+        Echo times in seconds.
+    adaptive_mask : (Md,) :obj:`numpy.ndarray`
+        Number of good echoes per voxel.
+    use_volumes : (T,) :obj:`numpy.ndarray` of bool
+        Volumes used for the shared R2*/frequency estimate.
+    n_threads : int
+        Number of threads.
+
+    Returns
+    -------
+    result : dict
+        ``(Md,)`` ``t2s``, ``r2star``, ``frequency_hz``, ``failures`` and
+        ``(Md, T)`` ``s0`` (magnitude) and ``phase0``.
+    """
+    n_samp, _, n_vols = complex_data.shape
+    echos_to_run = np.unique(adaptive_mask)
+    if 1 in echos_to_run:
+        echos_to_run = np.sort(np.unique(np.append(echos_to_run, 2)))
+    echos_to_run = echos_to_run[echos_to_run >= 2]
+
+    r2star = np.zeros(n_samp)
+    frequency_hz = np.zeros(n_samp)
+    failures = np.zeros(n_samp, dtype=bool)
+    s0_mag = np.zeros((n_samp, n_vols))
+    phase0 = np.zeros((n_samp, n_vols))
+
+    def _fit_voxel(voxel, echo_num):
+        # (T, E) for the shared fit (used volumes only) and all volumes for S0
+        signal_all = complex_data[voxel, :echo_num, :].T
+        joint = _fit_complex_decay_joint(signal_all[use_volumes], tes[:echo_num])
+        if joint is None:
+            return voxel, None
+        s0_all = _solve_complex_s0(
+            signal_all, tes[:echo_num], joint["r2star"], joint["frequency_hz"]
+        )
+        return voxel, {"joint": joint, "s0_all": s0_all}
+
+    for echo_num in echos_to_run:
+        if echo_num == 2:
+            voxel_idx = np.where(adaptive_mask <= echo_num)[0]
+        else:
+            voxel_idx = np.where(adaptive_mask == echo_num)[0]
+
+        results = Parallel(n_jobs=n_threads)(
+            delayed(_fit_voxel)(voxel, echo_num)
+            for voxel in tqdm(voxel_idx, desc=f"{echo_num}-echo varys0 NLLS")
+        )
+
+        for voxel, res in results:
+            if res is None:
+                failures[voxel] = True
+                continue
+            joint = res["joint"]
+            r2star[voxel] = joint["r2star"]
+            frequency_hz[voxel] = joint["frequency_hz"]
+            failures[voxel] = not joint["success"]
+            s0_all = res["s0_all"]
+            s0_mag[voxel, :] = np.abs(s0_all)
+            phase0[voxel, :] = np.angle(s0_all)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t2s = np.where(r2star > 0, 1.0 / r2star, np.inf)
+
+    return {
+        "t2s": t2s,
+        "r2star": r2star,
+        "frequency_hz": frequency_hz,
+        "s0": s0_mag,
+        "phase0": phase0,
+        "failures": failures,
+    }
+
+
 def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_threads=1):
     """Fit monoexponential decay model with nonlinear curve-fitting.
 

--- a/tedana/resources/config/outputs.json
+++ b/tedana/resources/config/outputs.json
@@ -31,14 +31,6 @@
         "orig": "phase0",
         "bidsv1.5.0": "phase0map"
     },
-    "fit cost img": {
-        "orig": "fit_cost",
-        "bidsv1.5.0": "desc-fitCost_statmap"
-    },
-    "fit nfev img": {
-        "orig": "fit_nfev",
-        "bidsv1.5.0": "desc-fitNfev_statmap"
-    },
     "t2star-s0 covariance img": {
         "orig": "t2s_s0_covar",
         "bidsv1.5.0": "stat-covariance_desc-t2star+s0_statmap"

--- a/tedana/resources/config/outputs.json
+++ b/tedana/resources/config/outputs.json
@@ -23,6 +23,22 @@
         "orig": "s0_var",
         "bidsv1.5.0": "stat-variance_desc-s0_statmap"
     },
+    "frequency img": {
+        "orig": "frequencyHz",
+        "bidsv1.5.0": "frequencyHzmap"
+    },
+    "phase0 img": {
+        "orig": "phase0",
+        "bidsv1.5.0": "phase0map"
+    },
+    "fit cost img": {
+        "orig": "fit_cost",
+        "bidsv1.5.0": "desc-fitCost_statmap"
+    },
+    "fit nfev img": {
+        "orig": "fit_nfev",
+        "bidsv1.5.0": "desc-fitNfev_statmap"
+    },
     "t2star-s0 covariance img": {
         "orig": "t2s_s0_covar",
         "bidsv1.5.0": "stat-covariance_desc-t2star+s0_statmap"

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -302,3 +302,29 @@ def test_fit_complex_monoexponential_recovers_maps():
     assert np.allclose(out["s0"], np.abs(s0_true), rtol=1e-2)
     assert out["frequency_hz"].shape == (n_vox,)
     assert not out["failures"].any()
+
+
+def test__fit_complex_decay_joint_shared_params():
+    """Joint fit recovers shared R2*/frequency with per-volume S0."""
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    r2star, freq = 15.0, 3.0
+    s0_per_vol = np.array([100.0, 150.0, 200.0]) * np.exp(1j * np.array([0.2, -0.4, 0.6]))
+    signal = np.stack(
+        [me.complex_decay_model(tes, s0, r2star, freq) for s0 in s0_per_vol]
+    )  # (T, E)
+    out = me._fit_complex_decay_joint(signal, tes)
+    assert out is not None
+    assert np.isclose(out["r2star"], r2star, atol=1e-3)
+    assert np.isclose(out["frequency_hz"], freq, atol=1e-3)
+    assert out["s0"].shape == (3,)
+    assert np.allclose(np.abs(out["s0"]), np.abs(s0_per_vol), rtol=1e-3)
+
+
+def test__solve_complex_s0_all_volumes():
+    """_solve_complex_s0 returns one complex S0 per volume."""
+    tes = np.array([0.01, 0.02, 0.03])
+    s0_per_vol = np.array([100.0 + 0j, 200.0 + 0j])
+    signal = np.stack([me.complex_decay_model(tes, s0, 20.0, 0.0) for s0 in s0_per_vol])
+    out = me._solve_complex_s0(signal, tes, 20.0, 0.0)
+    assert out.shape == (2,)
+    assert np.allclose(np.abs(out), np.abs(s0_per_vol), rtol=1e-6)

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -385,6 +385,13 @@ def test_fit_complex_decay_varys0_use_volumes(complex_testdata):
     assert np.isfinite(out["s0"][:, 2]).all()  # excluded volume still gets S0
 
 
+def test_fit_complex_decay_invalid_fitmode(complex_testdata):
+    """fit_complex_decay raises ValueError on an unknown fitmode."""
+    d = complex_testdata
+    with pytest.raises(ValueError, match="Unknown fitmode"):
+        me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "bogus")
+
+
 def test_rmse_of_fit_decay_ts_varys0():
     """rmse handles 3D t2s with 4D s0 for fitmode='varys0'."""
     rng = np.random.default_rng(2)

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -344,8 +344,15 @@ def complex_testdata():
         mag[v] = np.repeat(np.abs(sig)[:, None], n_vol, axis=1)
         phase[v] = np.repeat(np.angle(sig)[:, None], n_vol, axis=1)
     adaptive_mask = np.full(n_vox, n_echo, dtype=int)
-    return dict(mag=mag, phase=phase, tes=tes, adaptive_mask=adaptive_mask,
-               r2star=r2star, s0=s0, n_vol=n_vol)
+    return dict(
+        mag=mag,
+        phase=phase,
+        tes=tes,
+        adaptive_mask=adaptive_mask,
+        r2star=r2star,
+        s0=s0,
+        n_vol=n_vol,
+    )
 
 
 def test_fit_complex_decay_all(complex_testdata):
@@ -378,7 +385,11 @@ def test_fit_complex_decay_varys0_use_volumes(complex_testdata):
     d = complex_testdata
     use_volumes = np.array([True, True, False, True])
     out = me.fit_complex_decay(
-        d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "varys0",
+        d["mag"],
+        d["phase"],
+        d["tes"],
+        d["adaptive_mask"],
+        "varys0",
         use_volumes=use_volumes,
     )
     assert out["s0"].shape == (5, d["n_vol"])
@@ -392,6 +403,60 @@ def test_fit_complex_decay_invalid_fitmode(complex_testdata):
         me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "bogus")
 
 
+def test_fit_complex_monoexponential_caps_extreme_t2star():
+    """R2* is bounded so a no-decay signal cannot produce an infinite T2*.
+
+    With R2* unbounded below at 0, a flat (R2*=0) decay drives T2* = 1/R2* toward
+    infinity. The fit must instead pin R2* at MIN_R2STAR, keeping T2* finite and
+    at or below MAX_PHYSIOLOGICAL_T2STAR.
+    """
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vol = 3
+    # No decay across echoes -> the optimizer wants R2* = 0 (T2* = inf).
+    sig = me.complex_decay_model(tes, 200.0 * np.exp(1j * 0.3), 0.0, 1.0)
+    data = np.repeat(sig[:, None], n_vol, axis=1)[None]  # (1, E, T)
+    adaptive_mask = np.array([5])
+    out = me.fit_complex_monoexponential(data, tes, adaptive_mask, report=False)
+    assert np.isfinite(out["t2s"]).all()
+    assert (out["t2s"] <= me.MAX_PHYSIOLOGICAL_T2STAR + 1e-6).all()
+    assert (out["r2star"] >= me.MIN_R2STAR - 1e-9).all()
+
+
+def test_fit_complex_decay_varys0_caps_extreme_t2star():
+    """The varys0 driver bounds R2* so a no-decay signal cannot yield infinite T2*."""
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vox, n_echo, n_vol = 2, 5, 3
+    mag = np.zeros((n_vox, n_echo, n_vol))
+    phase = np.zeros((n_vox, n_echo, n_vol))
+    for v in range(n_vox):
+        for t in range(n_vol):
+            sig = me.complex_decay_model(tes, (100.0 + 50 * t) * np.exp(1j * 0.3), 0.0, 1.0)
+            mag[v, :, t] = np.abs(sig)
+            phase[v, :, t] = np.angle(sig)
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    out = me.fit_complex_decay(mag, phase, tes, adaptive_mask, "varys0")
+    assert np.isfinite(out["t2s"]).all()
+    assert (out["t2s"] <= me.MAX_PHYSIOLOGICAL_T2STAR + 1e-6).all()
+
+
+def test_modify_t2s_s0_maps_caps_full_map():
+    """The full T2* map is capped, not just the limited map.
+
+    A blown-up finite estimate (as produced by an unbounded fit) must be brought
+    down in the full map, instead of leaking through to be saved (and overflow to
+    +Inf when written as float32).
+    """
+    tes = np.array([0.01, 0.02, 0.03])
+    n = 100
+    t2s = np.full(n, 0.05)
+    t2s[0] = 1e38  # blown-up value, finite in float64 but absurd
+    s0 = np.full(n, 100.0)
+    adaptive_mask = np.full(n, len(tes), dtype=int)
+    t2s_full, _, _, _ = me.modify_t2s_s0_maps(t2s.copy(), s0.copy(), adaptive_mask, tes)
+    assert np.isfinite(t2s_full).all()
+    assert t2s_full.max() < 1e6
+
+
 def test_rmse_of_fit_decay_ts_varys0():
     """rmse handles 3D t2s with 4D s0 for fitmode='varys0'."""
     rng = np.random.default_rng(2)
@@ -399,8 +464,8 @@ def test_rmse_of_fit_decay_ts_varys0():
     n_vox, n_echo, n_vol = 4, 3, 5
     data = rng.uniform(50, 200, (n_vox, n_echo, n_vol))
     adaptive_mask = np.full(n_vox, n_echo, dtype=int)
-    t2s = np.full(n_vox, 0.04)            # (Mb,)
-    s0 = np.full((n_vox, n_vol), 150.0)   # (Mb, T)
+    t2s = np.full(n_vox, 0.04)  # (Mb,)
+    s0 = np.full((n_vox, n_vol), 150.0)  # (Mb, T)
     rmse_map, rmse_df = me.rmse_of_fit_decay_ts(
         data=data, tes=tes, adaptive_mask=adaptive_mask, t2s=t2s, s0=s0, fitmode="varys0"
     )

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -328,3 +328,58 @@ def test__solve_complex_s0_all_volumes():
     out = me._solve_complex_s0(signal, tes, 20.0, 0.0)
     assert out.shape == (2,)
     assert np.allclose(np.abs(out), np.abs(s0_per_vol), rtol=1e-6)
+
+
+@pytest.fixture
+def complex_testdata():
+    rng = np.random.default_rng(1)
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vox, n_echo, n_vol = 5, 5, 4
+    r2star = rng.uniform(10, 25, n_vox)
+    s0 = rng.uniform(100, 250, n_vox)
+    mag = np.zeros((n_vox, n_echo, n_vol))
+    phase = np.zeros((n_vox, n_echo, n_vol))
+    for v in range(n_vox):
+        sig = me.complex_decay_model(tes, s0[v] * np.exp(1j * 0.3), r2star[v], 2.0)
+        mag[v] = np.repeat(np.abs(sig)[:, None], n_vol, axis=1)
+        phase[v] = np.repeat(np.angle(sig)[:, None], n_vol, axis=1)
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    return dict(mag=mag, phase=phase, tes=tes, adaptive_mask=adaptive_mask,
+               r2star=r2star, s0=s0, n_vol=n_vol)
+
+
+def test_fit_complex_decay_all(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "all")
+    assert out["t2s"].shape == (5,)
+    assert out["s0"].shape == (5,)
+    assert np.allclose(out["t2s"], 1.0 / d["r2star"], rtol=1e-2)
+
+
+def test_fit_complex_decay_ts(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "ts")
+    assert out["t2s"].shape == (5, d["n_vol"])
+    assert out["s0"].shape == (5, d["n_vol"])
+
+
+def test_fit_complex_decay_varys0(complex_testdata):
+    d = complex_testdata
+    out = me.fit_complex_decay(d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "varys0")
+    assert out["t2s"].shape == (5,)
+    assert out["frequency_hz"].shape == (5,)
+    assert out["s0"].shape == (5, d["n_vol"])
+    assert out["phase0"].shape == (5, d["n_vol"])
+    assert np.allclose(out["t2s"], 1.0 / d["r2star"], rtol=1e-2)
+
+
+def test_fit_complex_decay_varys0_use_volumes(complex_testdata):
+    """use_volumes restricts the shared fit but S0 is returned for all volumes."""
+    d = complex_testdata
+    use_volumes = np.array([True, True, False, True])
+    out = me.fit_complex_decay(
+        d["mag"], d["phase"], d["tes"], d["adaptive_mask"], "varys0",
+        use_volumes=use_volumes,
+    )
+    assert out["s0"].shape == (5, d["n_vol"])
+    assert np.isfinite(out["s0"][:, 2]).all()  # excluded volume still gets S0

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -383,3 +383,19 @@ def test_fit_complex_decay_varys0_use_volumes(complex_testdata):
     )
     assert out["s0"].shape == (5, d["n_vol"])
     assert np.isfinite(out["s0"][:, 2]).all()  # excluded volume still gets S0
+
+
+def test_rmse_of_fit_decay_ts_varys0():
+    """rmse handles 3D t2s with 4D s0 for fitmode='varys0'."""
+    rng = np.random.default_rng(2)
+    tes = [0.01, 0.02, 0.03]
+    n_vox, n_echo, n_vol = 4, 3, 5
+    data = rng.uniform(50, 200, (n_vox, n_echo, n_vol))
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    t2s = np.full(n_vox, 0.04)            # (Mb,)
+    s0 = np.full((n_vox, n_vol), 150.0)   # (Mb, T)
+    rmse_map, rmse_df = me.rmse_of_fit_decay_ts(
+        data=data, tes=tes, adaptive_mask=adaptive_mask, t2s=t2s, s0=s0, fitmode="varys0"
+    )
+    assert rmse_map.shape == (n_vox,)
+    assert len(rmse_df) == n_vol

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -271,7 +271,7 @@ def test__fit_complex_decay_1d_optimizer_failure(monkeypatch):
     """On optimizer error, falls back to the initial estimate with success=False."""
     import scipy.optimize
 
-    def boom(*args, **kwargs):
+    def boom(*args, **kwargs):  # noqa: U100
         raise RuntimeError("forced failure")
 
     monkeypatch.setattr(scipy.optimize, "least_squares", boom)

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -282,3 +282,23 @@ def test__fit_complex_decay_1d_optimizer_failure(monkeypatch):
     out = me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper)
     assert out is not None
     assert out["success"] is False
+
+
+def test_fit_complex_monoexponential_recovers_maps():
+    """fit_complex_monoexponential recovers R2*/S0 over the adaptive mask."""
+    rng = np.random.default_rng(0)
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    n_vox, n_echo, n_vol = 6, 5, 3
+    r2star_true = rng.uniform(10, 30, n_vox)
+    s0_true = rng.uniform(100, 300, n_vox) * np.exp(1j * rng.uniform(-1, 1, n_vox))
+    data = np.zeros((n_vox, n_echo, n_vol), dtype=np.complex128)
+    for v in range(n_vox):
+        sig = me.complex_decay_model(tes, s0_true[v], r2star_true[v], 2.0)
+        data[v] = np.repeat(sig[:, None], n_vol, axis=1)
+    adaptive_mask = np.full(n_vox, n_echo, dtype=int)
+    out = me.fit_complex_monoexponential(data, tes, adaptive_mask, report=False)
+    assert out["t2s"].shape == (n_vox,)
+    assert np.allclose(out["t2s"], 1.0 / r2star_true, rtol=1e-2)
+    assert np.allclose(out["s0"], np.abs(s0_true), rtol=1e-2)
+    assert out["frequency_hz"].shape == (n_vox,)
+    assert not out["failures"].any()

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -265,3 +265,20 @@ def test__fit_complex_decay_1d_too_few_echoes():
     lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
     upper = np.array([np.inf, np.inf, np.inf, np.inf])
     assert me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper) is None
+
+
+def test__fit_complex_decay_1d_optimizer_failure(monkeypatch):
+    """On optimizer error, falls back to the initial estimate with success=False."""
+    import scipy.optimize
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("forced failure")
+
+    monkeypatch.setattr(scipy.optimize, "least_squares", boom)
+    tes = np.array([0.008, 0.020, 0.032])
+    signal = me.complex_decay_model(tes, 100.0 + 0j, 20.0, 0.0)
+    lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper = np.array([np.inf, np.inf, np.inf, np.inf])
+    out = me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper)
+    assert out is not None
+    assert out["success"] is False

--- a/tedana/tests/test_decay.py
+++ b/tedana/tests/test_decay.py
@@ -228,3 +228,40 @@ def test_smoke_fit_decay_curvefit_ts():
 
 
 # TODO: BREAK AND UNIT TESTS
+
+
+def test_complex_decay_model():
+    """complex_decay_model returns the analytic complex signal."""
+    tes = np.array([0.01, 0.02, 0.03])
+    s0 = 100.0 * np.exp(1j * 0.5)
+    r2star = 20.0
+    freq = 3.0
+    sig = me.complex_decay_model(tes, s0, r2star, freq)
+    expected = s0 * np.exp((-r2star + 1j * 2 * np.pi * freq) * tes)
+    assert np.allclose(sig, expected)
+
+
+def test__fit_complex_decay_1d_recovers_params():
+    """_fit_complex_decay_1d recovers known params from noiseless data."""
+    tes = np.array([0.008, 0.020, 0.032, 0.044, 0.056])
+    s0 = 250.0 * np.exp(1j * 0.7)
+    r2star = 18.0
+    freq = 4.0
+    signal = me.complex_decay_model(tes, s0, r2star, freq)
+    lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper = np.array([np.inf, np.inf, np.inf, np.inf])
+    out = me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper)
+    assert out is not None
+    assert np.isclose(out["r2star"], r2star, atol=1e-3)
+    assert np.isclose(out["frequency_hz"], freq, atol=1e-3)
+    assert np.isclose(np.abs(out["s0"]), np.abs(s0), rtol=1e-3)
+    assert out["success"]
+
+
+def test__fit_complex_decay_1d_too_few_echoes():
+    """_fit_complex_decay_1d returns None with fewer than 2 finite echoes."""
+    tes = np.array([0.01, 0.02])
+    signal = np.array([np.nan + 1j * np.nan, 5 + 1j * 2])
+    lower = np.array([-np.inf, 0.0, -np.inf, -np.inf])
+    upper = np.array([np.inf, np.inf, np.inf, np.inf])
+    assert me._fit_complex_decay_1d(signal, tes, lower_bounds=lower, upper_bounds=upper) is None

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -235,6 +235,11 @@ def _make_zero_phase_files(echo_files, out_dir):
     return phase_files
 
 
+# Complex NLLS can produce very large S0 in low-signal voxels of the synthetic
+# test data, causing a benign float32 cast overflow in IO when maps are saved.
+@pytest.mark.filterwarnings(
+    "ignore:overflow encountered in cast:RuntimeWarning"
+)
 @pytest.mark.parametrize("fitmode", ["all", "ts", "varys0"])
 def test_t2smap_nlls(tmp_path, fitmode):
     """t2smap runs with fittype='nlls' across fitmodes and writes expected maps."""

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -4,6 +4,7 @@ import os.path as op
 from shutil import rmtree
 
 import nibabel as nb
+import numpy as np
 import pytest
 
 from tedana import workflows
@@ -220,3 +221,69 @@ class TestT2smap:
     def teardown_method(self):
         # Clean up folders
         rmtree("TED.echo1.t2smap")
+
+
+def _make_zero_phase_files(echo_files, out_dir):
+    """Write zero-valued phase NIfTIs matching the given magnitude echoes."""
+    phase_files = []
+    for i, f in enumerate(echo_files):
+        img = nb.load(f)
+        phase = nb.Nifti1Image(np.zeros(img.shape, dtype=np.float32), img.affine, img.header)
+        path = op.join(out_dir, f"phase{i + 1}.nii.gz")
+        phase.to_filename(path)
+        phase_files.append(path)
+    return phase_files
+
+
+@pytest.mark.parametrize("fitmode", ["all", "ts", "varys0"])
+def test_t2smap_nlls(tmp_path, fitmode):
+    """t2smap runs with fittype='nlls' across fitmodes and writes expected maps."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    mask = op.join(data_dir, "mask.nii.gz")
+    phase_files = _make_zero_phase_files(echo_files, str(tmp_path))
+    workflows.t2smap_workflow(
+        data=echo_files,
+        tes=[14.5, 38.5, 62.5],
+        phase=phase_files,
+        mask=mask,
+        fittype="nlls",
+        fitmode=fitmode,
+        out_dir=str(tmp_path),
+    )
+    assert op.exists(op.join(tmp_path, "T2starmap.nii.gz"))
+    assert op.exists(op.join(tmp_path, "S0map.nii.gz"))
+    assert op.exists(op.join(tmp_path, "frequencyHzmap.nii.gz"))
+    assert op.exists(op.join(tmp_path, "phase0map.nii.gz"))
+    assert op.exists(op.join(tmp_path, "desc-optcom_bold.nii.gz"))
+    # varys0 should produce a 4D S0 timeseries; all/ts produce 3D/4D maps respectively
+    s0 = nb.load(op.join(tmp_path, "S0map.nii.gz"))
+    if fitmode == "varys0":
+        assert s0.ndim == 4
+
+
+def test_t2smap_nlls_requires_phase(tmp_path):
+    """fittype='nlls' without --phase raises."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    with pytest.raises(ValueError, match="requires phase"):
+        workflows.t2smap_workflow(
+            data=echo_files,
+            tes=[14.5, 38.5, 62.5],
+            fittype="nlls",
+            out_dir=str(tmp_path),
+        )
+
+
+def test_t2smap_varys0_requires_nlls(tmp_path):
+    """fitmode='varys0' with a non-nlls fittype raises."""
+    data_dir = get_test_data_path()
+    echo_files = [op.join(data_dir, f"echo{i + 1}.nii.gz") for i in range(3)]
+    with pytest.raises(ValueError, match="varys0"):
+        workflows.t2smap_workflow(
+            data=echo_files,
+            tes=[14.5, 38.5, 62.5],
+            fittype="loglin",
+            fitmode="varys0",
+            out_dir=str(tmp_path),
+        )

--- a/tedana/tests/test_t2smap.py
+++ b/tedana/tests/test_t2smap.py
@@ -235,11 +235,6 @@ def _make_zero_phase_files(echo_files, out_dir):
     return phase_files
 
 
-# Complex NLLS can produce very large S0 in low-signal voxels of the synthetic
-# test data, causing a benign float32 cast overflow in IO when maps are saved.
-@pytest.mark.filterwarnings(
-    "ignore:overflow encountered in cast:RuntimeWarning"
-)
 @pytest.mark.parametrize("fitmode", ["all", "ts", "varys0"])
 def test_t2smap_nlls(tmp_path, fitmode):
     """t2smap runs with fittype='nlls' across fitmodes and writes expected maps."""

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -568,9 +568,7 @@ def t2smap_workflow(
         io_generator.save_file(
             utils.unmask(complex_results["frequency_hz"], mask_denoise), "frequency img"
         )
-        io_generator.save_file(
-            utils.unmask(complex_results["phase0"], mask_denoise), "phase0 img"
-        )
+        io_generator.save_file(utils.unmask(complex_results["phase0"], mask_denoise), "phase0 img")
 
     # Delete unused variables
     del failures, t2s_var, s0_var, t2s_s0_covar

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -41,6 +41,18 @@ def _get_parser():
         required=True,
     )
     required_args.add_argument(
+        "--phase",
+        dest="phase",
+        nargs="+",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "Phase images for each echo, in radians, in ascending echo order "
+            "matching -d. Required when --fittype is 'nlls'."
+        ),
+        default=None,
+    )
+    required_args.add_argument(
         "-e",
         dest="tes",
         nargs="+",
@@ -151,23 +163,27 @@ def _get_parser():
     decay_args.add_argument(
         "--fittype",
         dest="fittype",
-        choices=["loglin", "curvefit"],
+        choices=["loglin", "curvefit", "nlls"],
         help=(
             "Desired T2*/S0 fitting method. "
             '"loglin" means that a linear model is fit to the log of the data. '
             '"curvefit" means that a more computationally demanding monoexponential model is fit '
             "to the raw data. "
+            '"nlls" fits a complex monoexponential model to magnitude+phase data and requires '
+            "--phase. "
         ),
         default="loglin",
     )
     decay_args.add_argument(
         "--fitmode",
         dest="fitmode",
-        choices=["all", "ts"],
+        choices=["all", "ts", "varys0"],
         help=(
             "Monoexponential model fitting scheme. "
             '"all" means that the model is fit, per voxel, across all timepoints. '
-            '"ts" means that the model is fit, per voxel and per timepoint.'
+            '"ts" means that the model is fit, per voxel and per timepoint. '
+            '"varys0" (nlls only) shares R2*/frequency across timepoints while '
+            "allowing complex S0 to vary per timepoint. "
         ),
         default="all",
     )
@@ -247,6 +263,7 @@ def t2smap_workflow(
     dummy_scans=0,
     exclude=None,
     masktype=["dropout"],
+    phase=None,
     fittype="loglin",
     fitmode="all",
     combmode="t2s",
@@ -291,16 +308,23 @@ def t2smap_workflow(
         Default is to not exclude any volumes.
     masktype : :obj:`list` with 'dropout' and/or 'decay' or None, optional
         Method(s) by which to define the adaptive mask. Default is ["dropout"].
-    fittype : {'loglin', 'curvefit'}, optional
+    phase : :obj:`list` of :obj:`str`, optional
+        Phase images for each echo, in radians, in ascending echo order matching ``data``.
+        Required when ``fittype`` is ``'nlls'``. Default is None.
+    fittype : {'loglin', 'curvefit', 'nlls'}, optional
         Monoexponential fitting method.
         'loglin' means to use the the default linear fit to the log of
         the data.
         'curvefit' means to use a monoexponential fit to the raw data,
         which is slightly slower but may be more accurate.
-    fitmode : {'all', 'ts'}, optional
+        'nlls' fits a complex monoexponential model to magnitude+phase data
+        and requires ``phase``.
+    fitmode : {'all', 'ts', 'varys0'}, optional
         Monoexponential model fitting scheme.
         'all' means that the model is fit, per voxel, across all timepoints.
         'ts' means that the model is fit, per voxel and per timepoint.
+        'varys0' (nlls only) shares R2*/frequency across timepoints while
+        allowing complex S0 to vary per timepoint.
         Default is 'all'.
     combmode : {'t2s', 'paid'}, optional
         Combination scheme for TEs: 't2s' (Posse 1999, default), 'paid' (Poser).
@@ -386,6 +410,16 @@ def t2smap_workflow(
             "Please set fitmode='all' or remove the exclude argument."
         )
 
+    if fittype == "nlls" and phase is None:
+        raise ValueError("fittype='nlls' requires phase images (--phase).")
+    if phase is not None and fittype != "nlls":
+        raise ValueError("phase images are only used with fittype='nlls'.")
+    if fitmode == "varys0" and fittype != "nlls":
+        raise ValueError("fitmode='varys0' is only valid with fittype='nlls'.")
+
+    if isinstance(phase, str):
+        phase = [phase]
+
     # ensure tes are in appropriate format
     tes = [float(te) for te in tes]
     tes = utils.check_te_values(tes)
@@ -394,6 +428,9 @@ def t2smap_workflow(
     # coerce data to samples x echos x time array
     if isinstance(data, str):
         data = [data]
+
+    if phase is not None and len(phase) != len(data):
+        raise ValueError("--phase must have the same number of files as -d.")
 
     # Initialize OutputGenerator with reference image
     # XXX: This doesn't support AFNI data yet.
@@ -456,32 +493,84 @@ def t2smap_workflow(
     io_generator.save_file(masksum_denoise, "adaptive mask img")
 
     LGR.info("Computing T2* map")
-    data_without_excluded_vols = data_without_excluded_vols[mask_denoise, ...]
+    data_fit = data_without_excluded_vols[mask_denoise, ...]
     masksum_masked = masksum_denoise[mask_denoise]
-    decay_function = decay.fit_decay if fitmode == "all" else decay.fit_decay_ts
-    t2s_full, s0_full, failures, t2s_var, s0_var, t2s_s0_covar = decay_function(
-        data=data_without_excluded_vols,
-        tes=tes,
-        adaptive_mask=masksum_masked,
-        fittype=fittype,
-        n_threads=n_threads,
-    )
+
+    if fittype == "nlls":
+        phase_cat = io.load_data_nilearn(phase, mask_img=mask_img, n_echos=n_echos)
+        if dummy_scans > 0:
+            phase_cat = phase_cat[..., dummy_scans:]
+        if phase_cat.shape != data_cat.shape:
+            raise ValueError(
+                f"Phase shape {phase_cat.shape} does not match data shape {data_cat.shape}."
+            )
+        # For varys0, pass all volumes plus a use_volumes mask; otherwise drop excluded volumes.
+        if fitmode == "varys0":
+            phase_fit = phase_cat[mask_denoise, ...]
+            data_complex_mag = data_cat[mask_denoise, ...]
+            if n_exclude > 0:
+                vol_mask = use_volumes
+            else:
+                vol_mask = np.ones(n_vols, dtype=bool)
+            complex_results = decay.fit_complex_decay(
+                data=data_complex_mag,
+                phase=phase_fit,
+                tes=tes,
+                adaptive_mask=masksum_masked,
+                fitmode="varys0",
+                use_volumes=vol_mask,
+                n_threads=n_threads,
+            )
+        else:
+            if n_exclude == 0:
+                phase_fit = phase_cat[mask_denoise, ...]
+            else:
+                phase_fit = phase_cat[:, :, use_volumes][mask_denoise, ...]
+            complex_results = decay.fit_complex_decay(
+                data=data_fit,
+                phase=phase_fit,
+                tes=tes,
+                adaptive_mask=masksum_masked,
+                fitmode=fitmode,
+                n_threads=n_threads,
+            )
+        t2s_full = complex_results["t2s"]
+        s0_full = complex_results["s0"]
+        failures = complex_results["failures"]
+        t2s_var = s0_var = t2s_s0_covar = None
+    else:
+        decay_function = decay.fit_decay if fitmode == "all" else decay.fit_decay_ts
+        t2s_full, s0_full, failures, t2s_var, s0_var, t2s_s0_covar = decay_function(
+            data=data_fit,
+            tes=tes,
+            adaptive_mask=masksum_masked,
+            fittype=fittype,
+            n_threads=n_threads,
+        )
     del data_without_excluded_vols
 
-    if fittype == "curvefit":
+    if fittype in ("curvefit", "nlls"):
         io_generator.save_file(
             failures.astype(np.uint8),
             "fit failures img",
             mask=mask_denoise,
         )
-        if verbose:
-            io_generator.save_file(t2s_var, "t2star variance img", mask=mask_denoise)
-            io_generator.save_file(s0_var, "s0 variance img", mask=mask_denoise)
-            io_generator.save_file(
-                t2s_s0_covar,
-                "t2star-s0 covariance img",
-                mask=mask_denoise,
-            )
+    if fittype == "curvefit" and verbose:
+        io_generator.save_file(t2s_var, "t2star variance img", mask=mask_denoise)
+        io_generator.save_file(s0_var, "s0 variance img", mask=mask_denoise)
+        io_generator.save_file(
+            t2s_s0_covar,
+            "t2star-s0 covariance img",
+            mask=mask_denoise,
+        )
+
+    if fittype == "nlls":
+        io_generator.save_file(
+            utils.unmask(complex_results["frequency_hz"], mask_denoise), "frequency img"
+        )
+        io_generator.save_file(
+            utils.unmask(complex_results["phase0"], mask_denoise), "phase0 img"
+        )
 
     # Delete unused variables
     del failures, t2s_var, s0_var, t2s_s0_covar


### PR DESCRIPTION
Relates to #531. This adds the ability to include phase data in the T2*/S0 estimation step in `t2smap` (not `tedana`). It does not include the magnitude correction requested in #531.

I just let Opus implement this based on a mishmash of my own edits and other Opus edits on a separate clone of tedana, so I'm keeping it as a draft until I have the chance to go through it line by line.

Changes proposed in this pull request:

- Add `--phase` argument to `t2smap`. This accepts phase data to match the magnitude data from `-d`. Because we typically apply `t2smap` to motion-corrected, and even distortion-corrected, magnitude data, we'll need to think about the best way to handle phase data. Right now, I think the best workflow is:
    1. Rescale phase to -pi - pi.
    2. Convert magnitude and phase to real and imaginary.
    3. Apply transforms to real and imaginary files (probably not including slice timing correction).
    4. Convert BOLD reference-space real and imaginary files back to magnitude and phase.
    5. Run `t2smap`.
- Add `--fittype nlls` option to `t2smap`. This will use the phase data in the T2*/S0 estimation step.
- Add `--fitmode varys0` option to `t2smap`. This triggers a fitting approach where S0 is allowed to vary across volumes, but T2* is kept static. It should be faster than `--fitmode all`.
