### PR TITLE
Reorder layers in adaptive mask plot

### DIFF
--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -804,10 +804,10 @@ def plot_adaptive_mask(
             cut_coords=5,
         )
         ob.add_contours(
-            mask_clf,
+            io_generator.mask,
             threshold=0.2,
             levels=[0.5],
-            colors=[color_dict["Classification, OC & Initial"]],
+            colors=[color_dict["Initial mask only"]],
             linewidths=1.5,
         )
         ob.add_contours(
@@ -818,10 +818,10 @@ def plot_adaptive_mask(
             linewidths=1.5,
         )
         ob.add_contours(
-            io_generator.mask,
+            mask_clf,
             threshold=0.2,
             levels=[0.5],
-            colors=[color_dict["Initial mask only"]],
+            colors=[color_dict["Classification, OC & Initial"]],
             linewidths=1.5,
         )
 


### PR DESCRIPTION
Closes none, but spins off a small bugfix from #1478.

Changes proposed in this pull request:

- Reverse order of mask lines in `plot_adaptive_mask` so that initial mask is on the bottom and the classification mask is on the top.
