### PR TITLE
Fix T2* and S0 variance assignment and empty T2* variance plot

### DIFF
--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -242,8 +242,8 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_thre
             s0_voxel,
             t2s_voxel,
             failure,
-            t2s_var_voxel,
             s0_var_voxel,
+            t2s_var_voxel,
             t2s_s0_covar_voxel,
         ) in results:
             if failure:
@@ -252,8 +252,8 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_thre
             else:
                 s0_init[voxel] = s0_voxel
                 t2s_init[voxel] = t2s_voxel
-                t2s_var_asc_maps[voxel, i_echo] = t2s_var_voxel
                 s0_var_asc_maps[voxel, i_echo] = s0_var_voxel
+                t2s_var_asc_maps[voxel, i_echo] = t2s_var_voxel
                 t2s_s0_covar_asc_maps[voxel, i_echo] = t2s_s0_covar_voxel
 
         if fail_count:
@@ -268,16 +268,20 @@ def fit_monoexponential(data_cat, echo_times, adaptive_mask, report=True, n_thre
         s0_asc_maps[:, i_echo] = s0_init
 
     # create full T2* and S0 maps
-    t2s = utils.unmask(t2s_asc_maps[echo_masks], adaptive_mask > 1)
     s0 = utils.unmask(s0_asc_maps[echo_masks], adaptive_mask > 1)
+    t2s = utils.unmask(t2s_asc_maps[echo_masks], adaptive_mask > 1)
     failures = utils.unmask(failures_asc_maps[echo_masks], adaptive_mask > 1)
-    t2s_var = utils.unmask(t2s_var_asc_maps[echo_masks], adaptive_mask > 1)
     s0_var = utils.unmask(s0_var_asc_maps[echo_masks], adaptive_mask > 1)
+    t2s_var = utils.unmask(t2s_var_asc_maps[echo_masks], adaptive_mask > 1)
     t2s_s0_covar = utils.unmask(t2s_s0_covar_asc_maps[echo_masks], adaptive_mask > 1)
 
-    # create full T2* maps with S0 estimation errors
-    t2s[adaptive_mask == 1] = t2s_asc_maps[adaptive_mask == 1, 0]
-    s0[adaptive_mask == 1] = s0_asc_maps[adaptive_mask == 1, 0]
+    # Fill voxels with adaptive mask value of 1 with values from first two echoes
+    one_echo = adaptive_mask == 1
+    s0[one_echo] = s0_asc_maps[one_echo, 0]
+    t2s[one_echo] = t2s_asc_maps[one_echo, 0]
+    s0_var[one_echo] = s0_var_asc_maps[one_echo, 0]
+    t2s_var[one_echo] = t2s_var_asc_maps[one_echo, 0]
+    t2s_s0_covar[one_echo] = t2s_s0_covar_asc_maps[one_echo, 0]
 
     return t2s, s0, failures, t2s_var, s0_var, t2s_s0_covar
 
@@ -678,6 +682,11 @@ def rmse_of_fit_decay_ts(
     for n_good_echoes in range(2, len(tes) + 1):
         # a boolean mask for voxels with a specific num of good echoes
         use_vox = adaptive_mask == n_good_echoes
+        if n_good_echoes == 2:
+            # Voxels with a single good echo are fit using the first two echoes
+            # (mirroring fit_monoexponential), so include them here rather than
+            # leaving their RMSE as NaN (which renders as empty voxels).
+            use_vox = use_vox | (adaptive_mask == 1)
         data_echo = data[use_vox, :n_good_echoes, :]
         if fitmode == "all":
             s0_echo = np.tile(s0[use_vox][:, np.newaxis], (1, n_vols))

--- a/tedana/decay.py
+++ b/tedana/decay.py
@@ -104,8 +104,8 @@ def _fit_single_voxel(voxel, echo_times_1d, data_column, s0_init, t2s_init, boun
     Returns
     -------
     result : tuple or None
-        If successful: (voxel, s0, t2s, False)
-        If failed: (voxel, None, None, True)
+        If successful: (voxel, s0, t2s, False, s0_var, t2s_var, s0t2s_covar)
+        If failed: (voxel, None, None, True, None, None, None)
     """
     try:
         popt, cov = scipy.optimize.curve_fit(

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -1203,7 +1203,7 @@ def plot_decay_variance(
                 symmetric_cbar=False,
                 black_bg=True,
                 cmap="Reds",
-                threshold=0, # T2* variance falls below default threshold
+                threshold=0,  # T2* variance falls below default threshold
                 vmin=data_p02,
                 vmax=data_p98,
                 annotate=False,

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -1203,6 +1203,7 @@ def plot_decay_variance(
                 symmetric_cbar=False,
                 black_bg=True,
                 cmap="Reds",
+                threshold=0, # T2* variance falls below default threshold
                 vmin=data_p02,
                 vmax=data_p98,
                 annotate=False,


### PR DESCRIPTION
Closes #1440.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Correctly assign T2* and S0 variance to the right files. They were previously swapped.
- Set threshold to 0 for variance plots, which should fix the empty T2* variance figure (#1440).
